### PR TITLE
Include commits into ZMProof and adjust RO

### DIFF
--- a/.github/workflows/upstream_update.yml
+++ b/.github/workflows/upstream_update.yml
@@ -32,6 +32,31 @@ jobs:
           echo "message=$SCION at $SCION_COMMIT does not include $ROOT at $ROOT_COMMIT" >> $GITHUB_ENV
         fi
       shell: bash
+      
+    - name: Rebase SCION onto ROOT
+      id: rebase
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git rebase origin/${{ env.ROOT }}
+      if: env.status == 'false'
+      continue-on-error: true
+
+    - uses: dtolnay/rust-toolchain@stable
+      if: steps.rebase.outcome == 'success'
+    - name: Run a trivial test
+      id: test
+      run: cargo check --all --tests --benches
+      if: steps.rebase.outcome == 'success'
+      continue-on-error: true
+
+    - name: Push the changes
+      run: |
+        git push origin HEAD:${{ env.SCION }} -f
+        SCION_COMMIT=$(git rev-parse HEAD)
+        echo "status=true" >> $GITHUB_ENV
+        echo "message=$SCION is rebased on $ROOT as of $SCION_COMMIT" >> $GITHUB_ENV
+      if: steps.rebase.outcome == 'success' && steps.test.outcome == 'success'
 
     - name: Find the last report issue open
       id: last_issue
@@ -50,6 +75,8 @@ jobs:
         echo ${{ env.message }}
         echo ${{ steps.last_issue.outputs.has-found }}
         echo ${{ steps.last_issue.outputs.issue-number }}
+        echo ${{ steps.rebase.outcome }}
+        echo ${{ steps.test.outcome }}
 
     - name: Close last report open issue
       if: env.status == 'true' && steps.last_issue.outputs.has-found == 'true'

--- a/.github/workflows/upstream_update.yml
+++ b/.github/workflows/upstream_update.yml
@@ -1,0 +1,82 @@
+name: Check development branch accounts for upstream updates
+
+on:
+  schedule:
+    - cron: '5 * * * *' # every hour, 5 mins past the hour
+  workflow_dispatch: # manual trigger
+
+env:
+  ROOT: "main"
+  SCION: "dev"
+
+jobs:
+  check_branches:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # necessary to access all commits
+        ref: ${{ env.SCION }}
+    - run: git fetch origin
+    - name: Check if SCION is an extension of ROOT
+      id: check
+      run: |
+        ROOT_COMMIT=$(git rev-parse origin/${{ env.ROOT }})
+        SCION_COMMIT=$(git rev-parse HEAD)
+        if git merge-base --is-ancestor $ROOT_COMMIT HEAD; then
+          echo "status=true" >> $GITHUB_ENV
+          echo "message=$SCION is rebased on $ROOT as of $SCION_COMMIT" >> $GITHUB_ENV
+        else
+          echo "status=false" >> $GITHUB_ENV
+          echo "message=$SCION at $SCION_COMMIT does not include $ROOT at $ROOT_COMMIT" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Find the last report issue open
+      id: last_issue
+      uses: micalevisk/last-issue-action@v2
+      with:
+        state: open
+        labels: |
+          upstream
+          automated issue
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Debug
+      run: |
+        echo ${{ env.status }}
+        echo ${{ env.message }}
+        echo ${{ steps.last_issue.outputs.has-found }}
+        echo ${{ steps.last_issue.outputs.issue-number }}
+
+    - name: Close last report open issue
+      if: env.status == 'true' && steps.last_issue.outputs.has-found == 'true'
+      uses: peter-evans/close-issue@v2
+      with:
+        issue-number: ${{ steps.last_issue.outputs.issue-number }}
+        comment: ${{ env.message }}
+
+    - name: Update last report open issue
+      if: env.status == 'false' && steps.last_issue.outputs.has-found == 'true'
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ steps.last_issue.outputs.issue-number }}
+        body: ${{ env.message }}
+        edit-mode: replace
+
+    - name: Create file for issue
+      if: env.status == 'false' && steps.last_issue.outputs.has-found == 'false'
+      run: echo "${{ env.message }}" > ./_body.md
+
+    - name: Create issue from report
+      if: env.status == 'false' && steps.last_issue.outputs.has-found == 'false'
+      uses: peter-evans/create-issue-from-file@v4
+      with:
+        title: ${{ env.SCION }} needs to be rebased on ${{ env.ROOT }}
+        content-filepath: ./_body.md
+        assignees: huitseeker
+        labels: |
+          upstream
+          automated issue

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,11 @@ byteorder = "1.4.3"
 thiserror = "1.0"
 halo2curves = { version = "0.4.0", features = ["derive_serde"] }
 group = "0.13.0"
+pairing = "0.23.0"
 abomonation = "0.7.3"
 abomonation_derive = { git = "https://github.com/winston-h-zhang/abomonation_derive.git" }
+anyhow = "1.0.72"
+rand = "0.8.4"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/src/provider/kzg.rs
+++ b/src/provider/kzg.rs
@@ -1,258 +1,255 @@
 // KZG
 
-use halo2curves::bn256::{
-    G1, G1Affine, G2, G2Affine, Fr,
-};
-use std::ops::{Mul, Sub};
 use crate::provider::cpu_best_multiexp;
 use ff::Field;
-use std::ops::Add;
 use halo2curves::bn256::Bn256;
-use halo2curves::pairing::Engine;
+use halo2curves::bn256::{Fr, G1Affine, G2Affine, G1, G2};
+use pairing::Engine;
 use pasta_curves::group::Group;
+use std::ops::Add;
+use std::ops::{Mul, Sub};
 
 #[derive(Clone)]
 pub struct KZGParams {
-    pub nmax: u64,
-    pub gen1: G1,
-    pub gen2: G2,
-    pub powers_of_tau: Vec<G1Affine>,
-    pub xi1: G1,
-    pub xi2: G2,
-    pub tau2: G2,
+  pub nmax: u64,
+  pub gen1: G1,
+  pub gen2: G2,
+  pub powers_of_tau: Vec<G1Affine>,
+  pub xi1: G1,
+  pub xi2: G2,
+  pub tau2: G2,
 }
 
 #[derive(Clone)]
 pub struct KZGProof {
-    pub pi: G1,
-    pub delta: G1,
+  pub pi: G1,
+  pub delta: G1,
 }
 
 pub trait KZGScheme {
-    fn setup(nmax: u64) -> Self;
-    fn commit(&self, p: &[Fr]) -> (G1, Fr);
-    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
-    fn eval(&self, q: &[Fr]) -> G1;
-    fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof;
-    fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool;
+  fn setup(nmax: u64) -> Self;
+  fn commit(&self, p: &[Fr]) -> (G1, Fr);
+  fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
+  fn eval(&self, q: &[Fr]) -> G1;
+  fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof;
+  fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool;
 }
 
-
 fn init(f: &[Fr]) -> Vec<Fr> {
-    let mut fmv = vec!(Fr::from(0); f.len());
-    for (i, elem) in f.iter().enumerate() {
-        fmv[i] = *elem;
-    }
-    fmv
+  let mut fmv = vec![Fr::from(0); f.len()];
+  for (i, elem) in f.iter().enumerate() {
+    fmv[i] = *elem;
+  }
+  fmv
 }
 
 fn compute_q(f: &[Fr], v: Fr, u: Fr) -> Vec<Fr> {
-    let mut q = vec!(Fr::from(0); f.len());
-    let mut xmu = vec!(Fr::from(0); f.len());
-    // f - v
-    let mut fmv = init(f);
-    fmv[0] = fmv[0].sub(&v);
+  let mut q = vec![Fr::from(0); f.len()];
+  let mut xmu = vec![Fr::from(0); f.len()];
+  // f - v
+  let mut fmv = init(f);
+  fmv[0] = fmv[0].sub(&v);
 
-    // X - u
-    xmu[1] = Fr::from(1);
-    xmu[0] = xmu[0].sub(&u);
+  // X - u
+  xmu[1] = Fr::from(1);
+  xmu[0] = xmu[0].sub(&u);
 
-    // (f - v) / (X - u)
-    // for each coeff,i in f.reverse, multiply (X - u) by coeff.Xˆ(i-1) and subtract from (f - v)
-    let mut remainder = vec!(Fr::from(0); f.len());
-    for (i, elem) in fmv.iter().enumerate() {
-        remainder[i] = *elem;
-    }
-    let mut i = fmv.len()-1;
-    while i > 0 {
-        let coeff = remainder[i];
-        // remainder = fvm - (X - u).coeff.Xˆ(i-1)
-        remainder[i] = remainder[i].sub(&coeff);
-        assert_eq!(remainder[i], Fr::from(0));
-        remainder[i-1] = remainder[i-1].add(coeff.mul(u));
-        // q += coeff.Xˆ(i-1)
-        q[i-1] += coeff;
-        i -= 1;
-    }
-    assert_eq!(remainder[0], Fr::from(0));
-    q
+  // (f - v) / (X - u)
+  // for each coeff,i in f.reverse, multiply (X - u) by coeff.Xˆ(i-1) and subtract from (f - v)
+  let mut remainder = vec![Fr::from(0); f.len()];
+  for (i, elem) in fmv.iter().enumerate() {
+    remainder[i] = *elem;
+  }
+  let mut i = fmv.len() - 1;
+  while i > 0 {
+    let coeff = remainder[i];
+    // remainder = fvm - (X - u).coeff.Xˆ(i-1)
+    remainder[i] = remainder[i].sub(&coeff);
+    assert_eq!(remainder[i], Fr::from(0));
+    remainder[i - 1] = remainder[i - 1].add(coeff.mul(u));
+    // q += coeff.Xˆ(i-1)
+    q[i - 1] += coeff;
+    i -= 1;
+  }
+  assert_eq!(remainder[0], Fr::from(0));
+  q
 }
-
 
 impl KZGScheme for KZGParams {
+  fn setup(nmax: u64) -> Self {
+    // FIXME: avoid repeated code
+    let rng = &mut rand::thread_rng();
+    let tau = Fr::random(rng);
+    let rng = &mut rand::thread_rng();
+    let xi = Fr::random(rng);
 
-    fn setup(nmax: u64) -> Self {
+    let gen1: G1 = G1::generator();
+    let gen2: G2 = G2::generator();
+    let mut powers = Vec::new();
+    let mut xi1 = gen1;
+    let mut xi2 = gen2;
+    let mut tau2 = gen2;
 
-        // FIXME: avoid repeated code
-        let rng = &mut rand::thread_rng();
-        let tau = Fr::random(rng);
-        let rng = &mut rand::thread_rng();
-        let xi = Fr::random(rng);
-
-        let gen1: G1 = G1::generator();
-        let gen2: G2 = G2::generator();
-        let mut powers = Vec::new();
-        let mut xi1 = gen1;
-        let mut xi2 = gen2;
-        let mut tau2 = gen2;
-
-        for i in 0..nmax {
-            let gtau = gen1;
-            let result = gtau.mul(tau.pow([i as u64]));
-            powers.push(result.into());
-            xi1 = gen1.mul(xi);
-            xi2 = gen2.mul(xi);
-            tau2 = gen2.mul(tau);
-        }
-        KZGParams{
-            nmax,
-            gen2: gen2.into(),
-            gen1: gen1.into(),
-            powers_of_tau: powers,
-            xi1,
-            xi2,
-            tau2,
-        }
+    for i in 0..nmax {
+      let gtau = gen1;
+      let result = gtau.mul(tau.pow([i as u64]));
+      powers.push(result.into());
+      xi1 = gen1.mul(xi);
+      xi2 = gen2.mul(xi);
+      tau2 = gen2.mul(tau);
     }
-
-    /// Commit to univariate polynomial p given in coefficient representation
-    fn commit(&self, p: &[Fr]) -> (G1, Fr) {
-
-        let rng = &mut rand::thread_rng();
-        let r = Fr::random(rng);
-
-        // MSM
-        let mut C = cpu_best_multiexp(p, &self.powers_of_tau);
-
-        // compute r.xi
-        let rxi = self.xi1.mul(r);
-
-        // add r
-        C = C.add(rxi);
-
-        (C, r)
+    KZGParams {
+      nmax,
+      gen2: gen2.into(),
+      gen1: gen1.into(),
+      powers_of_tau: powers,
+      xi1,
+      xi2,
+      tau2,
     }
+  }
 
+  /// Commit to univariate polynomial p given in coefficient representation
+  fn commit(&self, p: &[Fr]) -> (G1, Fr) {
+    let rng = &mut rand::thread_rng();
+    let r = Fr::random(rng);
 
-    /// Open polynomial commitment
-    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
+    // MSM
+    let mut C = cpu_best_multiexp(p, &self.powers_of_tau);
 
-        // MSM
-        let mut recomputedC = cpu_best_multiexp(p, &self.powers_of_tau);
+    // compute r.xi
+    let rxi = self.xi1.mul(r);
 
-        // compute r.xi
-        let rxi = self.xi1.mul(r);
+    // add r
+    C = C.add(rxi);
 
-        // add r
-        recomputedC = recomputedC.add(rxi);
+    (C, r)
+  }
 
-        let diff = C - recomputedC;
+  /// Open polynomial commitment
+  fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
+    // MSM
+    let mut recomputedC = cpu_best_multiexp(p, &self.powers_of_tau);
 
-        //C != recomputedC
-        diff.is_identity().into()
+    // compute r.xi
+    let rxi = self.xi1.mul(r);
+
+    // add r
+    recomputedC = recomputedC.add(rxi);
+
+    let diff = C - recomputedC;
+
+    //C != recomputedC
+    diff.is_identity().into()
+  }
+
+  /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
+  fn eval(&self, q: &[Fr]) -> G1 {
+    let mut sum = self.powers_of_tau[0].mul(q[0]);
+    for (i, coeff) in q.iter().enumerate().skip(1) {
+      let term = self.powers_of_tau[i].mul(coeff);
+      sum = sum.add(term);
     }
+    sum
+  }
 
+  /// Prove evaluation of f at point u is equal to v.
+  fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof {
+    let rng = &mut rand::thread_rng();
+    let s = Fr::random(rng);
 
+    // compute pi
+    let q = compute_q(f, v, u);
+    // eval q
+    let gqtau = self.eval(&q[..]);
 
-    /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
-    fn eval(&self, q: &[Fr]) -> G1 {
-        let mut sum = self.powers_of_tau[0].mul(q[0]);
-        for (i, coeff) in q.iter().enumerate().skip(1) {
-            let term = self.powers_of_tau[i].mul(coeff);
-            sum = sum.add(term);
-        }
-        sum
-    }
+    let sxi1 = self.xi1.mul(s);
+    let pi = gqtau.add(sxi1);
 
-    /// Prove evaluation of f at point u is equal to v.
-    fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof {
-        let rng = &mut rand::thread_rng();
-        let s = Fr::random(rng);
+    // compute delta
+    let mut delta = self.gen1.mul(r);
+    delta = delta.sub(self.powers_of_tau[1].mul(s));
+    delta = delta.add(self.gen1.mul(s.mul(u)));
+    KZGProof { pi, delta }
+  }
 
-        // compute pi
-        let q = compute_q(f, v, u);
-        // eval q
-        let gqtau = self.eval(&q[..]);
+  /// Verify proof that polynomial in commitment C evals to v at point u.
+  fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool {
+    // pleft
+    let vgen1 = self.gen1.mul(v);
+    let mut csvgen1 = C;
+    csvgen1 = csvgen1.sub(vgen1);
+    let g2 = self.gen2;
+    let pleft = Bn256::pairing(&G1Affine::from(csvgen1), &G2Affine::from(g2));
+    // pright1
+    let ug2 = g2.mul(u);
+    let tau2mug2 = self.tau2.sub(ug2);
+    let pright1 = Bn256::pairing(&G1Affine::from(proof.pi), &G2Affine::from(tau2mug2));
 
-
-        let sxi1 = self.xi1.mul(s);
-        let pi = gqtau.add(sxi1);
-
-        // compute delta
-        let mut delta = self.gen1.mul(r);
-        delta = delta.sub(self.powers_of_tau[1].mul(s));
-        delta = delta.add(self.gen1.mul(s.mul(u)));
-        KZGProof { pi, delta }
-    }
-
-    /// Verify proof that polynomial in commitment C evals to v at point u.
-    fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool {
-        // pleft
-        let vgen1 = self.gen1.mul(v);
-        let mut csvgen1 = C;
-        csvgen1 = csvgen1.sub(vgen1);
-        let g2 = self.gen2;
-        let pleft = Bn256::pairing(&G1Affine::from(csvgen1), &G2Affine::from(g2));
-        // pright1
-        let ug2 = g2.mul(u);
-        let tau2mug2 = self.tau2.sub(ug2);
-        let pright1 = Bn256::pairing(&G1Affine::from(proof.pi), &G2Affine::from(tau2mug2));
-
-        // pright2
-        let pright2 = Bn256::pairing(&G1Affine::from(proof.delta), &G2Affine::from(self.xi2));
-        // pleft =? pright1 - pright2
-        let r1pr2 = pright1.add(pright2);
-        pleft.eq(&r1pr2)
-    }
+    // pright2
+    let pright2 = Bn256::pairing(&G1Affine::from(proof.delta), &G2Affine::from(self.xi2));
+    // pleft =? pright1 - pright2
+    let r1pr2 = pright1.add(pright2);
+    pleft.eq(&r1pr2)
+  }
 }
 
 #[test]
-fn test_kzg_open(){
-
-    let kzg = KZGParams::setup(3);
-    //let params = setup(3);
-    let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
-    let (C, r) = kzg.commit(&p);
-    assert!(kzg.open(C, r, &p));
-}
-
-
-#[test]
-fn test_kzg_simple(){
-
-    let kzg = KZGParams::setup(3);
-    //let params = setup(3);
-    let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
-    let (C, r) = kzg.commit(&p);
-    let v = Fr::from(1);
-    let u = Fr::from(1);
-    // Xˆ2 - 1 = (X + 1).(X - 1)
-    let proof = kzg.proveEval(&p, v, u, r);
-    let b = kzg.verifyEval(C, v, u, proof.clone());
-    assert!(b);
+fn test_kzg_open() {
+  let kzg = KZGParams::setup(3);
+  //let params = setup(3);
+  let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
+  let (C, r) = kzg.commit(&p);
+  assert!(kzg.open(C, r, &p));
 }
 
 #[test]
-fn test_kzg_simple2(){
-    let kzg = KZGParams::setup(5);
-    let p = [Fr::from(0), Fr::from(0), Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ4
-    let (C, r) = kzg.commit(&p);
-    let v = Fr::from(1);
-    let u = Fr::from(1);
-    // Xˆ4 - 1 = (Xˆ2 + 1).(Xˆ2 - 1) = (Xˆ2 + 1).(X + 1).(X - 1)
-    let proof = kzg.proveEval(&p, v, u, r);
-    let b = kzg.verifyEval(C, v, u, proof.clone());
-    assert!(b);
+fn test_kzg_simple() {
+  let kzg = KZGParams::setup(3);
+  //let params = setup(3);
+  let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
+  let (C, r) = kzg.commit(&p);
+  let v = Fr::from(1);
+  let u = Fr::from(1);
+  // Xˆ2 - 1 = (X + 1).(X - 1)
+  let proof = kzg.proveEval(&p, v, u, r);
+  let b = kzg.verifyEval(C, v, u, proof.clone());
+  assert!(b);
 }
 
 #[test]
-fn test_kzg_simple3(){
-    let kzg = KZGParams::setup(5);
-    let p = [Fr::from(1), Fr::from(1), Fr::from(1), Fr::from(1), Fr::from(1)]; // this is Xˆ4 + Xˆ3 + ˆXˆ2 + Xˆ1 + 1
-    let (C, r) = kzg.commit(&p);
-    let v = Fr::from(5);
-    let u = Fr::from(1);
-    let proof = kzg.proveEval(&p, v, u, r);
-    let b = kzg.verifyEval(C, v, u, proof.clone());
-    assert!(b);
+fn test_kzg_simple2() {
+  let kzg = KZGParams::setup(5);
+  let p = [
+    Fr::from(0),
+    Fr::from(0),
+    Fr::from(0),
+    Fr::from(0),
+    Fr::from(1),
+  ]; // this is Xˆ4
+  let (C, r) = kzg.commit(&p);
+  let v = Fr::from(1);
+  let u = Fr::from(1);
+  // Xˆ4 - 1 = (Xˆ2 + 1).(Xˆ2 - 1) = (Xˆ2 + 1).(X + 1).(X - 1)
+  let proof = kzg.proveEval(&p, v, u, r);
+  let b = kzg.verifyEval(C, v, u, proof.clone());
+  assert!(b);
+}
+
+#[test]
+fn test_kzg_simple3() {
+  let kzg = KZGParams::setup(5);
+  let p = [
+    Fr::from(1),
+    Fr::from(1),
+    Fr::from(1),
+    Fr::from(1),
+    Fr::from(1),
+  ]; // this is Xˆ4 + Xˆ3 + ˆXˆ2 + Xˆ1 + 1
+  let (C, r) = kzg.commit(&p);
+  let v = Fr::from(5);
+  let u = Fr::from(1);
+  let proof = kzg.proveEval(&p, v, u, r);
+  let b = kzg.verifyEval(C, v, u, proof.clone());
+  assert!(b);
 }

--- a/src/provider/kzg.rs
+++ b/src/provider/kzg.rs
@@ -9,6 +9,7 @@ use ff::Field;
 use std::ops::Add;
 use halo2curves::bn256::Bn256;
 use halo2curves::pairing::Engine;
+use pasta_curves::group::Group;
 
 #[derive(Clone)]
 pub struct KZGParams {
@@ -27,57 +28,15 @@ pub struct KZGProof {
     pub delta: G1,
 }
 
-pub fn setup(nmax: u64) -> KZGParams {
-
-    // FIXME: avoid repeated code
-    let rng = &mut rand::thread_rng();
-    let tau = Fr::random(rng);
-    let rng = &mut rand::thread_rng();
-    let xi = Fr::random(rng);
-
-    let gen1: G1 = G1::generator();
-    let gen2: G2 = G2::generator();
-    let mut powers = Vec::new();
-    let mut xi1 = gen1;
-    let mut xi2 = gen2;
-    let mut tau2 = gen2;
-
-    for i in 0..nmax {
-        let gtau = gen1;
-        let result = gtau.mul(tau.pow([i as u64]));
-        powers.push(result.into());
-        xi1 = gen1.mul(xi);
-        xi2 = gen2.mul(xi);
-        tau2 = gen2.mul(tau);
-    }
-    KZGParams{
-        nmax,
-        gen2: gen2.into(),
-        gen1: gen1.into(),
-        powers_of_tau: powers,
-        xi1,
-        xi2,
-        tau2,
-    }
+pub trait KZGScheme {
+    fn setup(nmax: u64) -> Self;
+    fn commit(&self, p: &[Fr]) -> (G1, Fr);
+    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
+    fn eval(&self, q: &[Fr]) -> G1;
+    fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof;
+    fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool;
 }
 
-/// Commit to univariate polynomial p given in coefficient representation
-pub fn commit(p: &[Fr], params: KZGParams) -> (G1, Fr) {
-
-    let rng = &mut rand::thread_rng();
-    let r = Fr::random(rng);
-
-    // MSM
-    let mut C = cpu_best_multiexp(p, &params.powers_of_tau);
-
-    // compute r.xi
-    let rxi = params.xi1.mul(r);
-
-    // add r
-    C = C.add(rxi);
-
-    (C, r)
-}
 
 fn init(f: &[Fr]) -> Vec<Fr> {
     let mut fmv = vec!(Fr::from(0); f.len());
@@ -119,91 +78,181 @@ fn compute_q(f: &[Fr], v: Fr, u: Fr) -> Vec<Fr> {
     q
 }
 
-/// Use power of tau to compute evaluation of polynomial q in coefficient representation.
-fn eval(q: &[Fr], params: KZGParams) -> G1 {
-    let mut sum = params.powers_of_tau[0].mul(q[0]);
-    for (i, coeff) in q.iter().enumerate().skip(1) {
-        let term = params.powers_of_tau[i].mul(coeff);
-        sum = sum.add(term);
+
+impl KZGScheme for KZGParams {
+
+    fn setup(nmax: u64) -> Self {
+
+        // FIXME: avoid repeated code
+        let rng = &mut rand::thread_rng();
+        let tau = Fr::random(rng);
+        let rng = &mut rand::thread_rng();
+        let xi = Fr::random(rng);
+
+        let gen1: G1 = G1::generator();
+        let gen2: G2 = G2::generator();
+        let mut powers = Vec::new();
+        let mut xi1 = gen1;
+        let mut xi2 = gen2;
+        let mut tau2 = gen2;
+
+        for i in 0..nmax {
+            let gtau = gen1;
+            let result = gtau.mul(tau.pow([i as u64]));
+            powers.push(result.into());
+            xi1 = gen1.mul(xi);
+            xi2 = gen2.mul(xi);
+            tau2 = gen2.mul(tau);
+        }
+        KZGParams{
+            nmax,
+            gen2: gen2.into(),
+            gen1: gen1.into(),
+            powers_of_tau: powers,
+            xi1,
+            xi2,
+            tau2,
+        }
     }
-    sum
-}
 
-/// Prove evaluation of f at point u is equal to v.
-pub fn proveEval(f: &[Fr], v: Fr, u: Fr, r: Fr, params: KZGParams) -> KZGProof {
-    let rng = &mut rand::thread_rng();
-    let s = Fr::random(rng);
+    /// Commit to univariate polynomial p given in coefficient representation
+    fn commit(&self, p: &[Fr]) -> (G1, Fr) {
 
-    // compute pi
-    let q = compute_q(f, v, u);
-    // eval q
-    let gqtau = eval(&q[..], params.clone());
+        let rng = &mut rand::thread_rng();
+        let r = Fr::random(rng);
+
+        // MSM
+        let mut C = cpu_best_multiexp(p, &self.powers_of_tau);
+
+        // compute r.xi
+        let rxi = self.xi1.mul(r);
+
+        // add r
+        C = C.add(rxi);
+
+        (C, r)
+    }
 
 
-    let sxi1 = params.xi1.mul(s);
-    let pi = gqtau.add(sxi1);
+    /// Open polynomial commitment
+    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
 
-    // compute delta
-    let mut delta = params.gen1.mul(r);
-    delta = delta.sub(params.powers_of_tau[1].mul(s));
-    delta = delta.add(params.gen1.mul(s.mul(u)));
-    KZGProof { pi, delta }
-}
+        // MSM
+        let mut recomputedC = cpu_best_multiexp(p, &self.powers_of_tau);
 
-/// Verify proof that polynomial in commitment C evals to v at point u.
-pub fn verifyEval(C: G1, v: Fr, u: Fr, proof: KZGProof, params: KZGParams) -> bool {
-    // pleft
-    let vgen1 = params.gen1.mul(v);
-    let mut csvgen1 = C;
-    csvgen1 = csvgen1.sub(vgen1);
-    let g2 = params.gen2;
-    let pleft = Bn256::pairing(&G1Affine::from(csvgen1), &G2Affine::from(g2));
-    // pright1
-    let ug2 = g2.mul(u);
-    let tau2mug2 = params.tau2.sub(ug2);
-    let pright1 = Bn256::pairing(&G1Affine::from(proof.pi), &G2Affine::from(tau2mug2));
+        // compute r.xi
+        let rxi = self.xi1.mul(r);
 
-    // pright2
-    let pright2 = Bn256::pairing(&G1Affine::from(proof.delta), &G2Affine::from(params.xi2));
-    // pleft =? pright1 - pright2
-    let r1pr2 = pright1.add(pright2);
-    pleft.eq(&r1pr2)
+        // add r
+        recomputedC = recomputedC.add(rxi);
+
+        let diff = C - recomputedC;
+
+        //C != recomputedC
+        diff.is_identity().into()
+    }
+
+
+
+    /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
+    fn eval(&self, q: &[Fr]) -> G1 {
+        let mut sum = self.powers_of_tau[0].mul(q[0]);
+        for (i, coeff) in q.iter().enumerate().skip(1) {
+            let term = self.powers_of_tau[i].mul(coeff);
+            sum = sum.add(term);
+        }
+        sum
+    }
+
+    /// Prove evaluation of f at point u is equal to v.
+    fn proveEval(&self, f: &[Fr], v: Fr, u: Fr, r: Fr) -> KZGProof {
+        let rng = &mut rand::thread_rng();
+        let s = Fr::random(rng);
+
+        // compute pi
+        let q = compute_q(f, v, u);
+        // eval q
+        let gqtau = self.eval(&q[..]);
+
+
+        let sxi1 = self.xi1.mul(s);
+        let pi = gqtau.add(sxi1);
+
+        // compute delta
+        let mut delta = self.gen1.mul(r);
+        delta = delta.sub(self.powers_of_tau[1].mul(s));
+        delta = delta.add(self.gen1.mul(s.mul(u)));
+        KZGProof { pi, delta }
+    }
+
+    /// Verify proof that polynomial in commitment C evals to v at point u.
+    fn verifyEval(&self, C: G1, v: Fr, u: Fr, proof: KZGProof) -> bool {
+        // pleft
+        let vgen1 = self.gen1.mul(v);
+        let mut csvgen1 = C;
+        csvgen1 = csvgen1.sub(vgen1);
+        let g2 = self.gen2;
+        let pleft = Bn256::pairing(&G1Affine::from(csvgen1), &G2Affine::from(g2));
+        // pright1
+        let ug2 = g2.mul(u);
+        let tau2mug2 = self.tau2.sub(ug2);
+        let pright1 = Bn256::pairing(&G1Affine::from(proof.pi), &G2Affine::from(tau2mug2));
+
+        // pright2
+        let pright2 = Bn256::pairing(&G1Affine::from(proof.delta), &G2Affine::from(self.xi2));
+        // pleft =? pright1 - pright2
+        let r1pr2 = pright1.add(pright2);
+        pleft.eq(&r1pr2)
+    }
 }
 
 #[test]
-fn test_kzg_simple(){
-    let params = setup(3);
+fn test_kzg_open(){
+
+    let kzg = KZGParams::setup(3);
+    //let params = setup(3);
     let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
-    let (C, r) = commit(&p, params.clone());
+    let (C, r) = kzg.commit(&p);
+    assert!(kzg.open(C, r, &p));
+}
+
+
+#[test]
+fn test_kzg_simple(){
+
+    let kzg = KZGParams::setup(3);
+    //let params = setup(3);
+    let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ2
+    let (C, r) = kzg.commit(&p);
     let v = Fr::from(1);
     let u = Fr::from(1);
     // Xˆ2 - 1 = (X + 1).(X - 1)
-    let proof = proveEval(&p, v, u, r, params.clone());
-    let b = verifyEval(C, v, u, proof.clone(), params.clone());
+    let proof = kzg.proveEval(&p, v, u, r);
+    let b = kzg.verifyEval(C, v, u, proof.clone());
     assert!(b);
 }
 
 #[test]
 fn test_kzg_simple2(){
-    let params = setup(5);
+    let kzg = KZGParams::setup(5);
     let p = [Fr::from(0), Fr::from(0), Fr::from(0), Fr::from(0), Fr::from(1)]; // this is Xˆ4
-    let (C, r) = commit(&p, params.clone());
+    let (C, r) = kzg.commit(&p);
     let v = Fr::from(1);
     let u = Fr::from(1);
     // Xˆ4 - 1 = (Xˆ2 + 1).(Xˆ2 - 1) = (Xˆ2 + 1).(X + 1).(X - 1)
-    let proof = proveEval(&p, v, u, r, params.clone());
-    let b = verifyEval(C, v, u, proof.clone(), params.clone());
+    let proof = kzg.proveEval(&p, v, u, r);
+    let b = kzg.verifyEval(C, v, u, proof.clone());
     assert!(b);
 }
 
 #[test]
 fn test_kzg_simple3(){
-    let params = setup(5);
+    let kzg = KZGParams::setup(5);
     let p = [Fr::from(1), Fr::from(1), Fr::from(1), Fr::from(1), Fr::from(1)]; // this is Xˆ4 + Xˆ3 + ˆXˆ2 + Xˆ1 + 1
-    let (C, r) = commit(&p, params.clone());
+    let (C, r) = kzg.commit(&p);
     let v = Fr::from(5);
     let u = Fr::from(1);
-    let proof = proveEval(&p, v, u, r, params.clone());
-    let b = verifyEval(C, v, u, proof.clone(), params.clone());
+    let proof = kzg.proveEval(&p, v, u, r);
+    let b = kzg.verifyEval(C, v, u, proof.clone());
     assert!(b);
 }

--- a/src/provider/kzg.rs
+++ b/src/provider/kzg.rs
@@ -1,0 +1,182 @@
+// KZG
+
+use halo2curves::bn256::{
+    G1, G1Affine, G2, G2Affine, Fr,
+};
+use std::ops::{Mul, Sub};
+use crate::provider::cpu_best_multiexp;
+use ff::Field;
+use std::ops::Add;
+use halo2curves::bn256::Bn256;
+use halo2curves::pairing::Engine;
+
+#[derive(Clone)]
+pub struct KZGParams {
+    pub nmax: u64,
+    pub tau: Fr, // TODO: remove toxic waste! q(tau) must be computed using power of tau
+    pub powers_of_tau: Vec<G1Affine>,
+    pub xi1: G1Affine,
+    pub gen2: G2Affine,
+    pub xi2: G2Affine,
+    pub tau2: G2Affine,
+}
+
+#[derive(Clone)]
+pub struct KZGProof {
+    pub pi: G1Affine,
+    pub delta: G1Affine,
+}
+
+pub fn setup(nmax: u64) -> KZGParams {
+
+    let rng = &mut rand::thread_rng();
+    let tau = Fr::random(rng);
+    //let tau = Fr::from(1);
+    let rng = &mut rand::thread_rng();
+    let xi = Fr::random(rng);
+
+    let mut powers = Vec::new();
+    let mut xi1 = G1::generator();
+    let mut xi2 = G2::generator();
+    let mut tau2 = G2::generator();
+    let gen1 = G1::generator();
+    let gen2 = G2::generator();
+    for i in 0..nmax {
+
+        let gtau = gen1;
+        let result = gtau.mul(tau.pow([i as u64]));
+
+        powers.push(result.into());
+        xi1 = gen1.mul(xi).into();
+        xi2 = gen2.mul(xi).into();
+
+        tau2 = gen2.mul(tau).into();
+    }
+    let res: KZGParams = KZGParams{
+        nmax,
+        tau,
+        powers_of_tau: powers,
+        xi1: xi1.into(),
+        gen2: gen2.into(),
+        xi2: xi2.into(),
+        tau2: tau2.into(),
+    };
+    return res;
+}
+
+pub fn commit(p: &[Fr], params: KZGParams) -> (G1, Fr) {
+
+    let rng = &mut rand::thread_rng();
+    let r = Fr::random(rng);
+
+    // MSM
+    let mut C = cpu_best_multiexp(p, &params.powers_of_tau);
+
+    // compute r.xi
+    let rxi = params.xi1.mul(r);
+
+    // add r
+    C = C.add(rxi);
+
+    (C, r)
+}
+
+fn compute_q_helper(f: &[Fr], v: Fr, u: Fr) -> Vec<Fr> {
+    let mut q = vec!(Fr::from(0); f.len());
+    let mut xmu = vec!(Fr::from(0); f.len());
+    // f - v
+    let mut fmv = vec!(Fr::from(0); f.len());
+    for (i, elem) in f.iter().enumerate() {
+        fmv[i] = *elem;
+    }
+    fmv[0] = fmv[0].sub(&v);
+
+    // X - u
+    xmu[1] = Fr::from(1);
+    xmu[0] = xmu[0].sub(&u);
+
+    // (f - v) / (X - u)
+    // for each coeff,i in f.reverse, multiply (X - u) by coeff.Xˆ(i-1) and subtract from (f - v)
+    let mut remainder = vec!(Fr::from(0); f.len());
+    for (i, elem) in fmv.iter().enumerate() {
+        remainder[i] = *elem;
+    }
+    let mut i = fmv.len()-1;
+    while i > 0 {
+        let coeff = remainder[i];
+        // remainder = fvm - (X - u).coeff.Xˆ(i-1)
+        remainder[i] = remainder[i].sub(&coeff);
+        assert_eq!(remainder[i], Fr::from(0));
+        remainder[i-1] = remainder[i-1].add(coeff.mul(u));
+        // q += coeff.Xˆ(i-1)
+        q[i-1] += coeff;
+        i -= 1;
+    }
+    assert_eq!(remainder[0], Fr::from(0));
+    q
+}
+
+fn eval(q: &[Fr], tau: Fr) -> Fr {
+    let mut ptau = Fr::from(1);
+    let mut sum = Fr::from(0);
+    for coeff in q.iter() {
+        let term = coeff.mul(&ptau);
+        ptau *= tau;
+        sum += term;
+    }
+    sum
+}
+
+pub fn proveEval(f: &[Fr], v: Fr, u: Fr, r: Fr, params: KZGParams) -> KZGProof {
+    let rng = &mut rand::thread_rng();
+    let s = Fr::random(rng);
+
+    let q = compute_q_helper(f, v, u);
+    // eval q
+    let qtau = eval(&q[..], params.tau);
+
+    let gen1 = G1::generator();
+    let gqtau = gen1.mul(qtau);
+    let sxi1 = params.xi1.mul(s);
+    let pi = gqtau.add(sxi1);
+
+    // compute pi
+    // compute delta
+    let mut delta = gen1.mul(r);
+    delta = delta.sub(params.powers_of_tau[1].mul(s));
+    delta = delta.add(gen1.mul(s.mul(u)));
+    KZGProof { pi: pi.into(), delta: delta.into() }
+}
+
+pub fn verifyEval(C: G1Affine, v: Fr, u: Fr, proof: KZGProof, params: KZGParams) -> bool {
+    // pleft
+    let gen1 = G1::generator();
+    let gen2 = G2::generator();
+    let vgen1 = G1Affine::from(gen1).mul(v);
+    let mut csvgen1 = C;
+    csvgen1 = csvgen1.sub(G1Affine::from(vgen1)).into();
+    let g2 = G2Affine::from(gen2);
+    let pleft = Bn256::pairing(&csvgen1, &(g2));
+    // pright1
+    let ug2 = g2.mul(u);
+    let tau2mug2 = params.tau2.sub(ug2);
+    let pright1 = Bn256::pairing(&proof.pi, &G2Affine::from(tau2mug2));
+
+    // pright2
+    let pright2 = Bn256::pairing(&proof.delta, &params.xi2);
+    // pleft =? pright1 - pright2
+    let r1pr2 = pright1.add(pright2);
+    pleft.eq(&r1pr2)
+}
+
+#[test]
+fn test_kzg(){
+    let params = setup(3);
+    let p = [Fr::from(0), Fr::from(0), Fr::from(1)];
+    let (C, r) = commit(&p, params.clone());
+    let v = Fr::from(1);
+    let u = Fr::from(1);
+    let proof = proveEval(&[Fr::from(0), Fr::from(0), Fr::from(1)], v, u, r, params.clone());
+    let b = verifyEval(G1Affine::from(C), v, u, proof.clone(), params.clone());
+    assert!(b);
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -7,10 +7,11 @@
 pub mod bn256_grumpkin;
 pub mod ipa_pc;
 pub mod keccak;
+pub mod kzg;
+pub mod non_hiding_kzg;
 pub mod pasta;
 pub mod pedersen;
 pub mod poseidon;
-pub mod kzg;
 pub mod zeromorph;
 
 use ff::PrimeField;
@@ -114,7 +115,7 @@ fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &
 ///
 /// This will use multithreading if beneficial.
 /// Adapted from zcash/halo2
-pub(crate) fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
+fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
   assert_eq!(coeffs.len(), bases.len());
 
   let num_threads = rayon::current_num_threads();

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -10,6 +10,7 @@ pub mod keccak;
 pub mod pasta;
 pub mod pedersen;
 pub mod poseidon;
+pub mod kzg;
 
 use ff::PrimeField;
 use pasta_curves::{self, arithmetic::CurveAffine, group::Group as AnotherGroup};

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -11,6 +11,7 @@ pub mod pasta;
 pub mod pedersen;
 pub mod poseidon;
 pub mod kzg;
+pub mod zeromorph;
 
 use ff::PrimeField;
 use pasta_curves::{self, arithmetic::CurveAffine, group::Group as AnotherGroup};

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -7,12 +7,13 @@
 pub mod bn256_grumpkin;
 pub mod ipa_pc;
 pub mod keccak;
-pub mod kzg;
+// pub mod kzg;
 pub mod non_hiding_kzg;
+pub mod non_hiding_zeromorph;
 pub mod pasta;
 pub mod pedersen;
 pub mod poseidon;
-pub mod zeromorph;
+// pub mod zeromorph;
 
 use ff::PrimeField;
 use pasta_curves::{self, arithmetic::CurveAffine, group::Group as AnotherGroup};

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -4,7 +4,9 @@ use std::{borrow::Borrow, marker::PhantomData, ops::Mul};
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group as _};
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
+use rand::Rng;
 use rand_core::{CryptoRng, RngCore};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 use crate::{errors::NovaError, traits::Group};
 
@@ -220,6 +222,19 @@ where
     Ok(UVKZGCommitment(C.to_affine()))
   }
 
+  /// Generate a commitment for a list of polynomials
+  pub fn batch_commit(
+    prover_param: impl Borrow<UVKZGProverKey<E>>,
+    polys: &[UVKZGPoly<E::Fr>],
+  ) -> Result<Vec<UVKZGCommitment<E>>, NovaError> {
+    let prover_param = prover_param.borrow();
+
+    polys
+      .into_par_iter()
+      .map(|poly| Self::commit(prover_param, poly))
+      .collect::<Result<Vec<UVKZGCommitment<E>>, NovaError>>()
+  }
+
   /// On input a polynomial `p` and a point `point`, outputs a proof for the
   /// same.
   pub fn open(
@@ -250,6 +265,31 @@ where
     ))
   }
 
+  /// Input a list of polynomials, and a same number of points,
+  /// compute a multi-opening for all the polynomials.
+  // This is a naive approach
+  // TODO: to implement a more efficient batch opening algorithm
+  // (e.g., the appendix C.4 in https://eprint.iacr.org/2020/1536.pdf)
+  pub fn batch_open(
+    prover_param: impl Borrow<UVKZGProverKey<E>>,
+    polynomials: &[UVKZGPoly<E::Fr>],
+    points: &[E::Fr],
+  ) -> Result<(Vec<UVKZGProof<E>>, Vec<UVKZGEvaluation<E>>), NovaError> {
+    if polynomials.len() != points.len() {
+      // TODO: a better Error
+      return Err(NovaError::InvalidIPA);
+    }
+    let mut batch_proof = vec![];
+    let mut evals = vec![];
+    for (poly, point) in polynomials.iter().zip(points.iter()) {
+      let (proof, eval) = Self::open(prover_param.borrow(), poly, point)?;
+      batch_proof.push(proof);
+      evals.push(eval);
+    }
+
+    Ok((batch_proof, evals))
+  }
+
   /// Verifies that `value` is the evaluation at `x` of the polynomial
   /// committed inside `comm`.
   pub fn verify(
@@ -275,6 +315,62 @@ where
       .collect::<Vec<_>>();
     let pairing_result = E::multi_miller_loop(pairing_input_refs.as_slice()).final_exponentiation();
     Ok(pairing_result.is_identity().into())
+  }
+
+  /// Verifies that `value_i` is the evaluation at `x_i` of the polynomial
+  /// `poly_i` committed inside `comm`.
+  // This is a naive approach
+  // TODO: to implement the more efficient batch verification algorithm
+  // (e.g., the appendix C.4 in https://eprint.iacr.org/2020/1536.pdf)
+  pub fn batch_verify<R: RngCore + CryptoRng>(
+    verifier_params: impl Borrow<UVKZGVerifierKey<E>>,
+    multi_commitment: &[UVKZGCommitment<E>],
+    points: &[E::Fr],
+    values: &[UVKZGEvaluation<E>],
+    batch_proof: &[UVKZGProof<E>],
+    rng: &mut R,
+  ) -> Result<bool, NovaError> {
+    let verifier_params = verifier_params.borrow();
+
+    let mut total_c = <E::G1>::identity();
+    let mut total_w = <E::G1>::identity();
+
+    let mut randomizer = E::Fr::ONE;
+    // Instead of multiplying g and gamma_g in each turn, we simply accumulate
+    // their coefficients and perform a final multiplication at the end.
+    let mut g_multiplier = E::Fr::ZERO;
+    for (((c, z), v), proof) in multi_commitment
+      .iter()
+      .zip(points)
+      .zip(values)
+      .zip(batch_proof)
+    {
+      let w = proof.proof;
+      let mut temp = w.mul(*z);
+      temp += &c.0;
+      let c = temp;
+      g_multiplier += &(randomizer * v.0);
+      total_c += &c.mul(randomizer);
+      total_w += &w.mul(randomizer);
+      // We don't need to sample randomizers from the full field,
+      // only from 128-bit strings.
+      randomizer = E::Fr::from_u128(rng.gen::<u128>());
+    }
+    total_c -= &verifier_params.g.mul(g_multiplier);
+
+    let mut affine_points = vec![E::G1Affine::identity(); 2];
+    E::G1::batch_normalize(&[-total_w, total_c], &mut affine_points);
+    let (total_w, total_c) = (affine_points[0], affine_points[1]);
+
+    let result = E::multi_miller_loop(&[
+      (&total_w, &verifier_params.beta_h.into()),
+      (&total_c, &verifier_params.h.into()),
+    ])
+    .final_exponentiation()
+    .is_identity()
+    .into();
+
+    Ok(result)
   }
 }
 
@@ -309,8 +405,50 @@ mod tests {
     Ok(())
   }
 
+  fn batch_check_test_template<E>() -> Result<(), NovaError>
+  where
+    E: MultiMillerLoop,
+    E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+  {
+    for _ in 0..10 {
+      let mut rng = &mut thread_rng();
+
+      let degree = rng.gen_range(2..20);
+
+      let pp = UVUniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, degree);
+      let (ck, vk) = pp.trim(degree);
+
+      let mut comms = Vec::new();
+      let mut values = Vec::new();
+      let mut points = Vec::new();
+      let mut proofs = Vec::new();
+      for _ in 0..10 {
+        let mut rng = rng.clone();
+        let p = UVKZGPoly::random(degree, &mut rng);
+        let comm = UVKZGPCS::<E>::commit(&ck, &p)?;
+        let point = E::Fr::random(rng);
+        let (proof, value) = UVKZGPCS::<E>::open(&ck, &p, &point)?;
+
+        assert!(UVKZGPCS::<E>::verify(&vk, &comm, &point, &proof, &value)?);
+        comms.push(comm);
+        values.push(value);
+        points.push(point);
+        proofs.push(proof);
+      }
+      assert!(UVKZGPCS::<E>::batch_verify(
+        &vk, &comms, &points, &values, &proofs, &mut rng
+      )?);
+    }
+    Ok(())
+  }
+
   #[test]
   fn end_to_end_test() {
     end_to_end_test_template::<halo2curves::bn256::Bn256>().expect("test failed for Bn256");
+  }
+
+  #[test]
+  fn batch_check_test() {
+    batch_check_test_template::<halo2curves::bn256::Bn256>().expect("test failed for Bn256");
   }
 }

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -1,0 +1,316 @@
+use std::{borrow::Borrow, marker::PhantomData, ops::Mul};
+
+// KZG
+use ff::{Field, PrimeField};
+use group::{prime::PrimeCurveAffine, Curve, Group as _};
+use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
+use rand_core::{CryptoRng, RngCore};
+
+use crate::{errors::NovaError, traits::Group};
+
+/// `UniversalParams` are the universal parameters for the KZG10 scheme.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct UVUniversalKZGParam<E: Engine> {
+  /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to
+  /// `degree`.
+  pub powers_of_g: Vec<E::G1Affine>,
+  /// The generator of G2.
+  pub h: E::G2Affine,
+  /// \beta times the above generator of G2.
+  pub beta_h: E::G2Affine,
+}
+
+/// `UnivariateProverKey` is used to generate a proof
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct UVKZGProverKey<E: Engine> {
+  /// generators
+  pub powers_of_g: Vec<E::G1Affine>,
+}
+
+/// `UVKZGVerifierKey` is used to check evaluation proofs for a given
+/// commitment.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct UVKZGVerifierKey<E: Engine> {
+  /// The generator of G1.
+  pub g: E::G1Affine,
+  /// The generator of G2.
+  pub h: E::G2Affine,
+  /// \beta times the above generator of G2.
+  pub beta_h: E::G2Affine,
+}
+
+impl<E: Engine> UVUniversalKZGParam<E>
+where
+  E::G1: Group,
+{
+  /// Returns the maximum supported degree
+  pub fn max_degree(&self) -> usize {
+    self.powers_of_g.len()
+  }
+
+  /// Returns the prover parameters
+  ///
+  /// # Panics
+  /// if `supported_size` is greater than `self.max_degree()`
+  pub fn extract_prover_key(&self, supported_size: usize) -> UVKZGProverKey<E> {
+    let powers_of_g = self.powers_of_g[..=supported_size].to_vec();
+    UVKZGProverKey { powers_of_g }
+  }
+
+  /// Returns the verifier parameters
+  ///
+  /// # Panics
+  /// If self.prover_params is empty.
+  pub fn extract_verifier_key(&self, supported_size: usize) -> UVKZGVerifierKey<E> {
+    if self.powers_of_g.len() < supported_size {
+      panic!("supported_size is greater than self.max_degree()");
+    }
+    UVKZGVerifierKey {
+      g: self.powers_of_g[0],
+      h: self.h,
+      beta_h: self.beta_h,
+    }
+  }
+
+  /// Trim the universal parameters to specialize the public parameters
+  /// for univariate polynomials to the given `supported_size`, and
+  /// returns prover key and verifier key. `supported_size` should
+  /// be in range `1..params.len()`
+  ///
+  /// # Panics
+  /// If `supported_size` is greater than `self.max_degree()`, or `self.max_degree()` is zero.
+  pub fn trim(&self, supported_size: usize) -> (UVKZGProverKey<E>, UVKZGVerifierKey<E>) {
+    let powers_of_g = self.powers_of_g[..=supported_size].to_vec();
+
+    let pk = UVKZGProverKey { powers_of_g };
+    let vk = UVKZGVerifierKey {
+      g: self.powers_of_g[0],
+      h: self.h,
+      beta_h: self.beta_h,
+    };
+    (pk, vk)
+  }
+
+  /// Build SRS for testing.
+  /// WARNING: THIS FUNCTION IS FOR TESTING PURPOSE ONLY.
+  /// THE OUTPUT SRS SHOULD NOT BE USED IN PRODUCTION.
+  pub fn gen_srs_for_testing<R: RngCore + CryptoRng>(mut rng: &mut R, max_degree: usize) -> Self {
+    let beta = E::Fr::random(&mut rng);
+    let g = E::G1::random(&mut rng);
+    let h = E::G2::random(rng);
+
+    let powers_of_g_projective = (0..=max_degree)
+      .scan(g, |acc, _| {
+        let val = *acc;
+        *acc *= beta;
+        Some(val)
+      })
+      .collect::<Vec<E::G1>>();
+
+    let mut powers_of_g = vec![E::G1Affine::identity(); powers_of_g_projective.len()];
+    E::G1::batch_normalize(&powers_of_g_projective, &mut powers_of_g);
+
+    let h = h.to_affine();
+    let beta_h = (h * beta).to_affine();
+
+    let pp = Self {
+      powers_of_g,
+      h,
+      beta_h,
+    };
+    pp
+  }
+}
+
+/// Commitments
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct UVKZGCommitment<E: Engine>(
+  /// the actual commitment is an affine point.
+  pub E::G1Affine,
+);
+
+/// Polynomial Evaluation
+pub struct UVKZGEvaluation<E: Engine>(E::Fr);
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+
+/// Proofs
+pub struct UVKZGProof<E: Engine> {
+  /// proof
+  pub proof: E::G1Affine,
+}
+
+// TODO: we are extending this into a real Dense UV Polynomial type,
+// and this is probably better organized elsewhere.
+/// Polynomial and its associated types
+pub type UVKZGPoly<F> = crate::spartan::sumcheck::UniPoly<F>;
+
+impl<F: PrimeField> UVKZGPoly<F> {
+  fn zero() -> Self {
+    UVKZGPoly::new(Vec::new())
+  }
+
+  pub fn random<R: RngCore + CryptoRng>(degree: usize, mut rng: &mut R) -> Self {
+    let coeffs = (0..=degree).map(|_| F::random(&mut rng)).collect();
+    UVKZGPoly::new(coeffs)
+  }
+
+  /// Divide self by another polynomial, and returns the
+  /// quotient and remainder.
+  fn divide_with_q_and_r(&self, divisor: &Self) -> Option<(UVKZGPoly<F>, UVKZGPoly<F>)> {
+    if self.is_zero() {
+      Some((UVKZGPoly::zero(), UVKZGPoly::zero()))
+    } else if divisor.is_zero() {
+      panic!("Dividing by zero polynomial")
+    } else if self.degree() < divisor.degree() {
+      Some((UVKZGPoly::zero(), self.clone()))
+    } else {
+      // Now we know that self.degree() >= divisor.degree();
+      let mut quotient = vec![F::ZERO; self.degree() - divisor.degree() + 1];
+      let mut remainder: UVKZGPoly<F> = self.clone();
+      // Can unwrap here because we know self is not zero.
+      let divisor_leading_inv = divisor.leading_coefficient().unwrap().invert().unwrap();
+      while !remainder.is_zero() && remainder.degree() >= divisor.degree() {
+        let cur_q_coeff = *remainder.leading_coefficient().unwrap() * divisor_leading_inv;
+        let cur_q_degree = remainder.degree() - divisor.degree();
+        quotient[cur_q_degree] = cur_q_coeff;
+
+        for (i, div_coeff) in divisor.coeffs.iter().enumerate() {
+          remainder.coeffs[cur_q_degree + i] -= &(cur_q_coeff * div_coeff);
+        }
+        while let Some(true) = remainder.coeffs.last().map(|c| c == &F::ZERO) {
+          remainder.coeffs.pop();
+        }
+      }
+      Some((UVKZGPoly::new(quotient), remainder))
+    }
+  }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+/// KZG Polynomial Commitment Scheme on univariate polynomial.
+/// Note: this is non-hiding, which is why we will implement the EvaluationEngineTrait on this token struct,
+/// as we will have several impls for the trait pegged on the same instance of a pairing::Engine.
+pub struct UVKZGPCS<E> {
+  #[doc(hidden)]
+  phantom: PhantomData<E>,
+}
+
+impl<E: MultiMillerLoop> UVKZGPCS<E>
+where
+  E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+{
+  // TODO: this relies on NovaError::InvalidIPA, which should really be extended to a sub-error enum
+  // called "PCSError"
+  /// Generate a commitment for a polynomial
+  /// Note that the scheme is not hidding
+  pub fn commit(
+    prover_param: impl Borrow<UVKZGProverKey<E>>,
+    poly: &UVKZGPoly<E::Fr>,
+  ) -> Result<UVKZGCommitment<E>, NovaError> {
+    let prover_param = prover_param.borrow();
+
+    if poly.degree() > prover_param.powers_of_g.len() {
+      return Err(NovaError::InvalidIPA);
+    }
+    let C = <E::G1 as Group>::vartime_multiscalar_mul(
+      poly.coeffs.as_slice(),
+      &prover_param.powers_of_g.as_slice()[..poly.coeffs.len()],
+    );
+    Ok(UVKZGCommitment(C.to_affine()))
+  }
+
+  /// On input a polynomial `p` and a point `point`, outputs a proof for the
+  /// same.
+  pub fn open(
+    prover_param: impl Borrow<UVKZGProverKey<E>>,
+    polynomial: &UVKZGPoly<E::Fr>,
+    point: &E::Fr,
+  ) -> Result<(UVKZGProof<E>, UVKZGEvaluation<E>), NovaError> {
+    let prover_param = prover_param.borrow();
+    let divisor = UVKZGPoly {
+      coeffs: vec![-*point, E::Fr::ONE],
+    };
+    // TODO: Better error
+    let witness_polynomial = polynomial
+      .divide_with_q_and_r(&divisor)
+      .map(|(q, _r)| q)
+      .ok_or(NovaError::InvalidIPA)?;
+    let proof = <E::G1 as Group>::vartime_multiscalar_mul(
+      witness_polynomial.coeffs.as_slice(),
+      &prover_param.powers_of_g.as_slice()[..witness_polynomial.coeffs.len()],
+    );
+    let evaluation = UVKZGEvaluation(polynomial.evaluate(point));
+
+    Ok((
+      UVKZGProof {
+        proof: proof.to_affine(),
+      },
+      evaluation,
+    ))
+  }
+
+  /// Verifies that `value` is the evaluation at `x` of the polynomial
+  /// committed inside `comm`.
+  pub fn verify(
+    verifier_param: impl Borrow<UVKZGVerifierKey<E>>,
+    commitment: &UVKZGCommitment<E>,
+    point: &E::Fr,
+    proof: &UVKZGProof<E>,
+    evaluation: &UVKZGEvaluation<E>,
+  ) -> Result<bool, NovaError> {
+    let verifier_param = verifier_param.borrow();
+
+    let pairing_inputs: Vec<(E::G1Affine, E::G2Prepared)> = vec![
+      (
+        (verifier_param.g.mul(evaluation.0) - proof.proof.mul(point) - commitment.0.to_curve())
+          .to_affine(),
+        verifier_param.h.into(),
+      ),
+      (proof.proof, verifier_param.beta_h.into()),
+    ];
+    let pairing_input_refs = pairing_inputs
+      .iter()
+      .map(|(a, b)| (a, b))
+      .collect::<Vec<_>>();
+    let pairing_result = E::multi_miller_loop(pairing_input_refs.as_slice()).final_exponentiation();
+    Ok(pairing_result.is_identity().into())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rand::{thread_rng, Rng};
+
+  use super::*;
+
+  fn end_to_end_test_template<E>() -> Result<(), NovaError>
+  where
+    E: MultiMillerLoop,
+    E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+  {
+    for _ in 0..100 {
+      let mut rng = &mut thread_rng();
+      let degree = rng.gen_range(2..20);
+
+      let pp = UVUniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, degree);
+      let (ck, vk) = pp.trim(degree);
+      let p = UVKZGPoly::random(degree, rng);
+      let comm = UVKZGPCS::<E>::commit(&ck, &p)?;
+      let point = E::Fr::random(rng);
+      let (proof, value) = UVKZGPCS::<E>::open(&ck, &p, &point)?;
+      assert!(
+        UVKZGPCS::<E>::verify(&vk, &comm, &point, &proof, &value)?,
+        "proof was incorrect for max_degree = {}, polynomial_degree = {}",
+        degree,
+        p.degree(),
+      );
+    }
+    Ok(())
+  }
+
+  #[test]
+  fn end_to_end_test() {
+    end_to_end_test_template::<halo2curves::bn256::Bn256>().expect("test failed for Bn256");
+  }
+}

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -1,3 +1,4 @@
+//! Non-hiding variant of KZG10 scheme for univariate polynomials.
 use std::{borrow::Borrow, marker::PhantomData, ops::Mul};
 
 // KZG
@@ -21,7 +22,6 @@ pub struct UVUniversalKZGParam<E: Engine> {
   /// \beta times the above generator of G2.
   pub beta_h: E::G2Affine,
 }
-
 /// `UnivariateProverKey` is used to generate a proof
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct UVKZGProverKey<E: Engine> {

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -142,6 +142,7 @@ where
   E::G1: Group,
 {
   fn to_transcript_bytes(&self) -> Vec<u8> {
+    // TODO: avoid the round-trip through the group
     E::G1::from(self.0).compress().to_transcript_bytes()
   }
 }

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -9,21 +9,23 @@ use rand::Rng;
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-use crate::{errors::NovaError, traits::Group};
+use crate::{
+  errors::NovaError,
+  traits::{Group, TranscriptReprTrait},
+};
 
 /// `UniversalParams` are the universal parameters for the KZG10 scheme.
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UVUniversalKZGParam<E: Engine> {
   /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to
   /// `degree`.
   pub powers_of_g: Vec<E::G1Affine>,
-  /// The generator of G2.
-  pub h: E::G2Affine,
-  /// \beta times the above generator of G2.
-  pub beta_h: E::G2Affine,
+  /// Group elements of the form `{ \beta^i H }`, where `i` ranges from 0 to
+  /// `degree`.
+  pub powers_of_h: Vec<E::G2Affine>,
 }
 /// `UnivariateProverKey` is used to generate a proof
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UVKZGProverKey<E: Engine> {
   /// generators
   pub powers_of_g: Vec<E::G1Affine>,
@@ -31,7 +33,7 @@ pub struct UVKZGProverKey<E: Engine> {
 
 /// `UVKZGVerifierKey` is used to check evaluation proofs for a given
 /// commitment.
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UVKZGVerifierKey<E: Engine> {
   /// The generator of G1.
   pub g: E::G1Affine,
@@ -41,10 +43,7 @@ pub struct UVKZGVerifierKey<E: Engine> {
   pub beta_h: E::G2Affine,
 }
 
-impl<E: Engine> UVUniversalKZGParam<E>
-where
-  E::G1: Group,
-{
+impl<E: Engine> UVUniversalKZGParam<E> {
   /// Returns the maximum supported degree
   pub fn max_degree(&self) -> usize {
     self.powers_of_g.len()
@@ -69,8 +68,8 @@ where
     }
     UVKZGVerifierKey {
       g: self.powers_of_g[0],
-      h: self.h,
-      beta_h: self.beta_h,
+      h: self.powers_of_h[0],
+      beta_h: self.powers_of_h[1],
     }
   }
 
@@ -87,8 +86,8 @@ where
     let pk = UVKZGProverKey { powers_of_g };
     let vk = UVKZGVerifierKey {
       g: self.powers_of_g[0],
-      h: self.h,
-      beta_h: self.beta_h,
+      h: self.powers_of_h[0],
+      beta_h: self.powers_of_h[1],
     };
     (pk, vk)
   }
@@ -112,13 +111,20 @@ where
     let mut powers_of_g = vec![E::G1Affine::identity(); powers_of_g_projective.len()];
     E::G1::batch_normalize(&powers_of_g_projective, &mut powers_of_g);
 
-    let h = h.to_affine();
-    let beta_h = (h * beta).to_affine();
+    let powers_of_h_projective = (0..=max_degree)
+      .scan(h, |acc, _| {
+        let val = *acc;
+        *acc *= beta;
+        Some(val)
+      })
+      .collect::<Vec<E::G2>>();
+
+    let mut powers_of_h = vec![E::G2Affine::identity(); powers_of_h_projective.len()];
+    E::G2::batch_normalize(&powers_of_h_projective, &mut powers_of_h);
 
     let pp = Self {
       powers_of_g,
-      h,
-      beta_h,
+      powers_of_h,
     };
     pp
   }
@@ -131,8 +137,18 @@ pub struct UVKZGCommitment<E: Engine>(
   pub E::G1Affine,
 );
 
+impl<E: Engine> TranscriptReprTrait<E::G1> for UVKZGCommitment<E>
+where
+  E::G1: Group,
+{
+  fn to_transcript_bytes(&self) -> Vec<u8> {
+    E::G1::from(self.0).compress().to_transcript_bytes()
+  }
+}
+
 /// Polynomial Evaluation
-pub struct UVKZGEvaluation<E: Engine>(E::Fr);
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct UVKZGEvaluation<E: Engine>(pub E::Fr);
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -1,2 +1,285 @@
 //! Non-hiding Zeromorph scheme for Multilinear Polynomials.
-//! 
+//!
+//!
+
+use ff::{BatchInvert, Field};
+use pairing::{Engine, MultiMillerLoop};
+use rayon::prelude::{
+  IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
+use std::{borrow::Borrow, iter, marker::PhantomData};
+
+use crate::{
+  errors::NovaError,
+  spartan::polynomial::MultilinearPolynomial,
+  traits::{Group, TranscriptEngineTrait},
+};
+
+use super::non_hiding_kzg::{
+  UVKZGCommitment, UVKZGEvaluation, UVKZGPoly, UVKZGProof, UVKZGProverKey, UVKZGVerifierKey,
+  UVUniversalKZGParam, UVKZGPCS,
+};
+
+/// `ZMProverKey` is used to generate a proof
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZMProverKey<E: Engine> {
+  commit_pp: UVKZGProverKey<E>,
+  open_pp: UVKZGProverKey<E>,
+}
+
+/// `ZMVerifierKey` is used to check evaluation proofs for a given
+/// commitment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZMVerifierKey<E: Engine> {
+  vp: UVKZGVerifierKey<E>,
+  s_offset_h: E::G2Affine,
+}
+
+/// Trim the universal parameters to specialize the public parameters
+/// for multilinear polynomials to the given `max_degree`, and
+/// returns prover key and verifier key. `supported_size` should
+/// be in range `1..params.len()`
+///
+/// # Panics
+/// If `supported_size` is greater than `self.max_degree()`, or `self.max_degree()` is zero.
+//
+// TODO: important, we need a better way to handle that the commitment key should be 2^max_degree sized,
+// see the runtime error in commit() below
+pub fn trim<E: Engine>(
+  params: &UVUniversalKZGParam<E>,
+  max_degree: usize,
+) -> (ZMProverKey<E>, ZMVerifierKey<E>) {
+  let (commit_pp, vp) = params.trim(max_degree);
+  let offset = params.powers_of_g.len() - max_degree;
+  let open_pp = {
+    let offset_powers_of_g1 = params.powers_of_g[offset..].to_vec();
+    UVKZGProverKey {
+      powers_of_g: offset_powers_of_g1,
+    }
+  };
+  let s_offset_h = params.powers_of_h[offset];
+
+  (
+    ZMProverKey { commit_pp, open_pp },
+    ZMVerifierKey { vp, s_offset_h },
+  )
+}
+
+/// Commitments
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct ZMCommitment<E: Engine>(
+  /// the actual commitment is an affine point.
+  pub E::G1Affine,
+);
+
+impl<E: Engine> From<UVKZGCommitment<E>> for ZMCommitment<E> {
+  fn from(value: UVKZGCommitment<E>) -> Self {
+    ZMCommitment(value.0)
+  }
+}
+
+impl<E: Engine> From<ZMCommitment<E>> for UVKZGCommitment<E> {
+  fn from(value: ZMCommitment<E>) -> Self {
+    UVKZGCommitment(value.0)
+  }
+}
+
+/// Polynomial Evaluation
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct ZMEvaluation<E: Engine>(E::Fr);
+
+impl<E: Engine> From<UVKZGEvaluation<E>> for ZMEvaluation<E> {
+  fn from(value: UVKZGEvaluation<E>) -> Self {
+    ZMEvaluation(value.0)
+  }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+
+/// Proofs
+pub struct ZMProof<E: Engine> {
+  /// proof
+  pub proof: E::G1Affine,
+}
+
+impl<E: Engine> From<UVKZGProof<E>> for ZMProof<E> {
+  fn from(value: UVKZGProof<E>) -> Self {
+    ZMProof { proof: value.proof }
+  }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+/// Zeromorph Polynomial Commitment Scheme on multilinear polynomials.
+/// Note: this is non-hiding, which is why we will implement the EvaluationEngineTrait on this token struct,
+/// as we will have several impls for the trait pegged on the same instance of a pairing::Engine.
+pub struct ZMPCS<E> {
+  #[doc(hidden)]
+  phantom: PhantomData<E>,
+}
+
+impl<E: MultiMillerLoop> ZMPCS<E>
+where
+  E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+{
+  /// Generate a commitment for a polynomial
+  /// Note that the scheme is not hidding
+  pub fn commit(
+    pp: impl Borrow<ZMProverKey<E>>,
+    poly: &MultilinearPolynomial<E::Fr>,
+  ) -> Result<ZMCommitment<E>, NovaError> {
+    let pp = pp.borrow();
+    if pp.commit_pp.powers_of_g.len() < poly.Z.len() {
+      return Err(NovaError::InvalidIPA); // TODO: better error
+    }
+    // TODO: remove the undue clone in the creation of an UVKZGPoly here
+    UVKZGPCS::commit(&pp.commit_pp, &UVKZGPoly::new(poly.Z.clone())).map(|c| c.into())
+  }
+
+  /// Generate a commitment for a list of polynomials
+  pub fn batch_commit(
+    prover_param: impl Borrow<ZMProverKey<E>>,
+    polys: &[MultilinearPolynomial<E::Fr>],
+  ) -> Result<Vec<ZMCommitment<E>>, NovaError> {
+    let prover_param = prover_param.borrow();
+
+    polys
+      .into_par_iter()
+      .map(|poly| Self::commit(prover_param, poly))
+      .collect::<Result<Vec<ZMCommitment<E>>, NovaError>>()
+  }
+
+  /// On input a polynomial `poly` and a point `point`, outputs a proof for the
+  /// same.
+  pub fn open(
+    pp: &impl Borrow<ZMProverKey<E>>,
+    poly: &MultilinearPolynomial<E::Fr>,
+    comm: &ZMCommitment<E>,
+    point: &[E::Fr],
+    transcript: &mut impl TranscriptEngineTrait<E::G1>,
+  ) -> Result<(ZMProof<E>, ZMEvaluation<E>), NovaError> {
+    let num_vars = poly.get_num_vars();
+    let pp = pp.borrow();
+    if pp.commit_pp.powers_of_g.len() < poly.Z.len() {
+      return Err(NovaError::InvalidIPA); // TODO: better error
+    }
+
+    debug_assert_eq!(Self::commit(pp, poly).unwrap().0, comm.0);
+    let eval = poly.evaluate(point);
+
+    let (quotients, remainder) = poly.quotients(point);
+    debug_assert_eq!(remainder, eval);
+    // TODO: this should be a Cow
+    let quotients_polys = quotients
+      .iter()
+      .map(|q| UVKZGPoly::new(q.clone()))
+      .collect::<Vec<_>>();
+
+    let q_comms = quotients_polys
+      .iter()
+      .map(|q| UVKZGPCS::commit(&pp.commit_pp, q))
+      .collect::<Result<Vec<_>, _>>()?;
+    q_comms.iter().for_each(|c| transcript.absorb(b"quo", c));
+
+    let y = transcript.squeeze(b"y")?;
+
+    let powers_of_y = (0..num_vars)
+      .scan(y, |acc, _| {
+        let val = *acc;
+        *acc *= y;
+        Some(val)
+      })
+      .collect::<Vec<E::Fr>>();
+
+    let q_hat = {
+      let q_hat = powers_of_y.iter().zip(&quotients).enumerate().fold(
+        vec![E::Fr::ZERO; 1 << num_vars],
+        |mut q_hat, (idx, (power_of_y, q))| {
+          let offset = q_hat.len() - (1 << idx);
+          q_hat[offset..]
+            .par_iter_mut()
+            .zip(q)
+            .for_each(|(q_hat, q)| {
+              *q_hat = *q_hat + *power_of_y * *q;
+            });
+          q_hat
+        },
+      );
+      UVKZGPoly::new(q_hat)
+    };
+    let q_hat_comm = UVKZGPCS::commit(&pp.commit_pp, &q_hat)?;
+    transcript.absorb(b"q_hat", &q_hat_comm);
+
+    let x = transcript.squeeze(b"x")?;
+    let z = transcript.squeeze(b"z")?;
+
+    let (eval_scalar, q_scalars) = eval_and_quotient_scalars(y, x, z, point);
+
+    let mut f = UVKZGPoly::new(poly.Z.clone());
+    f *= &z;
+    f += &q_hat;
+    f[0] += eval_scalar * eval;
+    quotients_polys
+      .into_iter()
+      .zip(q_scalars)
+      .for_each(|(mut q, scalar)| {
+        q *= &scalar;
+        f += &q;
+      });
+
+    UVKZGPCS::<E>::open(&pp.open_pp, &f, &x).map(|(proof, eval)| (proof.into(), eval.into()))
+  }
+
+
+
+}
+
+
+
+
+// TODO : move this somewhere else
+fn eval_and_quotient_scalars<F: Field>(y: F, x: F, z: F, u: &[F]) -> (F, Vec<F>) {
+  let num_vars = u.len();
+
+  let squares_of_x = iter::successors(Some(x), |&x| Some(x.square()))
+    .take(num_vars)
+    .collect::<Vec<_>>();
+  let offsets_of_x = {
+    let mut offsets_of_x = squares_of_x
+      .iter()
+      .rev()
+      .skip(1)
+      .scan(F::ONE, |state, power_of_x| {
+        *state *= power_of_x;
+        Some(*state)
+      })
+      .collect::<Vec<_>>();
+    offsets_of_x.reverse();
+    offsets_of_x
+  };
+  let vs = {
+    let v_numer = squares_of_x[num_vars] - F::ONE;
+    let mut v_denoms = squares_of_x
+      .iter()
+      .map(|square_of_x| *square_of_x - F::ONE)
+      .collect::<Vec<_>>();
+    v_denoms.iter_mut().batch_invert();
+    v_denoms
+      .iter()
+      .map(|v_denom| v_numer * v_denom)
+      .collect::<Vec<_>>()
+  };
+  let q_scalars = iter::successors(Some(y), |acc| Some(*acc * y))
+    .zip(offsets_of_x)
+    .zip(squares_of_x)
+    .zip(&vs)
+    .zip(&vs[1..])
+    .zip(u)
+    .map(
+      |(((((power_of_y, offset_of_x), square_of_x), v_i), v_j), u_i)| {
+        -(power_of_y * offset_of_x + z * (square_of_x * v_j - *u_i * v_i))
+      },
+    )
+    .collect::<Vec<_>>();
+
+  (-vs[0] * z, q_scalars)
+}

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -167,8 +167,10 @@ where
     debug_assert_eq!(Self::commit(pp, poly).unwrap().0, comm.0);
     let eval = poly.evaluate(point);
 
-    let (quotients, remainder) = poly.quotients(point);
-    debug_assert_eq!(remainder, eval);
+    let (quotients, _remainder) = poly.quotients(point);
+    // TODO: see test_quo below
+    // debug_assert_eq!(remainder, eval);
+
     // TODO: this should be a Cow
     let quotients_polys = quotients
       .iter()
@@ -386,6 +388,7 @@ mod test {
     commit_open_verify_with::<Bn256>();
   }
 
+  #[ignore]
   #[test]
   fn test_quo() {
     let num_vars = 10;
@@ -404,6 +407,9 @@ mod test {
       println!("scalar: {:?}", scalar);
     }
     let (_quotients, remainder) = poly.quotients(&point);
+    // TODO: the evaluation this is meant to compare to is that of the underlying univ. poly, see Lemma 2.3.1
+    // whith is not what poly.evaluate(point) returns.
+    // debug_assert_eq!(remainder, eval);
     assert_eq!(
       poly.evaluate(&point),
       remainder,

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -1,0 +1,2 @@
+//! Non-hiding Zeromorph scheme for Multilinear Polynomials.
+//! 

--- a/src/provider/zeromorph.rs
+++ b/src/provider/zeromorph.rs
@@ -1,0 +1,130 @@
+// ZeroMorph
+
+use halo2curves::bn256::{
+    G1, G1Affine, G2, Fr,
+};
+use std::ops::{Mul};
+use ff::Field;
+use crate::provider::kzg::KZGParams;
+use crate::provider::kzg::KZGScheme;
+
+#[derive(Clone)]
+pub struct ZeroMorphParams {
+    pub nmax: u64,
+    pub gen1: G1,
+    pub gen2: G2,
+    pub powers_of_tau: Vec<G1Affine>,
+    pub xi1: G1,
+    pub xi2: G2,
+    pub tau2: G2,
+    pub kzg: KZGParams,
+}
+
+#[derive(Clone)]
+pub struct ZeroMorphProof {
+    pub pi: G1,
+    pub delta: G1,
+}
+
+
+pub trait ZeroMorphScheme {
+    fn setup(nmax: u64) -> Self;
+    fn commit(&self, p: &[Fr]) -> (G1, Fr);
+    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
+    fn eval(&self, q: &[Fr]) -> G1;
+    fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof;
+    fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool;
+}
+
+
+impl ZeroMorphScheme for ZeroMorphParams {
+
+    fn setup(nmax: u64) -> ZeroMorphParams {
+
+        let kzg = KZGParams::setup(nmax);
+
+        // FIXME: avoid repeated code
+        let rng = &mut rand::thread_rng();
+        let tau = Fr::random(rng);
+        let rng = &mut rand::thread_rng();
+        let xi = Fr::random(rng);
+
+        let gen1: G1 = G1::generator();
+        let gen2: G2 = G2::generator();
+        let mut powers = Vec::new();
+        let mut xi1 = gen1;
+        let mut xi2 = gen2;
+        let mut tau2 = gen2;
+
+        for i in 0..nmax {
+            let gtau = gen1;
+            let result = gtau.mul(tau.pow([i as u64]));
+            powers.push(result.into());
+            xi1 = gen1.mul(xi);
+            xi2 = gen2.mul(xi);
+            tau2 = gen2.mul(tau);
+        }
+        ZeroMorphParams{
+            nmax,
+            gen2: gen2.into(),
+            gen1: gen1.into(),
+            powers_of_tau: powers,
+            xi1,
+            xi2,
+            tau2,
+            kzg,
+        }
+    }
+
+    /// Commit to univariate polynomial p given in coefficient representation
+    fn commit(&self, p: &[Fr]) -> (G1, Fr) {
+        self.kzg.commit(p)
+    }
+
+    /// Open the KZG commitment
+    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
+        self.kzg.open(C, r, p)
+    }
+
+    /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
+    fn eval(&self, q: &[Fr]) -> G1 {
+        self.kzg.eval(q)
+    }
+
+    #[allow(unused_variables)]
+    /// Prove evaluation of f at point u is equal to v.
+    fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof {
+        todo!()
+    }
+
+    #[allow(unused_variables)]
+    /// Verify proof that polynomial in commitment C evals to v at point u.
+    fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool {
+        todo!()
+    }
+
+}
+
+#[test]
+fn test_zm_open(){
+    let zm = ZeroMorphParams::setup(3);
+    let p = [Fr::from(0), Fr::from(0), Fr::from(1)];
+    let (C, r) = zm.commit(&p);
+    assert!(zm.open(C, r, &p));
+}
+
+
+#[test]
+fn test_zm_simple(){
+    let zm = ZeroMorphParams::setup(3);
+    let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is X_1
+    let (C, r) = zm.commit(&p);
+    let v = Fr::from(1);
+    let u0 = Fr::from(0);
+    let u1 = Fr::from(1);
+    // X1 - 1 = (X1 - 1).1, we have q=1
+    let proof = zm.proveEval(&p, v, &[u0, u1], r);
+    let b = zm.verifyEval(C, v, &[u0, u1], proof.clone());
+    assert!(b);
+}
+

--- a/src/provider/zeromorph.rs
+++ b/src/provider/zeromorph.rs
@@ -1,130 +1,121 @@
 // ZeroMorph
 
-use halo2curves::bn256::{
-    G1, G1Affine, G2, Fr,
-};
-use std::ops::{Mul};
-use ff::Field;
 use crate::provider::kzg::KZGParams;
 use crate::provider::kzg::KZGScheme;
+use ff::Field;
+use halo2curves::bn256::{Fr, G1Affine, G1, G2};
+use std::ops::Mul;
 
 #[derive(Clone)]
 pub struct ZeroMorphParams {
-    pub nmax: u64,
-    pub gen1: G1,
-    pub gen2: G2,
-    pub powers_of_tau: Vec<G1Affine>,
-    pub xi1: G1,
-    pub xi2: G2,
-    pub tau2: G2,
-    pub kzg: KZGParams,
+  pub nmax: u64,
+  pub gen1: G1,
+  pub gen2: G2,
+  pub powers_of_tau: Vec<G1Affine>,
+  pub xi1: G1,
+  pub xi2: G2,
+  pub tau2: G2,
+  pub kzg: KZGParams,
 }
 
 #[derive(Clone)]
 pub struct ZeroMorphProof {
-    pub pi: G1,
-    pub delta: G1,
+  pub pi: G1,
+  pub delta: G1,
 }
-
 
 pub trait ZeroMorphScheme {
-    fn setup(nmax: u64) -> Self;
-    fn commit(&self, p: &[Fr]) -> (G1, Fr);
-    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
-    fn eval(&self, q: &[Fr]) -> G1;
-    fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof;
-    fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool;
+  fn setup(nmax: u64) -> Self;
+  fn commit(&self, p: &[Fr]) -> (G1, Fr);
+  fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool;
+  fn eval(&self, q: &[Fr]) -> G1;
+  fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof;
+  fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool;
 }
-
 
 impl ZeroMorphScheme for ZeroMorphParams {
+  fn setup(nmax: u64) -> ZeroMorphParams {
+    let kzg = KZGParams::setup(nmax);
 
-    fn setup(nmax: u64) -> ZeroMorphParams {
+    // FIXME: avoid repeated code
+    let rng = &mut rand::thread_rng();
+    let tau = Fr::random(rng);
+    let rng = &mut rand::thread_rng();
+    let xi = Fr::random(rng);
 
-        let kzg = KZGParams::setup(nmax);
+    let gen1: G1 = G1::generator();
+    let gen2: G2 = G2::generator();
+    let mut powers = Vec::new();
+    let mut xi1 = gen1;
+    let mut xi2 = gen2;
+    let mut tau2 = gen2;
 
-        // FIXME: avoid repeated code
-        let rng = &mut rand::thread_rng();
-        let tau = Fr::random(rng);
-        let rng = &mut rand::thread_rng();
-        let xi = Fr::random(rng);
-
-        let gen1: G1 = G1::generator();
-        let gen2: G2 = G2::generator();
-        let mut powers = Vec::new();
-        let mut xi1 = gen1;
-        let mut xi2 = gen2;
-        let mut tau2 = gen2;
-
-        for i in 0..nmax {
-            let gtau = gen1;
-            let result = gtau.mul(tau.pow([i as u64]));
-            powers.push(result.into());
-            xi1 = gen1.mul(xi);
-            xi2 = gen2.mul(xi);
-            tau2 = gen2.mul(tau);
-        }
-        ZeroMorphParams{
-            nmax,
-            gen2: gen2.into(),
-            gen1: gen1.into(),
-            powers_of_tau: powers,
-            xi1,
-            xi2,
-            tau2,
-            kzg,
-        }
+    for i in 0..nmax {
+      let gtau = gen1;
+      let result = gtau.mul(tau.pow([i as u64]));
+      powers.push(result.into());
+      xi1 = gen1.mul(xi);
+      xi2 = gen2.mul(xi);
+      tau2 = gen2.mul(tau);
     }
-
-    /// Commit to univariate polynomial p given in coefficient representation
-    fn commit(&self, p: &[Fr]) -> (G1, Fr) {
-        self.kzg.commit(p)
+    ZeroMorphParams {
+      nmax,
+      gen2: gen2.into(),
+      gen1: gen1.into(),
+      powers_of_tau: powers,
+      xi1,
+      xi2,
+      tau2,
+      kzg,
     }
+  }
 
-    /// Open the KZG commitment
-    fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
-        self.kzg.open(C, r, p)
-    }
+  /// Commit to univariate polynomial p given in coefficient representation
+  fn commit(&self, p: &[Fr]) -> (G1, Fr) {
+    self.kzg.commit(p)
+  }
 
-    /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
-    fn eval(&self, q: &[Fr]) -> G1 {
-        self.kzg.eval(q)
-    }
+  /// Open the KZG commitment
+  fn open(&self, C: G1, r: Fr, p: &[Fr]) -> bool {
+    self.kzg.open(C, r, p)
+  }
 
-    #[allow(unused_variables)]
-    /// Prove evaluation of f at point u is equal to v.
-    fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof {
-        todo!()
-    }
+  /// Use power of tau to compute evaluation of polynomial q in coefficient representation.
+  fn eval(&self, q: &[Fr]) -> G1 {
+    self.kzg.eval(q)
+  }
 
-    #[allow(unused_variables)]
-    /// Verify proof that polynomial in commitment C evals to v at point u.
-    fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool {
-        todo!()
-    }
+  #[allow(unused_variables)]
+  /// Prove evaluation of f at point u is equal to v.
+  fn proveEval(&self, f: &[Fr], v: Fr, u: &[Fr], r: Fr) -> ZeroMorphProof {
+    todo!()
+  }
 
+  #[allow(unused_variables)]
+  /// Verify proof that polynomial in commitment C evals to v at point u.
+  fn verifyEval(&self, C: G1, v: Fr, u: &[Fr], proof: ZeroMorphProof) -> bool {
+    todo!()
+  }
 }
 
 #[test]
-fn test_zm_open(){
-    let zm = ZeroMorphParams::setup(3);
-    let p = [Fr::from(0), Fr::from(0), Fr::from(1)];
-    let (C, r) = zm.commit(&p);
-    assert!(zm.open(C, r, &p));
+fn test_zm_open() {
+  let zm = ZeroMorphParams::setup(3);
+  let p = [Fr::from(0), Fr::from(0), Fr::from(1)];
+  let (C, r) = zm.commit(&p);
+  assert!(zm.open(C, r, &p));
 }
-
 
 #[test]
-fn test_zm_simple(){
-    let zm = ZeroMorphParams::setup(3);
-    let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is X_1
-    let (C, r) = zm.commit(&p);
-    let v = Fr::from(1);
-    let u0 = Fr::from(0);
-    let u1 = Fr::from(1);
-    // X1 - 1 = (X1 - 1).1, we have q=1
-    let proof = zm.proveEval(&p, v, &[u0, u1], r);
-    let b = zm.verifyEval(C, v, &[u0, u1], proof.clone());
-    assert!(b);
+fn test_zm_simple() {
+  let zm = ZeroMorphParams::setup(3);
+  let p = [Fr::from(0), Fr::from(0), Fr::from(1)]; // this is X_1
+  let (C, r) = zm.commit(&p);
+  let v = Fr::from(1);
+  let u0 = Fr::from(0);
+  let u1 = Fr::from(1);
+  // X1 - 1 = (X1 - 1).1, we have q=1
+  let proof = zm.proveEval(&p, v, &[u0, u1], r);
+  let b = zm.verifyEval(C, v, &[u0, u1], proof.clone());
+  assert!(b);
 }
-

--- a/src/provider/zeromorph.rs
+++ b/src/provider/zeromorph.rs
@@ -1,14 +1,13 @@
 // ZeroMorph
 
 use crate::provider::kzg::{KZGParams, KZGScheme};
-use ff::Field;
-use halo2curves::bn256::{Fr, G1Affine, G1, G2};
-use std::ops::Mul;
-use serde::{Deserialize, Serialize};
 use crate::Group;
+use ff::Field;
+use halo2curves::bn256::G2Affine;
+use halo2curves::bn256::{Fr, G1Affine, G1, G2};
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
- use halo2curves::bn256::G2Affine;
-
+use std::ops::Mul;
 
 /// Provides an implementation of a polynomial evaluation engine using ZeroMorph
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -16,25 +15,25 @@ pub struct EvaluationEngine<G: Group> {
   _p: PhantomData<G>,
 }
 
-fn phi(monomial: usize, n: u32) -> &'static [Fr] {
-    let pow2n = usize::pow(2, n);
-    let mut res = vec!(Fr::from(0); pow2n);
-    let mut i = monomial;
-    while i < pow2n {
-        res[i] = Fr::ONE;
-        i += monomial;
-    };
-    &res[..]
+#[allow(dead_code)]
+fn phi(monomial: usize, n: u32) -> Vec<Fr> {
+  let pow2n = usize::pow(2, n);
+  let mut res = Vec::with_capacity(pow2n);
+  let mut i = monomial;
+  while i < pow2n {
+    res[i] = Fr::ONE;
+    i += monomial;
+  }
+  res
 }
 
 // Univariatization
-fn un(a: &[Fr], n: usize) -> &[Fr] {
-    // For all integers x in the domain [0, 2ˆn - 1]
-    // evaluate a at x and set coefficient at position x
-    a
+#[allow(dead_code)]
+fn un(a: &[Fr], _n: usize) -> &[Fr] {
+  // For all integers x in the domain [0, 2ˆn - 1]
+  // evaluate a at x and set coefficient at position x
+  a
 }
-
-
 
 #[derive(Clone)]
 pub struct ZeroMorphParams {
@@ -65,46 +64,46 @@ pub trait ZeroMorphScheme {
 }
 
 impl ZeroMorphScheme for ZeroMorphParams {
-    fn setup(nmax: u64) -> ZeroMorphParams {
-        let kzg = KZGParams::setup(nmax);
+  fn setup(nmax: u64) -> ZeroMorphParams {
+    let kzg = KZGParams::setup(nmax);
 
-        // FIXME: avoid repeated code
-        let rng = &mut rand::thread_rng();
-        let tau = Fr::random(rng);
-        let rng = &mut rand::thread_rng();
-        let xi = Fr::random(rng);
+    // FIXME: avoid repeated code
+    let rng = &mut rand::thread_rng();
+    let tau = Fr::random(rng);
+    let rng = &mut rand::thread_rng();
+    let xi = Fr::random(rng);
 
-        let gen1: G1 = G1::generator();
-        let gen2: G2 = G2::generator();
-        let mut powers1 = Vec::new();
-        let mut powers2 = Vec::new();
-        let mut xi1 = gen1;
-        let mut xi2 = gen2;
-        let mut tau2 = gen2;
+    let gen1: G1 = G1::generator();
+    let gen2: G2 = G2::generator();
+    let mut powers1 = Vec::new();
+    let mut powers2 = Vec::new();
+    let mut xi1 = gen1;
+    let mut xi2 = gen2;
+    let mut tau2 = gen2;
 
-        for i in 0..nmax {
-            let gtau1 = gen1;
-            let gtau2 = gen2;
-            powers1.push(gtau1.mul(tau.pow([i as u64])).into());
-            powers2.push(gtau2.mul(tau.pow([i as u64])).into());
-            xi1 = gen1.mul(xi);
-            xi2 = gen2.mul(xi);
-            tau2 = gen2.mul(tau);
-        }
-        ZeroMorphParams {
-            nmax,
-            gen2: gen2.into(),
-            gen1: gen1.into(),
-            powers_of_tau1: powers1,
-            powers_of_tau2: powers2,
-            xi1,
-            xi2,
-            tau2,
-            kzg,
-        }
+    for i in 0..nmax {
+      let gtau1 = gen1;
+      let gtau2 = gen2;
+      powers1.push(gtau1.mul(tau.pow([i as u64])).into());
+      powers2.push(gtau2.mul(tau.pow([i as u64])).into());
+      xi1 = gen1.mul(xi);
+      xi2 = gen2.mul(xi);
+      tau2 = gen2.mul(tau);
     }
+    ZeroMorphParams {
+      nmax,
+      gen2: gen2.into(),
+      gen1: gen1.into(),
+      powers_of_tau1: powers1,
+      powers_of_tau2: powers2,
+      xi1,
+      xi2,
+      tau2,
+      kzg,
+    }
+  }
 
-    /// Commit to univariate polynomial p given in coefficient representation
+  /// Commit to univariate polynomial p given in coefficient representation
   fn commit(&self, p: &[Fr]) -> (G1, Fr) {
     self.kzg.commit(p)
   }

--- a/src/provider/zeromorph.rs
+++ b/src/provider/zeromorph.rs
@@ -1,17 +1,48 @@
 // ZeroMorph
 
-use crate::provider::kzg::KZGParams;
-use crate::provider::kzg::KZGScheme;
+use crate::provider::kzg::{KZGParams, KZGScheme};
 use ff::Field;
 use halo2curves::bn256::{Fr, G1Affine, G1, G2};
 use std::ops::Mul;
+use serde::{Deserialize, Serialize};
+use crate::Group;
+use std::marker::PhantomData;
+ use halo2curves::bn256::G2Affine;
+
+
+/// Provides an implementation of a polynomial evaluation engine using ZeroMorph
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EvaluationEngine<G: Group> {
+  _p: PhantomData<G>,
+}
+
+fn phi(monomial: usize, n: u32) -> &'static [Fr] {
+    let pow2n = usize::pow(2, n);
+    let mut res = vec!(Fr::from(0); pow2n);
+    let mut i = monomial;
+    while i < pow2n {
+        res[i] = Fr::ONE;
+        i += monomial;
+    };
+    &res[..]
+}
+
+// Univariatization
+fn un(a: &[Fr], n: usize) -> &[Fr] {
+    // For all integers x in the domain [0, 2ˆn - 1]
+    // evaluate a at x and set coefficient at position x
+    a
+}
+
+
 
 #[derive(Clone)]
 pub struct ZeroMorphParams {
   pub nmax: u64,
   pub gen1: G1,
   pub gen2: G2,
-  pub powers_of_tau: Vec<G1Affine>,
+  pub powers_of_tau1: Vec<G1Affine>,
+  pub powers_of_tau2: Vec<G2Affine>,
   pub xi1: G1,
   pub xi2: G2,
   pub tau2: G2,
@@ -34,43 +65,46 @@ pub trait ZeroMorphScheme {
 }
 
 impl ZeroMorphScheme for ZeroMorphParams {
-  fn setup(nmax: u64) -> ZeroMorphParams {
-    let kzg = KZGParams::setup(nmax);
+    fn setup(nmax: u64) -> ZeroMorphParams {
+        let kzg = KZGParams::setup(nmax);
 
-    // FIXME: avoid repeated code
-    let rng = &mut rand::thread_rng();
-    let tau = Fr::random(rng);
-    let rng = &mut rand::thread_rng();
-    let xi = Fr::random(rng);
+        // FIXME: avoid repeated code
+        let rng = &mut rand::thread_rng();
+        let tau = Fr::random(rng);
+        let rng = &mut rand::thread_rng();
+        let xi = Fr::random(rng);
 
-    let gen1: G1 = G1::generator();
-    let gen2: G2 = G2::generator();
-    let mut powers = Vec::new();
-    let mut xi1 = gen1;
-    let mut xi2 = gen2;
-    let mut tau2 = gen2;
+        let gen1: G1 = G1::generator();
+        let gen2: G2 = G2::generator();
+        let mut powers1 = Vec::new();
+        let mut powers2 = Vec::new();
+        let mut xi1 = gen1;
+        let mut xi2 = gen2;
+        let mut tau2 = gen2;
 
-    for i in 0..nmax {
-      let gtau = gen1;
-      let result = gtau.mul(tau.pow([i as u64]));
-      powers.push(result.into());
-      xi1 = gen1.mul(xi);
-      xi2 = gen2.mul(xi);
-      tau2 = gen2.mul(tau);
+        for i in 0..nmax {
+            let gtau1 = gen1;
+            let gtau2 = gen2;
+            powers1.push(gtau1.mul(tau.pow([i as u64])).into());
+            powers2.push(gtau2.mul(tau.pow([i as u64])).into());
+            xi1 = gen1.mul(xi);
+            xi2 = gen2.mul(xi);
+            tau2 = gen2.mul(tau);
+        }
+        ZeroMorphParams {
+            nmax,
+            gen2: gen2.into(),
+            gen1: gen1.into(),
+            powers_of_tau1: powers1,
+            powers_of_tau2: powers2,
+            xi1,
+            xi2,
+            tau2,
+            kzg,
+        }
     }
-    ZeroMorphParams {
-      nmax,
-      gen2: gen2.into(),
-      gen1: gen1.into(),
-      powers_of_tau: powers,
-      xi1,
-      xi2,
-      tau2,
-      kzg,
-    }
-  }
 
-  /// Commit to univariate polynomial p given in coefficient representation
+    /// Commit to univariate polynomial p given in coefficient representation
   fn commit(&self, p: &[Fr]) -> (G1, Fr) {
     self.kzg.commit(p)
   }

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod math;
 pub mod polynomial;
 pub mod ppsnark;
 pub mod snark;
-mod sumcheck;
+pub(crate) mod sumcheck;
 
 use crate::{traits::Group, Commitment};
 use ff::Field;

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -6,6 +6,7 @@
 //! - `SparsePolynomial`: Efficient representation of sparse multilinear polynomials, storing only non-zero evaluations.
 use core::ops::Index;
 use ff::PrimeField;
+use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
@@ -125,6 +126,16 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   /// This method returns true if the polynomial has no evaluations, and false otherwise.
   pub fn is_empty(&self) -> bool {
     self.Z.is_empty()
+  }
+
+  /// Returns a random polynomial
+  ///
+  pub fn random<R: RngCore + CryptoRng>(num_vars: usize, mut rng: &mut R) -> Self {
+    MultilinearPolynomial::new(
+      std::iter::from_fn(|| Some(Scalar::random(&mut rng)))
+        .take(1 << num_vars)
+        .collect(),
+    )
   }
 
   /// Bounds the polynomial's top variable using the given scalar.

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -302,9 +302,9 @@ impl<G: Group> SumcheckProof<G> {
 
 // ax^2 + bx + c stored as vec![a,b,c]
 // ax^3 + bx^2 + cx + d stored as vec![a,b,c,d]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UniPoly<Scalar: PrimeField> {
-  coeffs: Vec<Scalar>,
+  pub coeffs: Vec<Scalar>,
 }
 
 // ax^2 + bx + c stored as vec![a,c]
@@ -315,6 +315,26 @@ pub struct CompressedUniPoly<Scalar: PrimeField> {
 }
 
 impl<Scalar: PrimeField> UniPoly<Scalar> {
+  pub fn new(coeffs: Vec<Scalar>) -> Self {
+    let mut res = UniPoly { coeffs };
+    res.truncate_leading_zeros();
+    res
+  }
+
+  pub fn is_zero(&self) -> bool {
+    self.coeffs.is_empty() || self.coeffs.iter().all(|c| c == &Scalar::ZERO)
+  }
+
+  fn truncate_leading_zeros(&mut self) {
+    while self.coeffs.last().map_or(false, |c| c == &Scalar::ZERO) {
+      self.coeffs.pop();
+    }
+  }
+
+  pub fn leading_coefficient(&self) -> Option<&Scalar> {
+    self.coeffs.last()
+  }
+
   pub fn from_evals(evals: &[Scalar]) -> Self {
     // we only support degree-2 or degree-3 univariate polynomials
     assert!(evals.len() == 3 || evals.len() == 4);

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -460,7 +460,7 @@ impl<Scalar: PrimeField> AddAssign<&Self> for UniPoly<Scalar> {
     for (lhs, rhs) in self.coeffs.iter_mut().zip(&rhs.coeffs) {
       *lhs += rhs;
     }
-    if matches!(ordering, Ordering::Greater) || matches!(ordering, Ordering::Equal) {
+    if matches!(ordering, Ordering::Less) {
       self
         .coeffs
         .extend(rhs.coeffs[self.coeffs.len()..].iter().cloned());


### PR DESCRIPTION
Include auxiliar commitments into `ZMProof` and adjust verifier to compute the same `x, y, z` as in the prover. 

Added an assert to ensure random oracles are synced. 