### PR TITLE
clean up secondary circuit

### DIFF
--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -94,7 +94,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         RecursiveSNARK::iter_base_step(
           &running_claim1,
           digest,
-          program_counter,
+          Some(program_counter),
           0,
           1,
           &z0_primary,
@@ -216,7 +216,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
         RecursiveSNARK::iter_base_step(
           &running_claim1,
           digest,
-          program_counter,
+          Some(program_counter),
           0,
           2,
           &z0_primary,
@@ -315,9 +315,9 @@ where
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
-    pc: &AllocatedNum<F>,
+    pc: Option<&AllocatedNum<F>>,
     z: &[AllocatedNum<F>],
-  ) -> Result<(AllocatedNum<F>, Vec<AllocatedNum<F>>), SynthesisError> {
+  ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
     // Consider a an equation: `x^2 = y`, where `x` and `y` are respectively the input and output.
     let mut x = z[0].clone();
     let mut y = x.clone();
@@ -325,6 +325,6 @@ where
       y = x.square(cs.namespace(|| format!("x_sq_{i}")))?;
       x = y.clone();
     }
-    Ok((pc.clone(), vec![y]))
+    Ok((pc.cloned(), vec![y]))
   }
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -103,7 +103,7 @@ where
       cs.namespace(|| "circuit_index"),
       F::from(self.circuit_index as u64),
     )?;
-    let pc = pc.unwrap();
+    let pc = pc.expect("primary circuit requires program counter");
     constrain_augmented_circuit_index(
       cs.namespace(|| "CubicCircuit agumented circuit constraint"),
       pc,
@@ -187,7 +187,7 @@ where
       cs.namespace(|| "circuit_index"),
       F::from(self.circuit_index as u64),
     )?;
-    let pc = pc.unwrap();
+    let pc = pc.expect("primary circuit requires program counter");
     constrain_augmented_circuit_index(
       cs.namespace(|| "SquareCircuit agumented circuit constraint"),
       pc,


### PR DESCRIPTION
This PR tries to tease apart usages of the supernova `TrivialTestCircuit`:
- create a new `TrivialSecondaryCircuit` for use in NIVC generally.
- leave the existing test circuit, but remove references to ROM.
- modify uses of program counter on the secondary circuit from the NIVC mechanism, so secondary circuits are not required to provide it
- add some initial support for `CircuitSet` type to formalize what an NIVC user will need to provide

I think it may be possible (and if so, probably desirable) to just use a normal trivial `StepCircuit` (not supernova) for the secondary circuit. However, trying to do this maximally led me into problems I could not debug. Hopefully as the implementation undergoes ongoing crypto review and refactoring/extension it will become clear which parts of the initial scaffolding can be pared back.