### PR TITLE
Small RO trait simplification

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -379,7 +379,7 @@ mod tests {
     bellpepper::r1cs::{NovaShape, NovaWitness},
     gadgets::utils::scalar_as_base,
     provider::poseidon::PoseidonConstantsCircuit,
-    traits::{circuit::TrivialTestCircuit, ROConstantsTrait},
+    traits::circuit::TrivialTestCircuit,
   };
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
@@ -455,8 +455,8 @@ mod tests {
   fn test_recursive_circuit_pasta() {
     let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
-    let ro_consts1: ROConstantsCircuit<PastaG2> = PoseidonConstantsCircuit::new();
-    let ro_consts2: ROConstantsCircuit<PastaG1> = PoseidonConstantsCircuit::new();
+    let ro_consts1: ROConstantsCircuit<PastaG2> = PoseidonConstantsCircuit::default();
+    let ro_consts2: ROConstantsCircuit<PastaG1> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<PastaG1, PastaG2>(
       &params1, &params2, ro_consts1, ro_consts2, 9815, 10347,
@@ -468,9 +468,9 @@ mod tests {
     let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
     let ro_consts1: ROConstantsCircuit<provider::bn256_grumpkin::grumpkin::Point> =
-      PoseidonConstantsCircuit::new();
+      PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<provider::bn256_grumpkin::bn256::Point> =
-      PoseidonConstantsCircuit::new();
+      PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<
       provider::bn256_grumpkin::bn256::Point,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use traits::{
   circuit::StepCircuit,
   commitment::{CommitmentEngineTrait, CommitmentTrait},
   snark::RelaxedR1CSSNARKTrait,
-  AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROConstantsTrait, ROTrait,
+  AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROTrait,
 };
 
 /// A type that holds public parameters of Nova
@@ -150,15 +150,15 @@ where
     let augmented_circuit_params_secondary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
 
-    let ro_consts_primary: ROConstants<G1> = ROConstants::<G1>::new();
-    let ro_consts_secondary: ROConstants<G2> = ROConstants::<G2>::new();
+    let ro_consts_primary: ROConstants<G1> = ROConstants::<G1>::default();
+    let ro_consts_secondary: ROConstants<G2> = ROConstants::<G2>::default();
 
     let F_arity_primary = c_primary.arity();
     let F_arity_secondary = c_secondary.arity();
 
     // ro_consts_circuit_primary are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
-    let ro_consts_circuit_primary: ROConstantsCircuit<G2> = ROConstantsCircuit::<G2>::new();
-    let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::new();
+    let ro_consts_circuit_primary: ROConstantsCircuit<G2> = ROConstantsCircuit::<G2>::default();
+    let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::default();
 
     // Initialize ck for the primary
     let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -118,10 +118,7 @@ impl<G: Group> NIFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{
-    r1cs::R1CS,
-    traits::{Group, ROConstantsTrait},
-  };
+  use crate::{r1cs::R1CS, traits::Group};
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;
@@ -176,7 +173,7 @@ mod tests {
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
     let (shape, ck) = cs.r1cs_shape_and_key(None);
     let ro_consts =
-      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
+      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 
     // Now get the instance and assignment for one instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
@@ -328,7 +325,7 @@ mod tests {
     // generate generators and ro constants
     let ck = R1CS::<G>::commitment_key(&S, None);
     let ro_consts =
-      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
+      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 
     let rand_inst_witness_generator =
       |ck: &CommitmentKey<G>, I: &G::Scalar| -> (G::Scalar, R1CSInstance<G>, R1CSWitness<G>) {

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -1,5 +1,5 @@
 //! Poseidon Constants and Poseidon-based RO used in Nova
-use crate::traits::{ROCircuitTrait, ROConstantsTrait, ROTrait};
+use crate::traits::{ROCircuitTrait, ROTrait};
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use bellpepper_core::{
@@ -27,13 +27,9 @@ use serde::{Deserialize, Serialize};
 #[abomonation_bounds(where Scalar::Repr: Abomonation)]
 pub struct PoseidonConstantsCircuit<Scalar: PrimeField>(PoseidonConstants<Scalar, U24>);
 
-impl<Scalar> ROConstantsTrait<Scalar> for PoseidonConstantsCircuit<Scalar>
-where
-  Scalar: PrimeField + PrimeFieldBits,
-{
+impl<Scalar: PrimeField> Default for PoseidonConstantsCircuit<Scalar> {
   /// Generate Poseidon constants
-  #[allow(clippy::new_without_default)]
-  fn new() -> Self {
+  fn default() -> Self {
     Self(Sponge::<Scalar, U24>::api_constants(Strength::Standard))
   }
 }
@@ -42,14 +38,14 @@ where
 #[derive(Serialize, Deserialize, Abomonation)]
 #[abomonation_bounds(
   where
-    Base: PrimeField + PrimeFieldBits,
-    Scalar: PrimeField + PrimeFieldBits,
+    Base: PrimeField,
+    Scalar: PrimeField,
     <Base as PrimeField>::Repr: Abomonation
 )]
 pub struct PoseidonRO<Base, Scalar>
 where
-  Base: PrimeField + PrimeFieldBits,
-  Scalar: PrimeField + PrimeFieldBits,
+  Base: PrimeField,
+  Scalar: PrimeField,
 {
   // Internal State
   #[abomonate_with(Vec<Base::Repr>)]
@@ -64,8 +60,9 @@ impl<Base, Scalar> ROTrait<Base, Scalar> for PoseidonRO<Base, Scalar>
 where
   Base: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>,
   Base::Repr: Abomonation,
-  Scalar: PrimeField + PrimeFieldBits,
+  Scalar: PrimeField,
 {
+  type CircuitRO = PoseidonROCircuit<Base>;
   type Constants = PoseidonConstantsCircuit<Base>;
 
   fn new(constants: PoseidonConstantsCircuit<Base>, num_absorbs: usize) -> Self {
@@ -135,6 +132,7 @@ where
   Scalar: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>,
   Scalar::Repr: Abomonation,
 {
+  type VanillaRO<T: PrimeField> = PoseidonRO<Scalar, T>;
   type Constants = PoseidonConstantsCircuit<Scalar>;
 
   /// Initialize the internal state and set the poseidon constants
@@ -229,7 +227,7 @@ mod tests {
   {
     // Check that the number computed inside the circuit is equal to the number computed outside the circuit
     let mut csprng: OsRng = OsRng;
-    let constants = PoseidonConstantsCircuit::<G::Scalar>::new();
+    let constants = PoseidonConstantsCircuit::<G::Scalar>::default();
     let num_absorbs = 32;
     let mut ro: PoseidonRO<G::Scalar, G::Base> = PoseidonRO::new(constants.clone(), num_absorbs);
     let mut ro_gadget: PoseidonROCircuit<G::Scalar> =

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -13,7 +13,7 @@ use crate::{
   scalar_as_base,
   traits::{
     circuit_supernova::StepCircuit, commitment::CommitmentTrait, AbsorbInROTrait, Group,
-    ROConstants, ROConstantsCircuit, ROConstantsTrait, ROTrait,
+    ROConstants, ROConstantsCircuit, ROTrait,
   },
   Commitment, CommitmentKey,
 };
@@ -81,15 +81,15 @@ where
     let augmented_circuit_params_secondary =
       SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
 
-    let ro_consts_primary: ROConstants<G1> = ROConstants::<G1>::new();
-    let ro_consts_secondary: ROConstants<G2> = ROConstants::<G2>::new();
+    let ro_consts_primary: ROConstants<G1> = ROConstants::<G1>::default();
+    let ro_consts_secondary: ROConstants<G2> = ROConstants::<G2>::default();
 
     let F_arity_primary = c_primary.arity();
     let F_arity_secondary = c_secondary.arity();
 
     // ro_consts_circuit_primary are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
-    let ro_consts_circuit_primary: ROConstantsCircuit<G2> = ROConstantsCircuit::<G2>::new();
-    let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::new();
+    let ro_consts_circuit_primary: ROConstantsCircuit<G2> = ROConstantsCircuit::<G2>::default();
+    let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::default();
 
     // Initialize ck for the primary
     let circuit_primary: SuperNovaAugmentedCircuit<'_, G2, C1> = SuperNovaAugmentedCircuit::new(

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -572,8 +572,8 @@ fn test_recursive_circuit() {
   type G2 = pasta_curves::vesta::Point;
   let params1 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
   let params2 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
-  let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::new();
-  let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::new();
+  let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
+  let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
   test_recursive_circuit_with::<G1, G2>(params1, params2, ro_consts1, ro_consts2, 9835, 12036);
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -124,9 +124,12 @@ pub trait AbsorbInROTrait<G: Group> {
 }
 
 /// A helper trait that defines the behavior of a hash function that we use as an RO
-pub trait ROTrait<Base, Scalar> {
+pub trait ROTrait<Base: PrimeField, Scalar> {
+  /// The circuit alter ego of this trait impl - this constrains it to use the same constants
+  type CircuitRO: ROCircuitTrait<Base, Constants = Self::Constants>;
+
   /// A type representing constants/parameters associated with the hash function
-  type Constants: ROConstantsTrait<Base>
+  type Constants: Default
     + Clone
     + PartialEq
     + Send
@@ -147,8 +150,11 @@ pub trait ROTrait<Base, Scalar> {
 
 /// A helper trait that defines the behavior of a hash function that we use as an RO in the circuit model
 pub trait ROCircuitTrait<Base: PrimeField> {
-  /// A type representing constants/parameters associated with the hash function
-  type Constants: ROConstantsTrait<Base>
+  /// the vanilla alter ego of this trait - this constrains it to use the same constants
+  type VanillaRO<T: PrimeField>: ROTrait<Base, T, Constants = Self::Constants>;
+
+  /// A type representing constants/parameters associated with the hash function on this Base field
+  type Constants: Default
     + Clone
     + PartialEq
     + Send
@@ -167,12 +173,6 @@ pub trait ROCircuitTrait<Base: PrimeField> {
   fn squeeze<CS>(&mut self, cs: CS, num_bits: usize) -> Result<Vec<AllocatedBit>, SynthesisError>
   where
     CS: ConstraintSystem<Base>;
-}
-
-/// A helper trait that defines the constants associated with a hash function
-pub trait ROConstantsTrait<Base> {
-  /// produces constants/parameters associated with the hash function
-  fn new() -> Self;
 }
 
 /// An alias for constants associated with `G::RO`

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -21,7 +21,6 @@ pub trait Group:
   + Copy
   + Debug
   + Eq
-  + Sized
   + GroupOps
   + GroupOpsOwned
   + ScalarMul<<Self as Group>::Scalar>
@@ -102,7 +101,6 @@ pub trait CompressedGroup:
   + Copy
   + Debug
   + Eq
-  + Sized
   + Send
   + Sync
   + TranscriptReprTrait<Self::GroupElement>

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// A trait that defines the behavior of a `zkSNARK`
 pub trait RelaxedR1CSSNARKTrait<G: Group>:
-  Sized + Send + Sync + Serialize + for<'de> Deserialize<'de>
+  Send + Sync + Serialize + for<'de> Deserialize<'de>
 {
   /// A type that represents the prover's key
   type ProverKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;


### PR DESCRIPTION
- makes RO traits a tad more approachable by removing the `ROConstants` trait, 
- removes `Sized` bounds (on `Group`, which is used as a generic parameters, they are redundant)