### PR TITLE
Refactor supernova tests

### DIFF
--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -6,8 +6,9 @@ use criterion::*;
 use ff::PrimeField;
 use nova_snark::{
   compute_digest,
+  r1cs::R1CS,
   supernova::RecursiveSNARK,
-  supernova::{gen_commitment_key_by_r1cs, PublicParams, RunningClaim},
+  supernova::{PublicParams, RunningClaim},
   traits::{
     circuit_supernova::{StepCircuit, TrivialTestCircuit},
     Group,
@@ -66,8 +67,8 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(0, c_primary, c_secondary.clone(), 1);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary, None);
-    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary, None);
+    let ck_primary = R1CS::commitment_key(r1cs_shape_primary, None);
+    let ck_secondary = R1CS::commitment_key(r1cs_shape_secondary, None);
 
     // set unified ck_primary, ck_secondary and update digest
     running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
@@ -182,8 +183,8 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
     >::new(1, c_primary, c_secondary.clone(), 2);
 
     let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = gen_commitment_key_by_r1cs(r1cs_shape_primary, None);
-    let ck_secondary = gen_commitment_key_by_r1cs(r1cs_shape_secondary, None);
+    let ck_primary = R1CS::commitment_key(r1cs_shape_primary, None);
+    let ck_secondary = R1CS::commitment_key(r1cs_shape_secondary, None);
 
     // set unified ck_primary, ck_secondary and update digest
     running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,12 @@ mod bellpepper;
 mod circuit;
 mod constants;
 mod nifs;
-mod r1cs;
 
 // public modules
 pub mod errors;
 pub mod gadgets;
 pub mod provider;
+pub mod r1cs;
 pub mod spartan;
 pub mod traits;
 
@@ -42,6 +42,7 @@ use errors::NovaError;
 use ff::{Field, PrimeField};
 use gadgets::utils::scalar_as_base;
 use nifs::NIFS;
+pub use r1cs::R1CS;
 use r1cs::{
   CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -86,16 +86,24 @@ impl<G: Group> R1CS<G> {
   /// * `S`: The shape of the R1CS matrices.
   /// * `commitment_key_hint`: An optional function that provides a floor for the number of
   ///   generators. A good function to provide is the commitment_key_floor field in the trait `RelaxedR1CSSNARKTrait`.
-  ///   If no floot function is provided, the default number of generators will be max(S.num_cons, S.num_vars).
+  ///   If no floor function is provided, the default number of generators will be max(S.num_cons, S.num_vars).
   ///
   pub fn commitment_key(
     S: &R1CSShape<G>,
     commitment_key_floor: Option<CommitmentKeyHint<G>>,
   ) -> CommitmentKey<G> {
+    let size = Self::commitment_key_size(S, commitment_key_floor);
+    G::CE::setup(b"ck", size)
+  }
+
+  pub fn commitment_key_size(
+    S: &R1CSShape<G>,
+    commitment_key_floor: Option<CommitmentKeyHint<G>>,
+  ) -> usize {
     let num_cons = S.num_cons;
     let num_vars = S.num_vars;
     let generators_hint = commitment_key_floor.map(|f| f(S)).unwrap_or(0);
-    G::CE::setup(b"ck", max(max(num_cons, num_vars), generators_hint))
+    max(max(num_cons, num_vars), generators_hint)
   }
 }
 

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -73,6 +73,7 @@ pub struct RelaxedR1CSInstance<G: Group> {
   pub(crate) u: G::Scalar,
 }
 
+/// A type for functions that hints commitment key sizing by returning the floor of the number of required generators.
 pub type CommitmentKeyHint<G> = Box<dyn Fn(&R1CSShape<G>) -> usize>;
 
 impl<G: Group> R1CS<G> {
@@ -96,6 +97,7 @@ impl<G: Group> R1CS<G> {
     G::CE::setup(b"ck", size)
   }
 
+  /// Computes the number of generators required for the commitment key corresponding to shape `S`.
   pub fn commitment_key_size(
     S: &R1CSShape<G>,
     commitment_key_floor: Option<CommitmentKeyHint<G>>,
@@ -173,7 +175,7 @@ impl<G: Group> R1CSShape<G> {
     assert!(self.num_io < self.num_vars);
   }
 
-  pub fn multiply_vec(
+  pub(crate) fn multiply_vec(
     &self,
     z: &[G::Scalar],
   ) -> Result<(Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>), NovaError> {

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -802,8 +802,8 @@ where
   let shape_primary = max_shape!(r1cs_shape_primary);
   let shape_secondary = max_shape!(r1cs_shape_secondary);
 
-  let ck_primary = R1CS::<G1>::commitment_key(&shape_primary, None);
-  let ck_secondary = R1CS::<G2>::commitment_key(&shape_secondary, None);
+  let ck_primary = R1CS::commitment_key(shape_primary, None);
+  let ck_secondary = R1CS::commitment_key(shape_secondary, None);
 
   (ck_primary, ck_secondary)
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -18,9 +18,9 @@ use tap::TapOptional;
 
 use super::*;
 
-fn constraint_augmented_circuit_index<F: PrimeField, CS: ConstraintSystem<F>>(
+fn constrain_augmented_circuit_index<F: PrimeField, CS: ConstraintSystem<F>>(
   mut cs: CS,
-  pc_counter: &AllocatedNum<F>,
+  program_counter: &AllocatedNum<F>,
   rom: &[AllocatedNum<F>],
   circuit_index: &AllocatedNum<F>,
 ) -> Result<(), SynthesisError> {
@@ -37,7 +37,7 @@ fn constraint_augmented_circuit_index<F: PrimeField, CS: ConstraintSystem<F>>(
       let equal_bit = Boolean::from(alloc_num_equals(
         cs.namespace(|| format!("rom_values {} equal bit", i)),
         &index_alloc,
-        pc_counter,
+        program_counter,
       )?);
       conditionally_select(
         cs.namespace(|| format!("rom_values {} conditionally_select ", i)),
@@ -95,7 +95,7 @@ where
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
-    pc_counter: &AllocatedNum<F>,
+    program_counter: &AllocatedNum<F>,
     z: &[AllocatedNum<F>],
   ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
     // constrain rom[pc] equal to `self.circuit_index`
@@ -103,9 +103,9 @@ where
       cs.namespace(|| "circuit_index"),
       F::from(self.circuit_index as u64),
     )?;
-    constraint_augmented_circuit_index(
+    constrain_augmented_circuit_index(
       cs.namespace(|| "CubicCircuit agumented circuit constraint"),
-      pc_counter,
+      program_counter,
       &z[1..],
       &circuit_index,
     )?;
@@ -114,7 +114,7 @@ where
     let pc_next = add_allocated_num(
       // pc = pc + 1
       cs.namespace(|| "pc = pc + 1".to_string()),
-      pc_counter,
+      program_counter,
       &one,
     )?;
 
@@ -178,7 +178,7 @@ where
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
-    pc_counter: &AllocatedNum<F>,
+    program_counter: &AllocatedNum<F>,
     z: &[AllocatedNum<F>],
   ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
     // constrain rom[pc] equal to `self.circuit_index`
@@ -186,9 +186,9 @@ where
       cs.namespace(|| "circuit_index"),
       F::from(self.circuit_index as u64),
     )?;
-    constraint_augmented_circuit_index(
+    constrain_augmented_circuit_index(
       cs.namespace(|| "SquareCircuit agumented circuit constraint"),
-      pc_counter,
+      program_counter,
       &z[1..],
       &circuit_index,
     )?;
@@ -196,7 +196,7 @@ where
     let pc_next = add_allocated_num(
       // pc = pc + 1
       cs.namespace(|| "pc = pc + 1"),
-      pc_counter,
+      program_counter,
       &one,
     )?;
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -95,7 +95,7 @@ where
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
-    program_counter: &AllocatedNum<F>,
+    pc: &AllocatedNum<F>,
     z: &[AllocatedNum<F>],
   ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
     // constrain rom[pc] equal to `self.circuit_index`
@@ -105,7 +105,7 @@ where
     )?;
     constrain_augmented_circuit_index(
       cs.namespace(|| "CubicCircuit agumented circuit constraint"),
-      program_counter,
+      pc,
       &z[1..],
       &circuit_index,
     )?;
@@ -114,7 +114,7 @@ where
     let pc_next = add_allocated_num(
       // pc = pc + 1
       cs.namespace(|| "pc = pc + 1".to_string()),
-      program_counter,
+      pc,
       &one,
     )?;
 
@@ -178,7 +178,7 @@ where
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
-    program_counter: &AllocatedNum<F>,
+    pc: &AllocatedNum<F>,
     z: &[AllocatedNum<F>],
   ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
     // constrain rom[pc] equal to `self.circuit_index`
@@ -188,7 +188,7 @@ where
     )?;
     constrain_augmented_circuit_index(
       cs.namespace(|| "SquareCircuit agumented circuit constraint"),
-      program_counter,
+      pc,
       &z[1..],
       &circuit_index,
     )?;
@@ -196,7 +196,7 @@ where
     let pc_next = add_allocated_num(
       // pc = pc + 1
       cs.namespace(|| "pc = pc + 1"),
-      program_counter,
+      pc,
       &one,
     )?;
 
@@ -332,21 +332,8 @@ where
 
   // generate the commitkey based on max num of constraints and reused it for all other augmented circuit
   let circuit_public_params = vec![&running_claim1.params, &running_claim2.params];
-  let (max_index_circuit, _) = circuit_public_params
-    .iter()
-    .enumerate()
-    .map(|(i, params)| -> (usize, usize) { (i, params.r1cs_shape_primary.num_cons) })
-    .max_by(|(_, circuit_size1), (_, circuit_size2)| circuit_size1.cmp(circuit_size2))
-    .unwrap();
 
-  let ck_primary = gen_commitment_key_by_r1cs(
-    &circuit_public_params[max_index_circuit].r1cs_shape_primary,
-    None,
-  );
-  let ck_secondary = gen_commitment_key_by_r1cs(
-    &circuit_public_params[max_index_circuit].r1cs_shape_secondary,
-    None,
-  );
+  let (ck_primary, ck_secondary) = compute_commitment_keys(&circuit_public_params);
 
   // set unified ck_primary, ck_secondary and update digest
   running_claim1.params.ck_primary = Some(ck_primary.clone());

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -331,16 +331,12 @@ where
   );
 
   // generate the commitkey based on max num of constraints and reused it for all other augmented circuit
-  let circuit_public_params = vec![&running_claim1.params, &running_claim2.params];
-
-  let (ck_primary, ck_secondary) = compute_commitment_keys(&circuit_public_params);
+  let (ck_primary, ck_secondary) =
+    compute_commitment_keys(&[&running_claim1.params, &running_claim2.params]);
 
   // set unified ck_primary, ck_secondary and update digest
-  running_claim1.params.ck_primary = Some(ck_primary.clone());
-  running_claim1.params.ck_secondary = Some(ck_secondary.clone());
-
-  running_claim2.params.ck_primary = Some(ck_primary);
-  running_claim2.params.ck_secondary = Some(ck_secondary);
+  running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
+  running_claim2.set_commitment_key(ck_primary, ck_secondary);
 
   let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[
     running_claim1.get_public_params(),

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -58,4 +58,3 @@ where
     Ok((_pc_counter.clone(), z.to_vec()))
   }
 }
-

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -58,3 +58,4 @@ where
     Ok((_pc_counter.clone(), z.to_vec()))
   }
 }
+


### PR DESCRIPTION
This PR contains some small initial refactoring of the SuperNova tests, mostly intended to help expose the shape of the problem and remove some noise:
- Compute commitment key based on max shape separately for primary/secondary.
- Consider key size based on max of constraints and inputs (not just constraints).
- Move commitment key computation into the library.
- Use `set_commitment_key` rather than more verbose manual equivalent.
- Remove unneeded `gen_commitment_key_by_r1cs`.
- Various minor renames.