### PR TITLE
Standardize `tracing` crate + implement micro-benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,10 @@ cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
+# This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
+[patch.crates-io]
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch = "dev" }
+
 [profile.dev-ci]
 inherits = "dev"
 # By compiling dependencies with optimizations, performing tests gets much faster.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ rayon = "1.7"
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
 subtle = "2.5"
-pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev", features = ["repr-c", "serde"] }
-neptune = { git="https://github.com/lurk-lab/neptune", branch="dev", default-features = false }
+pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch="dev", features = ["repr-c", "serde"] }
+neptune = { git = "https://github.com/lurk-lab/neptune", branch="dev", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
@@ -34,10 +34,12 @@ byteorder = "1.4.3"
 thiserror = "1.0"
 halo2curves = { version = "0.4.0", features = ["derive_serde"] }
 group = "0.13.0"
-log = "0.4.17"
 abomonation = "0.7.3"
 abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git" }
 tap = "1.0.1"
+tracing = "0.1.37"
+tracing-texray = "0.2.0"
+tracing-subscriber = "0.3.17"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }
@@ -83,10 +85,6 @@ portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
-
-# This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
-[patch.crates-io]
-pasta_curves = { git="https://github.com/lurk-lab/pasta_curves", branch="dev" }
 
 [profile.dev-ci]
 inherits = "dev"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,18 +413,18 @@ where
       pp.ro_consts_circuit_primary.clone(),
     );
 
-    tracing::event!(Level::INFO, "synthesize primary");
+    tracing::info_span!("> synthesize primary").in_scope(|| {});
     let zi_primary = circuit_primary
       .synthesize(&mut cs_primary)
       .map_err(|_| NovaError::SynthesisError)?;
 
-    tracing::event!(Level::INFO, "r1cs_instance_and_witness primary");
+    tracing::info_span!("> r1cs_instance_and_witness primary").in_scope(|| {});
     let (l_u_primary, l_w_primary) = cs_primary
       .r1cs_instance_and_witness(&pp.r1cs_shape_primary, &pp.ck_primary)
       .map_err(|_e| NovaError::UnSat)
       .expect("Nova error unsat");
 
-    tracing::event!(Level::INFO, "NIFS::prove primary");
+    tracing::info_span!("> NIFS::prove primary").in_scope(|| {});
     // fold the primary circuit's instance
     let (nifs_primary, (r_U_primary, r_W_primary)) = NIFS::prove(
       &pp.ck_primary,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,7 @@ where
 
   /// Create a new `RecursiveSNARK` (or updates the provided `RecursiveSNARK`)
   /// by executing a step of the incremental computation
+  #[tracing::instrument(skip_all, name = "RecursiveSNARK::prove_step")]
   pub fn prove_step(
     &mut self,
     pp: &PublicParams<G1, G2, C1, C2>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ use abomonation_derive::Abomonation;
 use bellpepper_core::ConstraintSystem;
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};
-use tracing::Level;
 use core::marker::PhantomData;
 use errors::NovaError;
 use ff::{Field, PrimeField};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,6 @@ where
       .map_err(|_e| NovaError::UnSat)
       .expect("Nova error unsat");
 
-    tracing::info_span!("> NIFS::prove primary").in_scope(|| {});
     // fold the primary circuit's instance
     let (nifs_primary, (r_U_primary, r_W_primary)) = NIFS::prove(
       &pp.ck_primary,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,12 +413,10 @@ where
       pp.ro_consts_circuit_primary.clone(),
     );
 
-    tracing::info_span!("> synthesize primary").in_scope(|| {});
     let zi_primary = circuit_primary
       .synthesize(&mut cs_primary)
       .map_err(|_| NovaError::SynthesisError)?;
 
-    tracing::info_span!("> r1cs_instance_and_witness primary").in_scope(|| {});
     let (l_u_primary, l_w_primary) = cs_primary
       .r1cs_instance_and_witness(&pp.r1cs_shape_primary, &pp.ck_primary)
       .map_err(|_e| NovaError::UnSat)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use abomonation_derive::Abomonation;
 use bellpepper_core::ConstraintSystem;
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};
+use tracing::Level;
 use core::marker::PhantomData;
 use errors::NovaError;
 use ff::{Field, PrimeField};
@@ -411,15 +412,19 @@ where
       c_primary,
       pp.ro_consts_circuit_primary.clone(),
     );
+
+    tracing::event!(Level::INFO, "synthesize primary");
     let zi_primary = circuit_primary
       .synthesize(&mut cs_primary)
       .map_err(|_| NovaError::SynthesisError)?;
 
+    tracing::event!(Level::INFO, "r1cs_instance_and_witness primary");
     let (l_u_primary, l_w_primary) = cs_primary
       .r1cs_instance_and_witness(&pp.r1cs_shape_primary, &pp.ck_primary)
       .map_err(|_e| NovaError::UnSat)
       .expect("Nova error unsat");
 
+    tracing::event!(Level::INFO, "NIFS::prove primary");
     // fold the primary circuit's instance
     let (nifs_primary, (r_U_primary, r_W_primary)) = NIFS::prove(
       &pp.ck_primary,

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -45,13 +45,16 @@ impl<G: Group> NIFS<G> {
     // initialize a new RO
     let mut ro = G::RO::new(ro_consts.clone(), NUM_FE_FOR_RO);
 
+    tracing::info_span!("> absorb").in_scope(|| {});
     // append the digest of pp to the transcript
     ro.absorb(scalar_as_base::<G>(*pp_digest));
 
+    tracing::info_span!("> absorb_in_ro").in_scope(|| {});
     // append U1 and U2 to transcript
     U1.absorb_in_ro(&mut ro);
     U2.absorb_in_ro(&mut ro);
 
+    tracing::info_span!("> commit_T").in_scope(|| {});
     // compute a commitment to the cross-term
     let (T, comm_T) = S.commit_T(ck, U1, W1, U2, W2)?;
 
@@ -61,15 +64,12 @@ impl<G: Group> NIFS<G> {
     // compute a challenge from the RO
     let r = ro.squeeze(NUM_CHALLENGE_BITS);
 
-    tracing::info_span!("> fold instance").in_scope(|| {});
     // fold the instance using `r` and `comm_T`
     let U = U1.fold(U2, &comm_T, &r)?;
 
-    tracing::info_span!("> fold witness").in_scope(|| {});
     // fold the witness using `r` and `T`
     let W = W1.fold(W2, &T, &r)?;
 
-    tracing::info_span!("> fold witness").in_scope(|| {});
     // return the folded instance and witness
     Ok((
       Self {

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -31,6 +31,7 @@ impl<G: Group> NIFS<G> {
   /// with the guarantee that the folded witness `W` satisfies the folded instance `U`
   /// if and only if `W1` satisfies `U1` and `W2` satisfies `U2`.
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all, name = "NIFS::prove")]
   pub fn prove(
     ck: &CommitmentKey<G>,
     ro_consts: &ROConstants<G>,
@@ -60,12 +61,15 @@ impl<G: Group> NIFS<G> {
     // compute a challenge from the RO
     let r = ro.squeeze(NUM_CHALLENGE_BITS);
 
+    tracing::info_span!("> fold instance").in_scope(|| {});
     // fold the instance using `r` and `comm_T`
     let U = U1.fold(U2, &comm_T, &r)?;
 
+    tracing::info_span!("> fold witness").in_scope(|| {});
     // fold the witness using `r` and `T`
     let W = W1.fold(W2, &T, &r)?;
 
+    tracing::info_span!("> fold witness").in_scope(|| {});
     // return the folded instance and witness
     Ok((
       Self {

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -45,16 +45,13 @@ impl<G: Group> NIFS<G> {
     // initialize a new RO
     let mut ro = G::RO::new(ro_consts.clone(), NUM_FE_FOR_RO);
 
-    tracing::info_span!("> absorb").in_scope(|| {});
     // append the digest of pp to the transcript
     ro.absorb(scalar_as_base::<G>(*pp_digest));
 
-    tracing::info_span!("> absorb_in_ro").in_scope(|| {});
     // append U1 and U2 to transcript
     U1.absorb_in_ro(&mut ro);
     U2.absorb_in_ro(&mut ro);
 
-    tracing::info_span!("> commit_T").in_scope(|| {});
     // compute a commitment to the cross-term
     let (T, comm_T) = S.commit_T(ck, U1, W1, U2, W2)?;
 

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -68,6 +68,7 @@ macro_rules! impl_traits {
       type CE = CommitmentEngine<Self>;
 
       #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+      #[tracing::instrument(skip_all, name = "<_ as Group>::vartime_multiscalar_mul")]
       fn vartime_multiscalar_mul(
         scalars: &[Self::Scalar],
         bases: &[Self::PreprocessedGroupElement],

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -285,7 +285,6 @@ impl<G: Group> R1CSShape<G> {
 
   /// A method to compute a commitment to the cross-term `T` given a
   /// Relaxed R1CS instance-witness pair and an R1CS instance-witness pair
-  #[tracing::instrument(skip_all, name = "commit_T")]
   pub fn commit_T(
     &self,
     ck: &CommitmentKey<G>,

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -285,6 +285,7 @@ impl<G: Group> R1CSShape<G> {
 
   /// A method to compute a commitment to the cross-term `T` given a
   /// Relaxed R1CS instance-witness pair and an R1CS instance-witness pair
+  #[tracing::instrument(skip_all, name = "commit_T")]
   pub fn commit_T(
     &self,
     ck: &CommitmentKey<G>,
@@ -293,16 +294,19 @@ impl<G: Group> R1CSShape<G> {
     U2: &R1CSInstance<G>,
     W2: &R1CSWitness<G>,
   ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
+    tracing::info_span!("ABC 1").in_scope(|| {});
     let (AZ_1, BZ_1, CZ_1) = {
       let Z1 = [W1.W.clone(), vec![U1.u], U1.X.clone()].concat();
       self.multiply_vec(&Z1)?
     };
 
+    tracing::info_span!("ABC 2").in_scope(|| {});
     let (AZ_2, BZ_2, CZ_2) = {
       let Z2 = [W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()].concat();
       self.multiply_vec(&Z2)?
     };
 
+    tracing::info_span!("cross terms").in_scope(|| {});
     let AZ_1_circ_BZ_2 = (0..AZ_1.len())
       .into_par_iter()
       .map(|i| AZ_1[i] * BZ_2[i])
@@ -320,6 +324,7 @@ impl<G: Group> R1CSShape<G> {
       .map(|i| CZ_1[i])
       .collect::<Vec<G::Scalar>>();
 
+    tracing::info_span!("T").in_scope(|| {});
     let T = AZ_1_circ_BZ_2
       .par_iter()
       .zip(&AZ_2_circ_BZ_1)

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -294,44 +294,47 @@ impl<G: Group> R1CSShape<G> {
     U2: &R1CSInstance<G>,
     W2: &R1CSWitness<G>,
   ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
-    tracing::info_span!("ABC 1").in_scope(|| {});
-    let (AZ_1, BZ_1, CZ_1) = {
+    let (AZ_1, BZ_1, CZ_1) = tracing::info_span!("AZ_1, BZ_1, CZ_1").in_scope(|| {
       let Z1 = [W1.W.clone(), vec![U1.u], U1.X.clone()].concat();
-      self.multiply_vec(&Z1)?
-    };
+      self.multiply_vec(&Z1)
+    })?;
 
-    tracing::info_span!("ABC 2").in_scope(|| {});
-    let (AZ_2, BZ_2, CZ_2) = {
+    let (AZ_2, BZ_2, CZ_2) = tracing::info_span!("AZ_2, BZ_2, CZ_2").in_scope(|| {
       let Z2 = [W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()].concat();
-      self.multiply_vec(&Z2)?
-    };
+      self.multiply_vec(&Z2)
+    })?;
 
-    tracing::info_span!("cross terms").in_scope(|| {});
-    let AZ_1_circ_BZ_2 = (0..AZ_1.len())
-      .into_par_iter()
-      .map(|i| AZ_1[i] * BZ_2[i])
-      .collect::<Vec<G::Scalar>>();
-    let AZ_2_circ_BZ_1 = (0..AZ_2.len())
-      .into_par_iter()
-      .map(|i| AZ_2[i] * BZ_1[i])
-      .collect::<Vec<G::Scalar>>();
-    let u_1_cdot_CZ_2 = (0..CZ_2.len())
-      .into_par_iter()
-      .map(|i| U1.u * CZ_2[i])
-      .collect::<Vec<G::Scalar>>();
-    let u_2_cdot_CZ_1 = (0..CZ_1.len())
-      .into_par_iter()
-      .map(|i| CZ_1[i])
-      .collect::<Vec<G::Scalar>>();
+    // forgive the horror here, but it's for grouping into one span
+    let (AZ_1_circ_BZ_2, AZ_2_circ_BZ_1, u_1_cdot_CZ_2, u_2_cdot_CZ_1) =
+      tracing::info_span!("cross terms").in_scope(|| {
+        let AZ_1_circ_BZ_2 = (0..AZ_1.len())
+          .into_par_iter()
+          .map(|i| AZ_1[i] * BZ_2[i])
+          .collect::<Vec<G::Scalar>>();
+        let AZ_2_circ_BZ_1 = (0..AZ_2.len())
+          .into_par_iter()
+          .map(|i| AZ_2[i] * BZ_1[i])
+          .collect::<Vec<G::Scalar>>();
+        let u_1_cdot_CZ_2 = (0..CZ_2.len())
+          .into_par_iter()
+          .map(|i| U1.u * CZ_2[i])
+          .collect::<Vec<G::Scalar>>();
+        let u_2_cdot_CZ_1 = (0..CZ_1.len())
+          .into_par_iter()
+          .map(|i| CZ_1[i])
+          .collect::<Vec<G::Scalar>>();
+        (AZ_1_circ_BZ_2, AZ_2_circ_BZ_1, u_1_cdot_CZ_2, u_2_cdot_CZ_1)
+      });
 
-    tracing::info_span!("T").in_scope(|| {});
-    let T = AZ_1_circ_BZ_2
-      .par_iter()
-      .zip(&AZ_2_circ_BZ_1)
-      .zip(&u_1_cdot_CZ_2)
-      .zip(&u_2_cdot_CZ_1)
-      .map(|(((a, b), c), d)| *a + *b - *c - *d)
-      .collect::<Vec<G::Scalar>>();
+    let T = tracing::info_span!("T").in_scope(|| {
+      AZ_1_circ_BZ_2
+        .par_iter()
+        .zip(&AZ_2_circ_BZ_1)
+        .zip(&u_1_cdot_CZ_2)
+        .zip(&u_2_cdot_CZ_1)
+        .map(|(((a, b), c), d)| *a + *b - *c - *d)
+        .collect::<Vec<G::Scalar>>()
+    });
 
     let comm_T = CE::<G>::commit(ck, &T);
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -911,6 +911,7 @@ where
   }
 
   /// produces a succinct proof of satisfiability of a `RelaxedR1CS` instance
+  #[tracing::instrument(skip_all, name = "PPSNARK::prove")]
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -99,6 +99,7 @@ where
   }
 
   /// produces a succinct proof of satisfiability of a `RelaxedR1CS` instance
+  #[tracing::instrument(skip_all, name = "SNARK::prove")]
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -20,8 +20,8 @@ use crate::{
 };
 
 use ff::Field;
-use tracing::debug;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use crate::bellpepper::{
   r1cs::{NovaShape, NovaWitness},

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 use ff::Field;
-use log::debug;
+use tracing::debug;
 use serde::{Deserialize, Serialize};
 
 use crate::bellpepper::{


### PR DESCRIPTION
This PR is the next-in-line from downstream PR from https://github.com/lurk-lab/lurk-rs/pull/627, implementing an unified tracing ecosystem. Additionally, we add the `tracing_texray` crate, with allows us to easily visualize spans and benchmarks of lurk. Texray can be enabled wherever and [tracing](https://crates.io/crates/tracing) offers a lot of flexibility; please see the documentation for more info ([tracing-texray](https://crates.io/crates/tracing-texray)).

With this, we can get nice mirco-benchmarks like this:
```
    RecursiveSNARK::prove_step                   219ms               ├────────────┤
      <MultiFrame as StepCircuit>::synthesize     38ms                ├─┤
      <_ as Group>::vartime_multiscalar_mul       50ms                  ├─┤
      NIFS::prove                                106ms                     ├─────┤
          AZ_1, BZ_1, CZ_1                        31ms                     ├┤
          AZ_2, BZ_2, CZ_2                        29ms                       ├┤
          cross terms                              5ms                         ┆
          T                                      716μs                          ┆
          <_ as Group>::vartime_multiscalar_mul   37ms                          ├┤
      <_ as Group>::vartime_multiscalar_mul        4ms                             ┆
```
Looking here suggests that we are spending a surprising amount of time computing `[A-C] Z_{1, 2}`... 🤔 