### PR TITLE
Add a `digest` field to `R1CSShape`

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -8,6 +8,7 @@
 
 use crate::{
   constants::{NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS},
+  digest::SimpleDigestible,
   gadgets::{
     ecc::AllocatedPoint,
     r1cs::{AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance},
@@ -37,6 +38,8 @@ pub struct NovaAugmentedCircuitParams {
   n_limbs: usize,
   is_primary_circuit: bool, // A boolean indicating if this is the primary circuit
 }
+
+impl SimpleDigestible for NovaAugmentedCircuitParams {}
 
 impl NovaAugmentedCircuitParams {
   pub const fn new(limb_width: usize, n_limbs: usize, is_primary_circuit: bool) -> Self {

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,3 +1,4 @@
+//! This module provides a unified interface for working with digests of this libraries data.
 use digest::{typenum::Unsigned, OutputSizeUser};
 use ff::PrimeField;
 use serde::Serialize;
@@ -70,7 +71,8 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
     Sha3_256::new()
   }
 
-  fn map_to_field(digest: &mut [u8]) -> F {
+  /// Hash an arbitrary amount of bytes to a field element
+  pub fn map_to_field(digest: &mut [u8]) -> F {
     let bv = (0..NUM_HASH_BITS).map(|i| {
       let (byte_pos, bit_pos) = (i / 8, i % 8);
       let bit = (digest[byte_pos] >> bit_pos) & 1;
@@ -102,6 +104,7 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
   }
 }
 
+impl SimpleDigestible for bool {}
 impl SimpleDigestible for usize {}
 impl<T> SimpleDigestible for PhantomData<T> {}
 impl<T: Serialize> SimpleDigestible for Vec<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,6 +1002,64 @@ mod tests {
     }
   }
 
+  fn test_circuit_digest_with<G1, G2, T1>(circuit: &T1, expected: &str)
+  where
+    G1: Group<Base = <G2 as Group>::Scalar>,
+    G2: Group<Base = <G1 as Group>::Scalar>,
+    T1: StepCircuit<G1::Scalar>,
+  {
+    let digest = circuit_digest::<G1, G2, _>(circuit, true);
+
+    let digest_str = digest
+      .to_repr()
+      .as_ref()
+      .iter()
+      .map(|b| format!("{b:02x}"))
+      .collect::<String>();
+    assert_eq!(digest_str, expected);
+  }
+
+  #[test]
+  fn test_circuit_digest() {
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
+    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
+    let cubic_circuit2 = CubicCircuit::<<G2 as Group>::Scalar>::default();
+
+    test_circuit_digest_with::<G1, G2, _>(
+      &cubic_circuit1,
+      "789427954a51e446fa7905c64242efba6405d06d2d5f8d044fab5473e04ca802",
+    );
+
+    test_circuit_digest_with::<G2, G1, _>(
+      &cubic_circuit2,
+      "4962a68550cd0a387c594152684d71008648f51a7407a1708a31becd797d9303",
+    );
+
+    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
+    let cubic_circuit2_grumpkin = CubicCircuit::<<grumpkin::Point as Group>::Scalar>::default();
+
+    test_circuit_digest_with::<bn256::Point, grumpkin::Point, _>(
+      &cubic_circuit1_grumpkin,
+      "158c106e5cd7156050fbd585c4d624daa92288b72b979ca296ac1865dc8eae03",
+    );
+    test_circuit_digest_with::<grumpkin::Point, bn256::Point, _>(
+      &cubic_circuit2_grumpkin,
+      "8d30e95b9decf300b9eaaf9304088bce5a04af3d952cedc81a7735fc049f8203",
+    );
+
+    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as Group>::Scalar>::default();
+    let cubic_circuit2_secp = CubicCircuit::<<secq256k1::Point as Group>::Scalar>::default();
+    test_circuit_digest_with::<secp256k1::Point, secq256k1::Point, _>(
+      &cubic_circuit1_secp,
+      "0442eeb939c179f7d7cc83af96af742ab1a3bcf85d2633f2a0ef2547105a5602",
+    );
+    test_circuit_digest_with::<secq256k1::Point, secp256k1::Point, _>(
+      &cubic_circuit2_secp,
+      "f4911e3149c51ed48440dc93996cdb111c33750d319a6f297e740cef1afa2700",
+    );
+  }
+
   fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
@@ -1039,13 +1097,13 @@ mod tests {
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "39a4ea9dd384346fdeb6b5857c7be56fa035153b616d55311f3191dfbceea603",
+      "cc9b8776b7b04ba04daa6c5dc064384686a700921d4411d2a806261b41d01102",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "3f7b25f589f2da5ab26254beba98faa54f6442ebf5fa5860caf7b08b576cab00",
+      "0cc25f7bedbb01a3d092f004f721c0536754cfffda4d5c125d3aaffec3af9b03",
     );
 
     let trivial_circuit1_grumpkin =
@@ -1057,12 +1115,12 @@ mod tests {
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "967acca1d6b4731cd65d4072c12bbaca9648f24d7bcc2877aee720e4265d4302",
+      "1c1f7e860dcb0ce9501cd86dbfbfcaa4aa6cfa1ff55421e9f5e2c668224f8c03",
     );
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "44629f26a78bf6c4e3077f940232050d1793d304fdba5e221d0cf66f76a37903",
+      "b526eae3c3c5d353f99d1b4e097048b3114dcbdbdceb030cbae20de7aafd8b01",
     );
 
     let trivial_circuit1_secp =
@@ -1074,12 +1132,12 @@ mod tests {
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "b99760668a42354643e17b2f0a2d54f173d237eb213e7e758b20a88b4c653c01",
+      "cad89d8bff945f01d8290392271c34dc70873069c1a9fde4a9d4e4b643b27600",
     );
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "68db620e610a3cd75146a1e1bdd168f486b82c0b670277ad1e3d50441c501502",
+      "8b4868bba4c3ce10a645ac13cf9c3ad43f9fa9c8356c9b8fa8760db9c79b0703",
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 mod bellpepper;
 mod circuit;
 mod constants;
-mod digest;
 mod nifs;
 
 // public modules
+pub mod digest;
 pub mod errors;
 pub mod gadgets;
 pub mod provider;

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -1,4 +1,5 @@
 //! This module implements the Nova traits for `bn256::Point`, `bn256::Scalar`, `grumpkin::Point`, `grumpkin::Scalar`.
+use crate::digest::SimpleDigestible;
 use crate::{
   impl_traits,
   provider::{

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -274,5 +274,7 @@ macro_rules! impl_traits {
         Some($name_curve::from_bytes(&self).unwrap())
       }
     }
+
+    impl SimpleDigestible for $name::Scalar {}
   };
 }

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -1,5 +1,6 @@
 //! This module implements the Nova traits for `pallas::Point`, `pallas::Scalar`, `vesta::Point`, `vesta::Scalar`.
 use crate::{
+  digest::SimpleDigestible,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,
@@ -188,6 +189,8 @@ macro_rules! impl_traits {
         Some($name_curve::from_bytes(&self.repr).unwrap())
       }
     }
+
+    impl SimpleDigestible for $name::Scalar {}
   };
 }
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -1,5 +1,6 @@
 //! This module provides an implementation of a commitment engine
 use crate::{
+  digest::SimpleDigestible,
   errors::NovaError,
   traits::{
     commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
@@ -23,6 +24,8 @@ pub struct CommitmentKey<G: Group> {
   #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
   ck: Vec<G::PreprocessedGroupElement>,
 }
+
+impl<G: Group> SimpleDigestible for CommitmentKey<G> {}
 
 impl<G: Group> Len for CommitmentKey<G> {
   fn length(&self) -> usize {

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -1,5 +1,8 @@
 //! Poseidon Constants and Poseidon-based RO used in Nova
-use crate::traits::{ROCircuitTrait, ROTrait};
+use crate::{
+  digest::SimpleDigestible,
+  traits::{ROCircuitTrait, ROTrait},
+};
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use bellpepper_core::{
@@ -26,6 +29,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 #[abomonation_bounds(where Scalar::Repr: Abomonation)]
 pub struct PoseidonConstantsCircuit<Scalar: PrimeField>(PoseidonConstants<Scalar, U24>);
+
+impl<Scalar: PrimeField + Serialize> SimpleDigestible for PoseidonConstantsCircuit<Scalar> {}
 
 impl<Scalar: PrimeField> Default for PoseidonConstantsCircuit<Scalar> {
   /// Generate Poseidon constants

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,4 +1,5 @@
 //! This module implements the Nova traits for secp::Point, secp::Scalar, secq::Point, secq::Scalar.
+use crate::digest::SimpleDigestible;
 use crate::{
   impl_traits,
   provider::{

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -131,6 +131,7 @@ pub fn commitment_key_size<G: Group>(
 }
 
 impl<G: Group> DigestBuilder<G::Scalar, R1CSShape<G>> {
+  /// Set up builder to create `R1CSShape` from a triple `A`, `B`, `C`
   pub fn setup(
     num_cons: usize,
     num_vars: usize,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -238,11 +238,21 @@ where
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error> {
+  fn write_digestable_bytes<W: Sized + io::Write>(
+    &self,
+    byte_sink: &mut W,
+  ) -> Result<(), io::Error> {
+    self.digest.write_digestable_bytes(byte_sink)
+  }
+
+  fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {
+    let mut byte_sink = vec![];
     for claim in &self.claims {
-      claim.get_public_params().write_bytes(byte_sink)?;
+      claim
+        .get_public_params()
+        .write_digestable_bytes(&mut byte_sink)?;
     }
-    Ok(())
+    Ok(byte_sink)
   }
 }
 

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -1,6 +1,7 @@
 //! This module defines a collection of traits that define the behavior of a commitment engine
 //! We require the commitment engine to provide a commitment to vectors with a single group element
 use crate::{
+  digest::Digestible,
   errors::NovaError,
   traits::{AbsorbInROTrait, Group, TranscriptReprTrait},
 };
@@ -93,7 +94,8 @@ pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
     + Sync
     + Serialize
     + for<'de> Deserialize<'de>
-    + Abomonation;
+    + Abomonation
+    + Digestible;
 
   /// Holds the type of the commitment
   type Commitment: CommitmentTrait<G>;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,5 +1,5 @@
 //! This module defines various traits required by the users of the library to implement.
-use crate::errors::NovaError;
+use crate::{digest::Digestible, errors::NovaError};
 use abomonation::Abomonation;
 use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::{
@@ -40,7 +40,8 @@ pub trait Group:
     + Sync
     + TranscriptReprTrait<Self>
     + Serialize
-    + for<'de> Deserialize<'de>;
+    + for<'de> Deserialize<'de>
+    + Digestible;
 
   /// A type representing the compressed version of the group element
   type CompressedGroupElement: CompressedGroup<GroupElement = Self>;
@@ -134,7 +135,8 @@ pub trait ROTrait<Base: PrimeField, Scalar> {
     + Sync
     + Serialize
     + for<'de> Deserialize<'de>
-    + Abomonation;
+    + Abomonation
+    + Digestible;
 
   /// Initializes the hash function
   fn new(constants: Self::Constants, num_absorbs: usize) -> Self;
@@ -159,7 +161,8 @@ pub trait ROCircuitTrait<Base: PrimeField> {
     + Sync
     + Serialize
     + for<'de> Deserialize<'de>
-    + Abomonation;
+    + Abomonation
+    + Digestible;
 
   /// Initializes the hash function
   fn new(constants: Self::Constants, num_absorbs: usize) -> Self;


### PR DESCRIPTION
Resolves #31 and https://github.com/lurk-lab/lurk-rs/pull/648 downstream.

This PR adds a small mechanism to distinguish circuits via a digest. This is essentially the same as what is done for `PublicParams.digest`. Downstream in `lurk-rs`, the digest is needed to quickly determine if a set of public params matches the given circuits. Note that the cost of `circuit_digest` is somewhat small compared to fully generating params, but it remains to be benchmarked. If the cost is too high, maybe something more clever will be needed.