### PR TITLE
Refactor to use NonUniformCircuit.

### DIFF
--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -324,7 +324,7 @@ where
     match circuit_index {
       0 => TestRomCircuit::Cubic(CubicCircuit::new(circuit_index, self.rom.len())),
       1 => TestRomCircuit::Square(SquareCircuit::new(circuit_index, self.rom.len())),
-      _ => unimplemented!(),
+      _ => panic!("unsupported primary circuit index"),
     }
   }
 


### PR DESCRIPTION
This PR defines a `NonUniformCircuit` trait which manages most of the complexity of driving NIVC. Applications can provide an implementation of this trait then create proofs as shown in the existing (now refactored) test.