### PR TITLE
feat: Make commitment key generation configurable with an optional parameter

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -7,6 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialTestCircuit},
+    snark::RelaxedR1CSSNARKTrait,
     Group,
   },
   CompressedSNARK, PublicParams, RecursiveSNARK,
@@ -65,7 +66,12 @@ fn bench_compressed_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &c_primary,
+      &c_secondary,
+      Some(S1::commitment_key_floor()),
+      Some(S2::commitment_key_floor()),
+    );
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -152,8 +158,12 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
-
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &c_primary,
+      &c_secondary,
+      Some(SS1::commitment_key_floor()),
+      Some(SS2::commitment_key_floor()),
+    );
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
 

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -27,7 +27,12 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<G1, G2, C1, C2>::setup(black_box(&C1::new(10)), black_box(&C2::default()))
+      PublicParams::<G1, G2, C1, C2>::setup(
+        black_box(&C1::new(10)),
+        black_box(&C2::default()),
+        black_box(None),
+        black_box(None),
+      )
     })
   });
 }

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -66,8 +66,8 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(0, c_primary, c_secondary.clone(), 1);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary);
-    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary);
+    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary, None);
+    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary, None);
 
     // set unified ck_primary, ck_secondary and update digest
     running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
@@ -182,8 +182,8 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(1, c_primary, c_secondary.clone(), 2);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary);
-    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary);
+    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary, None);
+    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary, None);
 
     // set unified ck_primary, ck_secondary and update digest
     running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None);
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialTestCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None);
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -160,7 +160,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot_serde.rs
+++ b/examples/minroot_serde.rs
@@ -167,7 +167,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
     encode(&pp, &mut file).unwrap()
   };
@@ -193,7 +193,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
     assert!(result.clone() == pp, "not equal!");
     assert!(remaining.is_empty());
   } else {

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -50,7 +50,7 @@ mod tests {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = synthesize_alloc_bit(&mut cs);
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(None);
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -5,7 +5,7 @@
 use super::{shape_cs::ShapeCS, solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
 use crate::{
   errors::NovaError,
-  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, R1CS},
+  r1cs::{CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, R1CS},
   traits::Group,
   CommitmentKey,
 };
@@ -25,9 +25,15 @@ pub trait NovaWitness<G: Group> {
 /// `NovaShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
 pub trait NovaShape<G: Group> {
   /// Return an appropriate `R1CSShape` and `CommitmentKey` structs.
-  fn r1cs_shape_and_key(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
+  /// Optionally, a `CommitmentKeyHint` can be provided to help guide the
+  /// construction of the `CommitmentKey`. This parameter is documented in
+  /// `r1cs::R1CS::commitment_key`.
+  fn r1cs_shape_and_key(
+    &self,
+    optfn: Option<CommitmentKeyHint<G>>,
+  ) -> (R1CSShape<G>, CommitmentKey<G>) {
     let S = self.r1cs_shape();
-    let ck = R1CS::<G>::commitment_key(&S);
+    let ck = R1CS::<G>::commitment_key(&S, optfn);
 
     (S, ck)
   }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -400,7 +400,7 @@ mod tests {
       NovaAugmentedCircuit::new(primary_params, None, &ttc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
-    let (shape1, ck1) = cs.r1cs_shape_and_key();
+    let (shape1, ck1) = cs.r1cs_shape_and_key(None);
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
     let ttc2 = TrivialTestCircuit::default();
@@ -409,7 +409,7 @@ mod tests {
       NovaAugmentedCircuit::new(secondary_params, None, &ttc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
-    let (shape2, ck2) = cs.r1cs_shape_and_key();
+    let (shape2, ck2) = cs.r1cs_shape_and_key(None);
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -992,7 +992,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_smul::<G1, _>(cs.namespace(|| "synthesize"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1045,7 +1045,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_equal::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1102,7 +1102,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_negation::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -174,7 +174,7 @@ mod tests {
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(None);
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
 
@@ -326,7 +326,7 @@ mod tests {
     };
 
     // generate generators and ro constants
-    let ck = R1CS::<G>::commitment_key(&S);
+    let ck = R1CS::<G>::commitment_key(&S, None);
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -2,7 +2,7 @@
 use crate::{
   errors::NovaError,
   traits::{
-    commitment::{CommitmentEngineTrait, CommitmentTrait},
+    commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
     AbsorbInROTrait, CompressedGroup, Group, ROTrait, TranscriptReprTrait,
   },
 };
@@ -22,6 +22,12 @@ use serde::{Deserialize, Serialize};
 pub struct CommitmentKey<G: Group> {
   #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
   ck: Vec<G::PreprocessedGroupElement>,
+}
+
+impl<G: Group> Len for CommitmentKey<G> {
+  fn len(&self) -> usize {
+    self.ck.len()
+  }
 }
 
 /// A type that holds a commitment

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -25,7 +25,7 @@ pub struct CommitmentKey<G: Group> {
 }
 
 impl<G: Group> Len for CommitmentKey<G> {
-  fn len(&self) -> usize {
+  fn length(&self) -> usize {
     self.ck.len()
   }
 }

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -73,13 +73,29 @@ pub struct RelaxedR1CSInstance<G: Group> {
   pub(crate) u: G::Scalar,
 }
 
+pub type CommitmentKeyHint<G> = Box<dyn Fn(&R1CSShape<G>) -> usize>;
+
 impl<G: Group> R1CS<G> {
-  /// Samples public parameters for the specified number of constraints and variables in an R1CS
-  pub fn commitment_key(S: &R1CSShape<G>) -> CommitmentKey<G> {
+  /// Generates public parameters for a Rank-1 Constraint System (R1CS).
+  ///
+  /// This function takes into consideration the shape of the R1CS matrices and a hint function
+  /// for the number of generators. It returns a `CommitmentKey`.
+  ///
+  /// # Arguments
+  ///
+  /// * `S`: The shape of the R1CS matrices.
+  /// * `commitment_key_hint`: An optional function that provides a floor for the number of
+  ///   generators. A good function to provide is the commitment_key_floor field in the trait `RelaxedR1CSSNARKTrait`.
+  ///   If no floot function is provided, the default number of generators will be max(S.num_cons, S.num_vars).
+  ///
+  pub fn commitment_key(
+    S: &R1CSShape<G>,
+    commitment_key_floor: Option<CommitmentKeyHint<G>>,
+  ) -> CommitmentKey<G> {
     let num_cons = S.num_cons;
     let num_vars = S.num_vars;
-    let total_nz = S.A.len() + S.B.len() + S.C.len();
-    G::CE::setup(b"ck", max(max(num_cons, num_vars), total_nz))
+    let generators_hint = commitment_key_floor.map(|f| f(S)).unwrap_or(0);
+    G::CE::setup(b"ck", max(max(num_cons, num_vars), generators_hint))
   }
 }
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -97,7 +97,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
-    let (shape, ck) = cs.r1cs_shape_and_key();
+    let (shape, ck) = cs.r1cs_shape_and_key(Some(S::commitment_key_floor()));
 
     let (pk, vk) = S::setup(&ck, &shape)?;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -14,7 +14,7 @@ use crate::{
     PolyEvalInstance, PolyEvalWitness, SparsePolynomial,
   },
   traits::{
-    commitment::{CommitmentEngineTrait, CommitmentTrait},
+    commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
     evaluation::EvaluationEngineTrait,
     snark::RelaxedR1CSSNARKTrait,
     Group, TranscriptEngineTrait, TranscriptReprTrait,
@@ -856,10 +856,19 @@ where
   type ProverKey = ProverKey<G, EE>;
   type VerifierKey = VerifierKey<G, EE>;
 
+  fn commitment_key_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize> {
+    Box::new(|shape: &R1CSShape<G>| -> usize {
+      // the commitment key should be large enough to commit to the R1CS matrices
+      shape.A.len() + shape.B.len() + shape.C.len()
+    })
+  }
+
   fn setup(
     ck: &CommitmentKey<G>,
     S: &R1CSShape<G>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
+    // check the provided commitment key meets minimal requirements
+    assert!(ck.len() >= Self::commitment_key_floor()(S));
     let (pk_ee, vk_ee) = EE::setup(ck);
 
     // pad the R1CS matrices

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -868,7 +868,7 @@ where
     S: &R1CSShape<G>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     // check the provided commitment key meets minimal requirements
-    assert!(ck.len() >= Self::commitment_key_floor()(S));
+    assert!(ck.length() >= Self::commitment_key_floor()(S));
     let (pk_ee, vk_ee) = EE::setup(ck);
 
     // pad the R1CS matrices

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -6,7 +6,10 @@ use crate::{
   bellpepper::shape_cs::ShapeCS,
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
   errors::NovaError,
-  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness, R1CS},
+  r1cs::{
+    CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance,
+    RelaxedR1CSWitness, R1CS,
+  },
   scalar_as_base,
   traits::{
     circuit_supernova::StepCircuit, commitment::CommitmentTrait, AbsorbInROTrait, Group,
@@ -775,7 +778,29 @@ where
   }
 }
 
-/// genenate commitmentkey by r1cs shape
-pub fn gen_commitment_key_by_r1cs<G: Group>(shape: &R1CSShape<G>) -> CommitmentKey<G> {
-  R1CS::<G>::commitment_key(shape)
+/// Generates public parameters (a `CommitmentKey`) for a Rank-1 Constraint System (R1CS) circuit,
+/// appropriate for use with a particular SNARK protocol.
+///
+/// To generate a commitment key that is tailored to a specific R1CS circuit and SNARK protocol,
+/// this function considers the 'shape' of the R1CS circuit (provided via the `R1CSShape` parameter `shape`)
+/// and optionally specific requirements of the SNARK protocol’s methodology.
+///
+/// # Arguments
+///
+/// * `shape`: The shape of the R1CS matrices, which is essential to understanding the structure of the
+///   R1CS circuit for which the `CommitmentKey` is being generated.
+///
+/// * `optfn`: An optional parameter that encapsulates specific requirements of the
+///   SNARK protocol's methodology. For "classical" SNARKs with no special needs, this can be `None`.
+///   For specific SNARKs, like Spartan with computational commitments, a particular value should be
+///   passed here. This value is typically provided in the SNARK's trait or implementation details.
+///
+/// # Returns
+///
+/// A `CommitmentKey` tailored to the given R1CS circuit shape and SNARK protocol specifics.
+pub fn gen_commitment_key_by_r1cs<G: Group>(
+  shape: &R1CSShape<G>,
+  optfn: Option<CommitmentKeyHint<G>>,
+) -> CommitmentKey<G> {
+  R1CS::<G>::commitment_key(shape, optfn)
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -339,10 +339,14 @@ where
     .max_by(|(_, circuit_size1), (_, circuit_size2)| circuit_size1.cmp(circuit_size2))
     .unwrap();
 
-  let ck_primary =
-    gen_commitment_key_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_primary);
-  let ck_secondary =
-    gen_commitment_key_by_r1cs(&circuit_public_params[max_index_circuit].r1cs_shape_secondary);
+  let ck_primary = gen_commitment_key_by_r1cs(
+    &circuit_public_params[max_index_circuit].r1cs_shape_primary,
+    None,
+  );
+  let ck_secondary = gen_commitment_key_by_r1cs(
+    &circuit_public_params[max_index_circuit].r1cs_shape_secondary,
+    None,
+  );
 
   // set unified ck_primary, ck_secondary and update digest
   running_claim1.params.ck_primary = Some(ck_primary.clone());
@@ -484,7 +488,7 @@ fn test_recursive_circuit_with<G1, G2>(
   if let Err(e) = circuit1.synthesize(&mut cs) {
     panic!("{}", e)
   }
-  let (shape1, ck1) = cs.r1cs_shape_and_key();
+  let (shape1, ck1) = cs.r1cs_shape_and_key(None);
   assert_eq!(cs.num_constraints(), num_constraints_primary);
 
   // Initialize the shape and ck for the secondary
@@ -502,7 +506,7 @@ fn test_recursive_circuit_with<G1, G2>(
   if let Err(e) = circuit2.synthesize(&mut cs) {
     panic!("{}", e)
   }
-  let (shape2, ck2) = cs.r1cs_shape_and_key();
+  let (shape2, ck2) = cs.r1cs_shape_and_key(None);
   assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
   // Execute the base case for the primary

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -74,10 +74,19 @@ pub trait CommitmentTrait<G: Group>:
   fn decompress(c: &Self::CompressedCommitment) -> Result<Self, NovaError>;
 }
 
+/// A trait that helps determine the lenght of a structure.
+/// Note this does not impose any memory representation contraints on the structure.
+pub trait Len {
+  /// Returns the length of the structure.
+  fn len(&self) -> usize;
+}
+
 /// A trait that ties different pieces of the commitment generation together
 pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
   /// Holds the type of the commitment key
-  type CommitmentKey: Clone
+  /// The key should quantify its length in terms of group generators.
+  type CommitmentKey: Len
+    + Clone
     + PartialEq
     + Debug
     + Send

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -78,7 +78,7 @@ pub trait CommitmentTrait<G: Group>:
 /// Note this does not impose any memory representation contraints on the structure.
 pub trait Len {
   /// Returns the length of the structure.
-  fn len(&self) -> usize;
+  fn length(&self) -> usize;
 }
 
 /// A trait that ties different pieces of the commitment generation together

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -19,6 +19,15 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   /// A type that represents the verifier's key
   type VerifierKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
 
+  /// This associated function (not a method) provides a hint that offers
+  /// a minimum sizing cue for the commitment key used by this SNARK
+  /// implementation. The commitment key passed in setup should then
+  /// be at least as large as this hint.
+  fn commitment_key_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize> {
+    // The default is to not put an additional floor on the size of the commitment key
+    Box::new(|_shape: &R1CSShape<G>| 0)
+  }
+
   /// Produces the keys for the prover and the verifier
   fn setup(
     ck: &CommitmentKey<G>,


### PR DESCRIPTION
This reduces the size of public parameters by ~2 when a "classic" SNARK is used.
This is a port of https://github.com/microsoft/Nova/pull/203