### PR TITLE
Remove supernova feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ harness = false
 [[bench]]
 name = "recursive-snark-supernova"
 harness = false
-required-features = ["supernova"]
 
 [features]
 default = []
@@ -83,7 +82,6 @@ portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
-supernova = []
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ group = "0.13.0"
 log = "0.4.17"
 abomonation = "0.7.3"
 abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git" }
+tap = "1.0.1"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -7,7 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   compute_digest,
   supernova::RecursiveSNARK,
-  supernova::{gen_commitmentkey_by_r1cs, PublicParams, RunningClaim},
+  supernova::{gen_commitment_key_by_r1cs, PublicParams, RunningClaim},
   traits::{
     circuit_supernova::{StepCircuit, TrivialTestCircuit},
     Group,
@@ -66,11 +66,11 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(0, c_primary, c_secondary.clone(), 1);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitmentkey_by_r1cs(r1cs_shape_primary);
-    let ck_secondary = gen_commitmentkey_by_r1cs(r1cs_shape_secondary);
+    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary);
+    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary);
 
     // set unified ck_primary, ck_secondary and update digest
-    running_claim1.set_commitmentkey(ck_primary.clone(), ck_secondary.clone());
+    running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
     let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[running_claim1.get_publicparams()]);
 
     // Bench time to produce a recursive SNARK;
@@ -182,12 +182,12 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(1, c_primary, c_secondary.clone(), 2);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitmentkey_by_r1cs(r1cs_shape_primary);
-    let ck_secondary = gen_commitmentkey_by_r1cs(r1cs_shape_secondary);
+    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary);
+    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary);
 
     // set unified ck_primary, ck_secondary and update digest
-    running_claim1.set_commitmentkey(ck_primary.clone(), ck_secondary.clone());
-    running_claim2.set_commitmentkey(ck_primary.clone(), ck_secondary.clone());
+    running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
+    running_claim2.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
 
     let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[
       running_claim1.get_publicparams(),

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -71,7 +71,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     // set unified ck_primary, ck_secondary and update digest
     running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
-    let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[running_claim1.get_publicparams()]);
+    let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[running_claim1.get_public_params()]);
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -190,8 +190,8 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
     running_claim2.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
 
     let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[
-      running_claim1.get_publicparams(),
-      running_claim2.get_publicparams(),
+      running_claim1.get_public_params(),
+      running_claim2.get_public_params(),
     ]);
 
     // Bench time to produce a recursive SNARK;

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -50,7 +50,7 @@ mod tests {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = synthesize_alloc_bit(&mut cs);
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -25,7 +25,7 @@ pub trait NovaWitness<G: Group> {
 /// `NovaShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
 pub trait NovaShape<G: Group> {
   /// Return an appropriate `R1CSShape` and `CommitmentKey` structs.
-  fn r1cs_shape_with_commitmentkey(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
+  fn r1cs_shape_and_key(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
     let S = self.r1cs_shape();
     let ck = R1CS::<G>::commitment_key(&S);
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -400,7 +400,7 @@ mod tests {
       NovaAugmentedCircuit::new(primary_params, None, &ttc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
-    let (shape1, ck1) = cs.r1cs_shape_with_commitmentkey();
+    let (shape1, ck1) = cs.r1cs_shape_and_key();
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
     let ttc2 = TrivialTestCircuit::default();
@@ -409,7 +409,7 @@ mod tests {
       NovaAugmentedCircuit::new(secondary_params, None, &ttc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
-    let (shape2, ck2) = cs.r1cs_shape_with_commitmentkey();
+    let (shape2, ck2) = cs.r1cs_shape_and_key();
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -992,7 +992,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_smul::<G1, _>(cs.namespace(|| "synthesize"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1045,7 +1045,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_equal::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1102,7 +1102,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_negation::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ where
     );
     let mut cs: ShapeCS<G1> = ShapeCS::new();
     let _ = circuit_primary.synthesize(&mut cs);
-    let (r1cs_shape_primary, ck_primary) = cs.r1cs_shape_with_commitmentkey();
+    let (r1cs_shape_primary, ck_primary) = cs.r1cs_shape_and_key();
 
     // Initialize ck for the secondary
     let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
@@ -134,7 +134,7 @@ where
     );
     let mut cs: ShapeCS<G2> = ShapeCS::new();
     let _ = circuit_secondary.synthesize(&mut cs);
-    let (r1cs_shape_secondary, ck_secondary) = cs.r1cs_shape_with_commitmentkey();
+    let (r1cs_shape_secondary, ck_secondary) = cs.r1cs_shape_and_key();
 
     let mut pp = Self {
       F_arity_primary,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub mod provider;
 pub mod spartan;
 pub mod traits;
 
-#[cfg(feature = "supernova")]
 pub mod supernova;
 
 use crate::bellpepper::{

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -174,7 +174,7 @@ mod tests {
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -97,7 +97,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
-    let (shape, ck) = cs.r1cs_shape_with_commitmentkey();
+    let (shape, ck) = cs.r1cs_shape_and_key();
 
     let (pk, vk) = S::setup(&ck, &shape)?;
 

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -201,7 +201,7 @@ where
   }
 
   /// set primary/secondary commitment key
-  pub fn set_commitmentkey(
+  pub fn set_commitment_key(
     &mut self,
     ck_primary: CommitmentKey<G1>,
     ck_secondary: CommitmentKey<G2>,
@@ -776,6 +776,6 @@ where
 }
 
 /// genenate commitmentkey by r1cs shape
-pub fn gen_commitmentkey_by_r1cs<G: Group>(shape: &R1CSShape<G>) -> CommitmentKey<G> {
+pub fn gen_commitment_key_by_r1cs<G: Group>(shape: &R1CSShape<G>) -> CommitmentKey<G> {
   R1CS::<G>::commitment_key(shape)
 }

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -219,7 +219,7 @@ where
   }
 
   /// get augmented_circuit_index
-  pub fn get_publicparams(&self) -> &PublicParams<G1, G2> {
+  pub fn get_public_params(&self) -> &PublicParams<G1, G2> {
     &self.params
   }
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -483,7 +483,7 @@ fn test_recursive_circuit_with<G1, G2>(
   if let Err(e) = circuit1.synthesize(&mut cs) {
     panic!("{}", e)
   }
-  let (shape1, ck1) = cs.r1cs_shape_with_commitmentkey();
+  let (shape1, ck1) = cs.r1cs_shape_and_key();
   assert_eq!(cs.num_constraints(), num_constraints_primary);
 
   // Initialize the shape and ck for the secondary
@@ -501,7 +501,7 @@ fn test_recursive_circuit_with<G1, G2>(
   if let Err(e) = circuit2.synthesize(&mut cs) {
     panic!("{}", e)
   }
-  let (shape2, ck2) = cs.r1cs_shape_with_commitmentkey();
+  let (shape2, ck2) = cs.r1cs_shape_and_key();
   assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
   // Execute the base case for the primary

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -339,9 +339,9 @@ where
     .unwrap();
 
   let ck_primary =
-    gen_commitmentkey_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_primary);
+    gen_commitment_key_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_primary);
   let ck_secondary =
-    gen_commitmentkey_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_secondary);
+    gen_commitment_key_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_secondary);
 
   // set unified ck_primary, ck_secondary and update digest
   running_claim1.params.ck_primary = Some(ck_primary.clone());

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -351,8 +351,8 @@ where
   running_claim2.params.ck_secondary = Some(ck_secondary);
 
   let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[
-    running_claim1.get_publicparams(),
-    running_claim2.get_publicparams(),
+    running_claim1.get_public_params(),
+    running_claim2.get_public_params(),
   ]);
 
   let num_steps = rom.len();

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -14,6 +14,7 @@ use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use core::marker::PhantomData;
 use ff::Field;
 use ff::PrimeField;
+use tap::TapOptional;
 
 use super::*;
 
@@ -250,7 +251,7 @@ fn print_constraints_name_on_error_index<G1, G2, Ca, Cb>(
       let _ = circuit_primary.synthesize(&mut cs);
       cs.constraints
         .get(index)
-        .map(|constraint| debug!("{msg} failed at constraint {}", constraint.3));
+        .tap_some(|constraint| debug!("{msg} failed at constraint {}", constraint.3));
     }
     SuperNovaError::UnSatIndex(msg, index) if msg == "r_secondary" || msg == "l_secondary" => {
       let circuit_secondary: SuperNovaAugmentedCircuit<'_, G1, Cb> = SuperNovaAugmentedCircuit::new(
@@ -264,7 +265,7 @@ fn print_constraints_name_on_error_index<G1, G2, Ca, Cb>(
       let _ = circuit_secondary.synthesize(&mut cs);
       cs.constraints
         .get(index)
-        .map(|constraint| debug!("{msg} failed at constraint {}", constraint.3));
+        .tap_some(|constraint| debug!("{msg} failed at constraint {}", constraint.3));
     }
     _ => (),
   }
@@ -413,20 +414,20 @@ where
     });
 
     if augmented_circuit_index == OPCODE_0 {
-      let _ = recursive_snark
+      recursive_snark
         .prove_step(&running_claim1, &z0_primary, &z0_secondary)
         .unwrap();
-      let _ = recursive_snark
+      recursive_snark
         .verify(&running_claim1, &z0_primary, &z0_secondary)
         .map_err(|err| {
           print_constraints_name_on_error_index(err, &running_claim1, num_augmented_circuit)
         })
         .unwrap();
     } else if augmented_circuit_index == OPCODE_1 {
-      let _ = recursive_snark
+      recursive_snark
         .prove_step(&running_claim2, &z0_primary, &z0_secondary)
         .unwrap();
-      let _ = recursive_snark
+      recursive_snark
         .verify(&running_claim2, &z0_primary, &z0_secondary)
         .map_err(|err| {
           print_constraints_name_on_error_index(err, &running_claim2, num_augmented_circuit)

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -571,5 +571,5 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::new();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::new();
 
-  test_recursive_circuit_with::<G1, G2>(params1, params2, ro_consts1, ro_consts2, 9918, 12178);
+  test_recursive_circuit_with::<G1, G2>(params1, params2, ro_consts1, ro_consts2, 9835, 12036);
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -245,7 +245,6 @@ impl<G: Group, T: TranscriptReprTrait<G>> TranscriptReprTrait<G> for &[T] {
 }
 
 pub mod circuit;
-#[cfg(feature = "supernova")]
 pub mod circuit_supernova;
 pub mod evaluation;
 pub mod snark;


### PR DESCRIPTION
This PR removes the `supernova` feature, since we will make it available unconditionally.  It also contains some minor stylistic (naming) changes.