### PR TITLE
CSR Representation for Sparse Matrices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git
 tap = "1.0.1"
 tracing = "0.1.37"
 tracing-texray = "0.2.0"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+cfg-if = "1.0.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }
@@ -54,8 +55,6 @@ rand = "0.8.4"
 flate2 = "1.0"
 hex = "0.4.3"
 pprof = { version = "0.11" }
-tracing-test = "0.2.4"
-cfg-if = "1.0.0"
 sha2 = "0.10.7"
 proptest = "1.2.0"
 
@@ -86,6 +85,7 @@ portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
+csr = []
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
-csr = []
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ cfg-if = "1.0.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }
+proptest = "1.2.0"
+rand = "0.8.5"
 
 [target.wasm32-unknown-unknown.dependencies]
 # see https://github.com/rust-random/rand/pull/948
@@ -51,12 +53,10 @@ getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
-rand = "0.8.4"
 flate2 = "1.0"
 hex = "0.4.3"
 pprof = { version = "0.11" }
 sha2 = "0.10.7"
-proptest = "1.2.0"
 tracing-test = "0.2.4"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ hex = "0.4.3"
 pprof = { version = "0.11" }
 sha2 = "0.10.7"
 proptest = "1.2.0"
+tracing-test = "0.2.4"
 
 [[bench]]
 name = "recursive-snark"

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -131,7 +131,7 @@ where
   }
 }
 
-/// cargo run --release --features csr --example minroot
+/// cargo run --release --example minroot
 fn main() {
   let subscriber = Registry::default()
     .with(fmt::layer().pretty())
@@ -143,7 +143,7 @@ fn main() {
   println!("=========================================================");
 
   let num_steps = 10;
-  for num_iters_per_step in [65536] {
+  for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65536] {
     // number of iterations of MinRoot per Nova's recursive step
     let circuit_primary = MinRootCircuit {
       seq: vec![

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -15,6 +15,8 @@ use nova_snark::{
 };
 use num_bigint::BigUint;
 use std::time::Instant;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
+use tracing_texray::TeXRayLayer;
 
 #[derive(Clone, Debug)]
 struct MinRootIteration<F: PrimeField> {
@@ -129,12 +131,19 @@ where
   }
 }
 
+/// cargo run --release --features csr --examples minroot
 fn main() {
+  let subscriber = Registry::default()
+    .with(fmt::layer().pretty())
+    .with(EnvFilter::from_default_env())
+    .with(TeXRayLayer::new());
+  tracing::subscriber::set_global_default(subscriber).unwrap();
+
   println!("Nova-based VDF with MinRoot delay function");
   println!("=========================================================");
 
   let num_steps = 10;
-  for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65535] {
+  for num_iters_per_step in [65536, 524288] {
     // number of iterations of MinRoot per Nova's recursive step
     let circuit_primary = MinRootCircuit {
       seq: vec![

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -131,7 +131,7 @@ where
   }
 }
 
-/// cargo run --release --features csr --examples minroot
+/// cargo run --release --features csr --example minroot
 fn main() {
   let subscriber = Registry::default()
     .with(fmt::layer().pretty())
@@ -143,7 +143,7 @@ fn main() {
   println!("=========================================================");
 
   let num_steps = 10;
-  for num_iters_per_step in [65536, 524288] {
+  for num_iters_per_step in [65536] {
     // number of iterations of MinRoot per Nova's recursive step
     let circuit_primary = MinRootCircuit {
       seq: vec![

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -76,6 +76,7 @@ macro_rules! impl_nova_shape {
         let num_inputs = self.num_inputs();
         let num_constraints = self.num_constraints();
         let num_vars = self.num_aux();
+
         for constraint in self.constraints.iter() {
           add_constraint(
             &mut X,
@@ -86,6 +87,11 @@ macro_rules! impl_nova_shape {
           );
         }
         assert_eq!(num_cons_added, num_constraints);
+
+        A.cols = num_vars + num_inputs;
+        B.cols = num_vars + num_inputs;
+        C.cols = num_vars + num_inputs;
+
         let S: R1CSShape<G> = {
           let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C);
           res.unwrap()
@@ -125,7 +131,7 @@ where
     A.cols = num_vars + self.num_inputs();
     B.cols = num_vars + self.num_inputs();
     C.cols = num_vars + self.num_inputs();
-    
+
     let S: R1CSShape<G> = {
       let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C);
       res.unwrap()

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -92,53 +92,15 @@ macro_rules! impl_nova_shape {
         B.cols = num_vars + num_inputs;
         C.cols = num_vars + num_inputs;
 
-        let S: R1CSShape<G> = {
-          let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C);
-          res.unwrap()
-        };
-        S
+        // Don't count One as an input for shape's purposes.
+        let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C);
+        res.unwrap()
       }
     }
   };
 }
 
-impl<G: Group> NovaShape<G> for ShapeCS<G>
-where
-  G::Scalar: PrimeField,
-{
-  fn r1cs_shape(&self) -> R1CSShape<G> {
-    let mut A = SparseMatrix::<G::Scalar>::empty();
-    let mut B = SparseMatrix::<G::Scalar>::empty();
-    let mut C: SparseMatrix<<G as Group>::Scalar> = SparseMatrix::<G::Scalar>::empty();
-    let mut num_cons_added = 0;
-    let mut X = (&mut A, &mut B, &mut C, &mut num_cons_added);
-
-    let num_inputs = self.num_inputs();
-    let num_constraints = self.num_constraints();
-    let num_vars = self.num_aux();
-
-    for constraint in self.constraints.iter() {
-      add_constraint(
-        &mut X,
-        num_vars,
-        &constraint.0,
-        &constraint.1,
-        &constraint.2,
-      );
-    }
-    assert_eq!(num_cons_added, num_constraints);
-
-    A.cols = num_vars + self.num_inputs();
-    B.cols = num_vars + self.num_inputs();
-    C.cols = num_vars + self.num_inputs();
-
-    let S: R1CSShape<G> = {
-      let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C);
-      res.unwrap()
-    };
-    S
-  }
-}
+impl_nova_shape!(ShapeCS);
 impl_nova_shape!(TestShapeCS);
 
 fn add_constraint<S: PrimeField>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,64 +975,6 @@ mod tests {
     }
   }
 
-  fn test_circuit_digest_with<G1, G2, T1>(circuit: &T1, expected: &str)
-  where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
-    T1: StepCircuit<G1::Scalar>,
-  {
-    let digest = circuit_digest::<G1, G2, _>(circuit, true);
-
-    let digest_str = digest
-      .to_repr()
-      .as_ref()
-      .iter()
-      .map(|b| format!("{b:02x}"))
-      .collect::<String>();
-    assert_eq!(digest_str, expected);
-  }
-
-  #[test]
-  fn test_circuit_digest() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
-    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
-    let cubic_circuit2 = CubicCircuit::<<G2 as Group>::Scalar>::default();
-
-    test_circuit_digest_with::<G1, G2, _>(
-      &cubic_circuit1,
-      "789427954a51e446fa7905c64242efba6405d06d2d5f8d044fab5473e04ca802",
-    );
-
-    test_circuit_digest_with::<G2, G1, _>(
-      &cubic_circuit2,
-      "4962a68550cd0a387c594152684d71008648f51a7407a1708a31becd797d9303",
-    );
-
-    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
-    let cubic_circuit2_grumpkin = CubicCircuit::<<grumpkin::Point as Group>::Scalar>::default();
-
-    test_circuit_digest_with::<bn256::Point, grumpkin::Point, _>(
-      &cubic_circuit1_grumpkin,
-      "158c106e5cd7156050fbd585c4d624daa92288b72b979ca296ac1865dc8eae03",
-    );
-    test_circuit_digest_with::<grumpkin::Point, bn256::Point, _>(
-      &cubic_circuit2_grumpkin,
-      "8d30e95b9decf300b9eaaf9304088bce5a04af3d952cedc81a7735fc049f8203",
-    );
-
-    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as Group>::Scalar>::default();
-    let cubic_circuit2_secp = CubicCircuit::<<secq256k1::Point as Group>::Scalar>::default();
-    test_circuit_digest_with::<secp256k1::Point, secq256k1::Point, _>(
-      &cubic_circuit1_secp,
-      "0442eeb939c179f7d7cc83af96af742ab1a3bcf85d2633f2a0ef2547105a5602",
-    );
-    test_circuit_digest_with::<secq256k1::Point, secp256k1::Point, _>(
-      &cubic_circuit2_secp,
-      "f4911e3149c51ed48440dc93996cdb111c33750d319a6f297e740cef1afa2700",
-    );
-  }
-
   fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
@@ -1070,13 +1012,13 @@ mod tests {
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "cc9b8776b7b04ba04daa6c5dc064384686a700921d4411d2a806261b41d01102",
+      "bb3b6aedf54b8dd97e7394dd4be710334f26de96b1c224b535520fe38b1aaa00",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "0cc25f7bedbb01a3d092f004f721c0536754cfffda4d5c125d3aaffec3af9b03",
+      "e4237039efc018ae996397fbcfc0022c760b906bb05a861b55625879d5e3d901",
     );
 
     let trivial_circuit1_grumpkin =
@@ -1088,12 +1030,12 @@ mod tests {
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "1c1f7e860dcb0ce9501cd86dbfbfcaa4aa6cfa1ff55421e9f5e2c668224f8c03",
+      "5fe1690dda17560d99817d88c9e4a50ce9489c491d616eca5bcd32c337b89f00",
     );
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "b526eae3c3c5d353f99d1b4e097048b3114dcbdbdceb030cbae20de7aafd8b01",
+      "acebf64a16397db8ab3ae7a154eccf5016ec082e295a31a2e44a00c5ce8ddc00",
     );
 
     let trivial_circuit1_secp =
@@ -1105,12 +1047,12 @@ mod tests {
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "cad89d8bff945f01d8290392271c34dc70873069c1a9fde4a9d4e4b643b27600",
+      "a04d36966a03c0e302ae569fec4da6b69d503e88966e9bd886c4d9063ca03302",
     );
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "8b4868bba4c3ce10a645ac13cf9c3ad43f9fa9c8356c9b8fa8760db9c79b0703",
+      "faa3ac7971b64f60935913b3f49c585045542a814edb31c4e563a65fab0b8f00",
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,6 +975,64 @@ mod tests {
     }
   }
 
+  fn test_circuit_digest_with<G1, G2, T1>(circuit: &T1, expected: &str)
+  where
+    G1: Group<Base = <G2 as Group>::Scalar>,
+    G2: Group<Base = <G1 as Group>::Scalar>,
+    T1: StepCircuit<G1::Scalar>,
+  {
+    let digest = circuit_digest::<G1, G2, _>(circuit, true);
+
+    let digest_str = digest
+      .to_repr()
+      .as_ref()
+      .iter()
+      .map(|b| format!("{b:02x}"))
+      .collect::<String>();
+    assert_eq!(digest_str, expected);
+  }
+
+  #[test]
+  fn test_circuit_digest() {
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
+    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
+    let cubic_circuit2 = CubicCircuit::<<G2 as Group>::Scalar>::default();
+
+    test_circuit_digest_with::<G1, G2, _>(
+      &cubic_circuit1,
+      "789427954a51e446fa7905c64242efba6405d06d2d5f8d044fab5473e04ca802",
+    );
+
+    test_circuit_digest_with::<G2, G1, _>(
+      &cubic_circuit2,
+      "4962a68550cd0a387c594152684d71008648f51a7407a1708a31becd797d9303",
+    );
+
+    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
+    let cubic_circuit2_grumpkin = CubicCircuit::<<grumpkin::Point as Group>::Scalar>::default();
+
+    test_circuit_digest_with::<bn256::Point, grumpkin::Point, _>(
+      &cubic_circuit1_grumpkin,
+      "158c106e5cd7156050fbd585c4d624daa92288b72b979ca296ac1865dc8eae03",
+    );
+    test_circuit_digest_with::<grumpkin::Point, bn256::Point, _>(
+      &cubic_circuit2_grumpkin,
+      "8d30e95b9decf300b9eaaf9304088bce5a04af3d952cedc81a7735fc049f8203",
+    );
+
+    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as Group>::Scalar>::default();
+    let cubic_circuit2_secp = CubicCircuit::<<secq256k1::Point as Group>::Scalar>::default();
+    test_circuit_digest_with::<secp256k1::Point, secq256k1::Point, _>(
+      &cubic_circuit1_secp,
+      "0442eeb939c179f7d7cc83af96af742ab1a3bcf85d2633f2a0ef2547105a5602",
+    );
+    test_circuit_digest_with::<secq256k1::Point, secp256k1::Point, _>(
+      &cubic_circuit2_secp,
+      "f4911e3149c51ed48440dc93996cdb111c33750d319a6f297e740cef1afa2700",
+    );
+  }
+
   fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
@@ -1012,13 +1070,13 @@ mod tests {
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "39a4ea9dd384346fdeb6b5857c7be56fa035153b616d55311f3191dfbceea603",
+      "cc9b8776b7b04ba04daa6c5dc064384686a700921d4411d2a806261b41d01102",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "3f7b25f589f2da5ab26254beba98faa54f6442ebf5fa5860caf7b08b576cab00",
+      "0cc25f7bedbb01a3d092f004f721c0536754cfffda4d5c125d3aaffec3af9b03",
     );
 
     let trivial_circuit1_grumpkin =
@@ -1030,12 +1088,12 @@ mod tests {
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "967acca1d6b4731cd65d4072c12bbaca9648f24d7bcc2877aee720e4265d4302",
+      "1c1f7e860dcb0ce9501cd86dbfbfcaa4aa6cfa1ff55421e9f5e2c668224f8c03",
     );
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "44629f26a78bf6c4e3077f940232050d1793d304fdba5e221d0cf66f76a37903",
+      "b526eae3c3c5d353f99d1b4e097048b3114dcbdbdceb030cbae20de7aafd8b01",
     );
 
     let trivial_circuit1_secp =
@@ -1047,12 +1105,12 @@ mod tests {
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "b99760668a42354643e17b2f0a2d54f173d237eb213e7e758b20a88b4c653c01",
+      "cad89d8bff945f01d8290392271c34dc70873069c1a9fde4a9d4e4b643b27600",
     );
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "68db620e610a3cd75146a1e1bdd168f486b82c0b670277ad1e3d50441c501502",
+      "8b4868bba4c3ce10a645ac13cf9c3ad43f9fa9c8356c9b8fa8760db9c79b0703",
     );
   }
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -116,7 +116,10 @@ impl<G: Group> NIFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{r1cs::commitment_key, traits::Group};
+  use crate::{
+    r1cs::{commitment_key, sparse::SparseMatrix},
+    traits::Group,
+  };
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;
@@ -314,8 +317,17 @@ mod tests {
     };
 
     // create a shape object
+    let rows = num_cons;
+    let cols = num_vars + num_io + 1;
     let S = {
-      let res = R1CSShape::new(num_cons, num_vars, num_io, &A, &B, &C);
+      let res = R1CSShape::new(
+        num_cons,
+        num_vars,
+        num_io,
+        SparseMatrix::new(&A, rows, cols),
+        SparseMatrix::new(&B, rows, cols),
+        SparseMatrix::new(&C, rows, cols),
+      );
       assert!(res.is_ok());
       res.unwrap()
     };

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -152,7 +152,7 @@ impl<G: Group> R1CSShape<G> {
       num_vars,
       num_io,
       A,
-      B, 
+      B,
       C,
     })
   }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,6 +1,7 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 #![allow(clippy::type_complexity)]
 pub mod sparse;
+mod util;
 
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS},

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -22,26 +22,8 @@ use ff::Field;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "csr")]
 use self::sparse::SparseMatrix;
 
-#[cfg(not(feature = "csr"))]
-/// A type that holds the shape of the R1CS matrices
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
-#[abomonation_bounds(where <G::Scalar as ff::PrimeField>::Repr: Abomonation)]
-pub struct R1CSShape<G: Group> {
-  pub(crate) num_cons: usize,
-  pub(crate) num_vars: usize,
-  pub(crate) num_io: usize,
-  #[abomonate_with(Vec<(usize, usize, <G::Scalar as ff::PrimeField>::Repr)>)]
-  pub(crate) A: Vec<(usize, usize, G::Scalar)>,
-  #[abomonate_with(Vec<(usize, usize, <G::Scalar as ff::PrimeField>::Repr)>)]
-  pub(crate) B: Vec<(usize, usize, G::Scalar)>,
-  #[abomonate_with(Vec<(usize, usize, <G::Scalar as ff::PrimeField>::Repr)>)]
-  pub(crate) C: Vec<(usize, usize, G::Scalar)>,
-}
-
-#[cfg(feature = "csr")]
 /// A type that holds the shape of the R1CS matrices
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 #[abomonation_bounds(where <G::Scalar as ff::PrimeField>::Repr: Abomonation)]
@@ -52,8 +34,6 @@ pub struct R1CSShape<G: Group> {
   pub(crate) A: SparseMatrix<G::Scalar>,
   pub(crate) B: SparseMatrix<G::Scalar>,
   pub(crate) C: SparseMatrix<G::Scalar>,
-  #[abomonate_with(<G::Scalar as ff::PrimeField>::Repr)]
-  pub(crate) digest: G::Scalar, // digest of everything else with this field set to G::Scalar::ZERO
 }
 
 /// A type that holds a witness for a given R1CS instance
@@ -127,18 +107,18 @@ impl<G: Group> R1CSShape<G> {
     num_cons: usize,
     num_vars: usize,
     num_io: usize,
-    A: &[(usize, usize, G::Scalar)],
-    B: &[(usize, usize, G::Scalar)],
-    C: &[(usize, usize, G::Scalar)],
+    A: SparseMatrix<G::Scalar>,
+    B: SparseMatrix<G::Scalar>,
+    C: SparseMatrix<G::Scalar>,
   ) -> Result<R1CSShape<G>, NovaError> {
     let is_valid = |num_cons: usize,
                     num_vars: usize,
                     num_io: usize,
-                    M: &[(usize, usize, G::Scalar)]|
+                    M: &SparseMatrix<G::Scalar>|
      -> Result<(), NovaError> {
-      let res = (0..M.len())
-        .map(|i| {
-          let (row, col, _val) = M[i];
+      let res = M
+        .iter()
+        .map(|(row, col, _val)| {
           if row >= num_cons || col > num_io + num_vars {
             Err(NovaError::InvalidIndex)
           } else {
@@ -154,9 +134,9 @@ impl<G: Group> R1CSShape<G> {
       }
     };
 
-    let res_A = is_valid(num_cons, num_vars, num_io, A);
-    let res_B = is_valid(num_cons, num_vars, num_io, B);
-    let res_C = is_valid(num_cons, num_vars, num_io, C);
+    let res_A = is_valid(num_cons, num_vars, num_io, &A);
+    let res_B = is_valid(num_cons, num_vars, num_io, &B);
+    let res_C = is_valid(num_cons, num_vars, num_io, &C);
 
     if res_A.is_err() || res_B.is_err() || res_C.is_err() {
       return Err(NovaError::InvalidIndex);
@@ -167,30 +147,14 @@ impl<G: Group> R1CSShape<G> {
       return Err(NovaError::OddInputLength);
     }
 
-    cfg_if::cfg_if! {
-      if #[cfg(feature = "csr")] {
-        let rows = num_cons;
-        let cols = num_vars + num_io + 1;
-
-        Ok(R1CSShape {
-          num_cons,
-          num_vars,
-          num_io,
-          A: SparseMatrix::new(A, rows, cols),
-          B: SparseMatrix::new(B, rows, cols),
-          C: SparseMatrix::new(C, rows, cols),
-        })
-      } else {
-        Ok(R1CSShape {
-          num_cons,
-          num_vars,
-          num_io,
-          A: A.to_owned(),
-          B: B.to_owned(),
-          C: C.to_owned(),
-        })
-      }
-    }
+    Ok(R1CSShape {
+      num_cons,
+      num_vars,
+      num_io,
+      A,
+      B, 
+      C,
+    })
   }
 
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
@@ -203,45 +167,6 @@ impl<G: Group> R1CSShape<G> {
     assert!(self.num_io < self.num_vars);
   }
 
-  #[cfg(not(feature = "csr"))]
-  pub(crate) fn multiply_vec(
-    &self,
-    z: &[G::Scalar],
-  ) -> Result<(Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>), NovaError> {
-    if z.len() != self.num_io + self.num_vars + 1 {
-      return Err(NovaError::InvalidWitnessLength);
-    }
-
-    // computes a product between a sparse matrix `M` and a vector `z`
-    // This does not perform any validation of entries in M (e.g., if entries in `M` reference indexes outside the range of `z`)
-    // This is safe since we know that `M` is valid
-    let sparse_matrix_vec_product =
-      |M: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
-        (0..M.len())
-          .map(|i| {
-            let (row, col, val) = M[i];
-            (row, val * z[col])
-          })
-          .fold(vec![G::Scalar::ZERO; num_rows], |mut Mz, (r, v)| {
-            Mz[r] += v;
-            Mz
-          })
-      };
-
-    let (Az, (Bz, Cz)) = rayon::join(
-      || sparse_matrix_vec_product(&self.A, self.num_cons, z),
-      || {
-        rayon::join(
-          || sparse_matrix_vec_product(&self.B, self.num_cons, z),
-          || sparse_matrix_vec_product(&self.C, self.num_cons, z),
-        )
-      },
-    );
-
-    Ok((Az, Bz, Cz))
-  }
-
-  #[cfg(feature = "csr")]
   pub(crate) fn multiply_vec(
     &self,
     z: &[G::Scalar],
@@ -422,30 +347,10 @@ impl<G: Group> R1CSShape<G> {
     let num_vars_padded = m;
     let num_cons_padded = m;
 
-    cfg_if::cfg_if! {
-      if #[cfg(feature = "csr")] {
-        let apply_pad = |mut M: SparseMatrix<G::Scalar>| -> SparseMatrix<G::Scalar> {
-          M.pad(num_cons_padded, num_vars_padded, self.num_vars);
-          M
-        };
-      } else {
-        let apply_pad = |M: Vec<(usize, usize, G::Scalar)>| -> Vec<(usize, usize, G::Scalar)> {
-          M.into_par_iter()
-            .map(|(r, c, v)| {
-              (
-                r,
-                if c >= self.num_vars {
-                  c + num_vars_padded - self.num_vars
-                } else {
-                  c
-                },
-                v,
-              )
-            })
-            .collect::<Vec<_>>()
-        };
-      }
-    }
+    let apply_pad = |mut M: SparseMatrix<G::Scalar>| -> SparseMatrix<G::Scalar> {
+      M.pad(num_cons_padded, num_vars_padded, self.num_vars);
+      M
+    };
 
     let A_padded = apply_pad(self.A.clone());
     let B_padded = apply_pad(self.B.clone());

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -171,7 +171,7 @@ impl<'a, F: PrimeField> Iterator for Iter<'a, F> {
     self.i += 1;
     // edge case at the end
     if self.i == self.nnz {
-      return Some(curr_item); // well this is ugly :(
+      return Some(curr_item);
     }
     // if `i` has moved to next row
     while self.i >= self.matrix.indptr[self.row + 1] {

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -36,6 +36,16 @@ pub struct SparseMatrix<F: PrimeField> {
 }
 
 impl<F: PrimeField> SparseMatrix<F> {
+  /// 0x0 empty matrix
+  pub fn empty() -> Self {
+    SparseMatrix {
+      data: vec![],
+      indices: vec![],
+      indptr: vec![0],
+      cols: 0,
+    }
+  }
+
   /// construct from Vec<usize(row), usize(col), F>
   pub fn new(matrix: &[(usize, usize, F)], rows: usize, cols: usize) -> Self {
     let mut new_matrix = vec![vec![]; rows];
@@ -89,32 +99,12 @@ impl<F: PrimeField> SparseMatrix<F> {
       .collect()
   }
 
-  /// multiply by dense vector; should use rayon/gpu
-  /// we don't check dimensions
-  #[tracing::instrument(skip_all, name = "SparseMatrix::multiply_vec_unchecked")]
-  pub fn multiply_vec_unchecked(&self, vector: &[F]) -> Vec<F> {
-    // naive implementation for now
-    self
-      .indptr
-      .par_windows(2)
-      .map(|ptrs| {
-        let data = &self.data[ptrs[0]..ptrs[1]];
-        let indices = &self.indices[ptrs[0]..ptrs[1]];
-        data
-          .iter()
-          .zip(indices)
-          .map(|(val, col_idx)| *val * vector[*col_idx])
-          .sum()
-      })
-      .collect()
-  }
-
   /// number of non-zero entries
   pub fn len(&self) -> usize {
     *self.indptr.last().unwrap()
   }
 
-  /// number of non-zero entries
+  /// empty matrix
   pub fn is_empty(&self) -> bool {
     self.len() == 0
   }

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -1,0 +1,259 @@
+//! # Sparse Matrices
+//!
+//! This module defines a custom implementation of CSR/CSC sparse matrices.
+//! Specifically, we implement sparse matrix / dense vector multiplication
+//! to compute the `A z`, `B z`, and `C z` in Nova.
+//!
+//! Notes:
+//!
+//! There are many sparse matrix crates available in rust. However, most of
+//! these crates are do not parallelize, or are not compatiable with field elements.
+//!
+//! For example, [sprs](https://crates.io/crates/sprs/0.2.1) does not parallelize
+//! its sparse matrix / dense vector multiplication. It's traits also require
+//! `num_traits::Zero`, which is not compatiable with `ff::PrimeField`.
+
+use abomonation::Abomonation;
+use abomonation_derive::Abomonation;
+use ff::PrimeField;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// CSR format sparse matrix, We follow the names used by scipy.
+/// Detailed explanation here: https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
+#[abomonation_bounds(where <F as PrimeField>::Repr: Abomonation)]
+pub struct SparseMatrix<F: PrimeField> {
+  #[abomonate_with(Vec<F::Repr>)]
+  /// all non-zero values in the matrix
+  pub data: Vec<F>,
+  /// column indices
+  pub indices: Vec<usize>,
+  /// row information
+  pub indptr: Vec<usize>,
+  /// number of columns
+  pub cols: usize,
+}
+
+impl<F: PrimeField> SparseMatrix<F> {
+  /// construct from Vec<usize(row), usize(col), F>
+  pub fn new(matrix: &[(usize, usize, F)], rows: usize, cols: usize) -> Self {
+    let mut new_matrix = vec![vec![]; rows];
+    for (row, col, val) in matrix {
+      new_matrix[*row].push((*col, *val));
+    }
+
+    for col in new_matrix.iter_mut() {
+      col.sort_by(|(x, _), (y, _)| x.cmp(y));
+    }
+
+    let mut indptr = vec![0; rows + 1];
+    for (i, col) in new_matrix.iter().enumerate() {
+      indptr[i + 1] = indptr[i] + col.len();
+    }
+
+    let mut indices = vec![];
+    let mut data = vec![];
+    for col in new_matrix {
+      let (idx, val): (Vec<_>, Vec<_>) = col.into_iter().unzip();
+      indices.extend(idx);
+      data.extend(val);
+    }
+
+    SparseMatrix {
+      data,
+      indices,
+      indptr,
+      cols,
+    }
+  }
+
+  /// multiply by dense vector; should use rayon/gpu
+  #[tracing::instrument(skip_all, name = "SparseMatrix::multiply_vec")]
+  pub fn multiply_vec(&self, vector: &[F]) -> Vec<F> {
+    assert_eq!(self.cols, vector.len(), "invalid shape");
+
+    // naive implementation for now
+    self
+      .indptr
+      .par_windows(2)
+      .map(|ptrs| {
+        let data = &self.data[ptrs[0]..ptrs[1]];
+        let indices = &self.indices[ptrs[0]..ptrs[1]];
+        data
+          .iter()
+          .zip(indices)
+          .map(|(val, col_idx)| *val * vector[*col_idx])
+          .sum()
+      })
+      .collect()
+  }
+
+  /// multiply by dense vector; should use rayon/gpu
+  /// we don't check dimensions
+  #[tracing::instrument(skip_all, name = "SparseMatrix::multiply_vec_unchecked")]
+  pub fn multiply_vec_unchecked(&self, vector: &[F]) -> Vec<F> {
+    // naive implementation for now
+    self
+      .indptr
+      .par_windows(2)
+      .map(|ptrs| {
+        let data = &self.data[ptrs[0]..ptrs[1]];
+        let indices = &self.indices[ptrs[0]..ptrs[1]];
+        data
+          .iter()
+          .zip(indices)
+          .map(|(val, col_idx)| *val * vector[*col_idx])
+          .sum()
+      })
+      .collect()
+  }
+
+  /// number of non-zero entries
+  pub fn len(&self) -> usize {
+    *self.indptr.last().unwrap()
+  }
+
+  /// number of non-zero entries
+  pub fn is_empty(&self) -> bool {
+    self.len() == 0
+  }
+
+  /// returns a custom iterator
+  pub fn iter(&self) -> Iter<'_, F> {
+    let mut row = 0;
+    while self.indptr[row + 1] == 0 {
+      row += 1;
+    }
+    Iter {
+      matrix: self,
+      row,
+      i: 0,
+      nnz: *self.indptr.last().unwrap(),
+    }
+  }
+
+  /// pad to specific dimensions, which must be bigger
+  pub fn pad(&mut self, rows: usize, num_vars_padded: usize, num_vars: usize) {
+    assert!(rows + 1 >= self.indptr.len(), "row size must be bigger");
+
+    self.indices.par_iter_mut().for_each(|c| {
+      if *c >= num_vars {
+        *c += num_vars_padded - num_vars
+      }
+    });
+
+    self.cols += num_vars_padded - num_vars;
+
+    let ex = {
+      let nnz = self.indptr.last().unwrap();
+      vec![*nnz; rows - self.indptr.len() + 1]
+    };
+    self.indptr.extend(ex);
+  }
+}
+
+/// Iterator for sparse matrix
+pub struct Iter<'a, F: PrimeField> {
+  matrix: &'a SparseMatrix<F>,
+  row: usize,
+  i: usize,
+  nnz: usize,
+}
+
+impl<'a, F: PrimeField> Iterator for Iter<'a, F> {
+  type Item = (usize, usize, F);
+
+  fn next(&mut self) -> Option<Self::Item> {
+    // are we at the end?
+    if self.i == self.nnz {
+      return None;
+    }
+
+    // compute current item
+    let curr_item = (
+      self.row,
+      self.matrix.indices[self.i],
+      self.matrix.data[self.i],
+    );
+
+    // advance the iterator
+    self.i += 1;
+    // edge case at the end
+    if self.i == self.nnz {
+      return Some(curr_item); // well this is ugly :(
+    }
+    // if `i` has moved to next row
+    while self.i >= self.matrix.indptr[self.row + 1] {
+      self.row += 1;
+    }
+
+    Some(curr_item)
+  }
+}
+
+/// sorts a matrix by (row, col)
+pub fn sort_sparse<F: PrimeField>(matrix: &mut [(usize, usize, F)]) {
+  matrix.sort_by(|(r1, c1, _), (r2, c2, _)| (r1, c1).cmp(&(r2, c2)))
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::traits::Group;
+
+  use super::SparseMatrix;
+  use pasta_curves::pallas::Point as G;
+
+  #[test]
+  fn test_matrix_creation() {
+    type Fr = <G as Group>::Scalar;
+    let matrix_data = vec![
+      (0, 1, Fr::from(2)),
+      (1, 2, Fr::from(3)),
+      (2, 0, Fr::from(4)),
+    ];
+    let sparse_matrix = SparseMatrix::<Fr>::new(&matrix_data, 3, 3);
+
+    assert_eq!(
+      sparse_matrix.data,
+      vec![Fr::from(2), Fr::from(3), Fr::from(4)]
+    );
+    assert_eq!(sparse_matrix.indices, vec![1, 2, 0]);
+    assert_eq!(sparse_matrix.indptr, vec![0, 1, 2, 3]);
+  }
+
+  #[test]
+  fn test_matrix_vector_multiplication() {
+    type Fr = <G as Group>::Scalar;
+    let matrix_data = vec![
+      (0, 1, Fr::from(2)),
+      (1, 2, Fr::from(3)),
+      (2, 0, Fr::from(4)),
+    ];
+    let sparse_matrix = SparseMatrix::<Fr>::new(&matrix_data, 3, 3);
+    let vector = vec![Fr::from(1), Fr::from(2), Fr::from(3)];
+
+    let result = sparse_matrix.multiply_vec(&vector);
+
+    // Assuming the multiplication is done row by row,
+    // Result[0] = 2.0 * 2.0 = 4.0
+    // Result[1] = 3.0 * 3.0 = 9.0
+    // Result[2] = 4.0 * 1.0 = 4.0
+    assert_eq!(result, vec![Fr::from(4), Fr::from(9), Fr::from(4)]);
+  }
+
+  #[test]
+  fn test_matrix_iter() {
+    type Fr = <G as Group>::Scalar;
+    let matrix_data = vec![
+      (0, 1, Fr::from(2)),
+      (1, 2, Fr::from(3)),
+      (2, 0, Fr::from(4)),
+    ];
+    let sparse_matrix = SparseMatrix::<Fr>::new(&matrix_data, 3, 3);
+
+    for val in sparse_matrix.iter() {
+      println!("{:?}", val);
+    }
+  }
+}

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -37,7 +37,8 @@ impl<F: PrimeField> SparseMatrix<F> {
     }
   }
 
-  /// construct from Vec<usize(row), usize(col), F>
+  /// Construct from the COO representation; Vec<usize(row), usize(col), F>.
+  /// We implicitly sort the columns during construction.
   pub fn new(matrix: &[(usize, usize, F)], rows: usize, cols: usize) -> Self {
     let mut new_matrix = vec![vec![]; rows];
     for (row, col, val) in matrix {

--- a/src/r1cs/util.rs
+++ b/src/r1cs/util.rs
@@ -1,0 +1,26 @@
+use ff::PrimeField;
+#[cfg(not(target_arch = "wasm32"))]
+use proptest::prelude::*;
+
+/// Wrapper struct around a field element that implements additional traits
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FWrap<F: PrimeField>(pub F);
+
+impl<F: PrimeField> Copy for FWrap<F> {}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Trait implementation for generating `FWrap<F>` instances with proptest
+impl<F: PrimeField> Arbitrary for FWrap<F> {
+  type Parameters = ();
+  type Strategy = BoxedStrategy<Self>;
+
+  fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+    use rand::rngs::StdRng;
+    use rand_core::SeedableRng;
+
+    let strategy = any::<[u8; 32]>()
+      .prop_map(|seed| FWrap(F::random(StdRng::from_seed(seed))))
+      .no_shrink();
+    strategy.boxed()
+  }
+}

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -145,26 +145,13 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let (mut row, mut col) = (vec![0usize; N], vec![0usize; N]);
 
     for (i, (r, c, _)) in S.A.iter().chain(S.B.iter()).chain(S.C.iter()).enumerate() {
-      cfg_if::cfg_if! {
-        if #[cfg(feature = "csr")] {
-          row[i] = r;
-          col[i] = c;
-        } else {
-          row[i] = *r;
-          col[i] = *c;
-        }
-      }
+      row[i] = r;
+      col[i] = c;
     }
     let val_A = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.A.iter().enumerate() {
-        cfg_if::cfg_if! {
-          if #[cfg(feature = "csr")] {
-            val[i] = v;
-          } else {
-            val[i] = *v;
-          }
-        }
+        val[i] = v;
       }
       val
     };
@@ -172,13 +159,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_B = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.B.iter().enumerate() {
-        cfg_if::cfg_if! {
-          if #[cfg(feature = "csr")] {
-            val[S.A.len() + i] = v;
-          } else {
-            val[S.A.len() + i] = *v;
-          }
-        }
+        val[S.A.len() + i] = v;
       }
       val
     };
@@ -186,13 +167,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_C = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.C.iter().enumerate() {
-        cfg_if::cfg_if! {
-          if #[cfg(feature = "csr")] {
-            val[S.A.len() + S.B.len() + i] = v;
-          } else {
-            val[S.A.len() + S.B.len() + i] = *v;
-          }
-        }
+        val[S.A.len() + S.B.len() + i] = v;
       }
       val
     };
@@ -311,15 +286,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
         .iter()
         .chain(S.B.iter())
         .chain(S.C.iter())
-        .map(|(r, c, _)| {
-          cfg_if::cfg_if! {
-            if #[cfg(feature = "csr")] {
-              (mem_row[r], mem_col[c])
-            } else {
-              (mem_row[*r], mem_col[*c])
-            }
-          }
-        })
+        .map(|(r, c, _)| (mem_row[r], mem_col[c]))
         .enumerate()
       {
         E_row[i] = val_r;

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -145,14 +145,26 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let (mut row, mut col) = (vec![0usize; N], vec![0usize; N]);
 
     for (i, (r, c, _)) in S.A.iter().chain(S.B.iter()).chain(S.C.iter()).enumerate() {
-      row[i] = *r;
-      col[i] = *c;
+      cfg_if::cfg_if! {
+        if #[cfg(feature = "csr")] {
+          row[i] = r;
+          col[i] = c;
+        } else {
+          row[i] = *r;
+          col[i] = *c;
+        }
+      }
     }
-
     let val_A = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.A.iter().enumerate() {
-        val[i] = *v;
+        cfg_if::cfg_if! {
+          if #[cfg(feature = "csr")] {
+            val[i] = v;
+          } else {
+            val[i] = *v;
+          }
+        }
       }
       val
     };
@@ -160,7 +172,13 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_B = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.B.iter().enumerate() {
-        val[S.A.len() + i] = *v;
+        cfg_if::cfg_if! {
+          if #[cfg(feature = "csr")] {
+            val[S.A.len() + i] = v;
+          } else {
+            val[S.A.len() + i] = *v;
+          }
+        }
       }
       val
     };
@@ -168,7 +186,13 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_C = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.C.iter().enumerate() {
-        val[S.A.len() + S.B.len() + i] = *v;
+        cfg_if::cfg_if! {
+          if #[cfg(feature = "csr")] {
+            val[S.A.len() + S.B.len() + i] = v;
+          } else {
+            val[S.A.len() + S.B.len() + i] = *v;
+          }
+        }
       }
       val
     };
@@ -287,7 +311,15 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
         .iter()
         .chain(S.B.iter())
         .chain(S.C.iter())
-        .map(|(r, c, _)| (mem_row[*r], mem_col[*c]))
+        .map(|(r, c, _)| {
+          cfg_if::cfg_if! {
+            if #[cfg(feature = "csr")] {
+              (mem_row[r], mem_col[c])
+            } else {
+              (mem_row[*r], mem_col[*c])
+            }
+          }
+        })
         .enumerate()
       {
         E_row[i] = val_r;

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -7,7 +7,7 @@
 use crate::{
   digest::{DigestBuilder, HasDigest, SimpleDigestible},
   errors::NovaError,
-  r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
+  r1cs::{sparse::SparseMatrix, R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
   spartan::{
     polys::{eq::EqPolynomial, multilinear::MultilinearPolynomial, multilinear::SparsePolynomial},
     powers,
@@ -19,9 +19,6 @@ use crate::{
   },
   Commitment, CommitmentKey,
 };
-
-#[cfg(feature = "csr")]
-use crate::r1cs::sparse::SparseMatrix;
 
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
@@ -199,21 +196,11 @@ where
         |S: &R1CSShape<G>, rx: &[G::Scalar]| -> (Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>) {
           assert_eq!(rx.len(), S.num_cons);
 
-          cfg_if::cfg_if! {
-            if #[cfg(feature = "csr")] {
-              let inner = |M: &SparseMatrix<G::Scalar>, M_evals: &mut Vec<G::Scalar>| {
-                for (row, col, val) in M.iter() {
-                  M_evals[col] += rx[row] * val;
-                }
-              };
-            } else {
-              let inner = |M: &Vec<(usize, usize, G::Scalar)>, M_evals: &mut Vec<G::Scalar>| {
-                for (row, col, val) in M.iter() {
-                  M_evals[*col] += rx[*row] * val;
-                }
-              };
+          let inner = |M: &SparseMatrix<G::Scalar>, M_evals: &mut Vec<G::Scalar>| {
+            for (row, col, val) in M.iter() {
+              M_evals[col] += rx[row] * val;
             }
-          }
+          };
 
           let (A_evals, (B_evals, C_evals)) = rayon::join(
             || {
@@ -447,57 +434,27 @@ where
     };
 
     // compute evaluations of R1CS matrices
-    cfg_if::cfg_if! {
-      if #[cfg(feature = "csr")] {
-        let multi_evaluate = |M_vec: &[&SparseMatrix<G::Scalar>],
-                  r_x: &[G::Scalar],
-                  r_y: &[G::Scalar]|
-        -> Vec<G::Scalar> {
-          let evaluate_with_table =
-          |M: &SparseMatrix<G::Scalar>, T_x: &[G::Scalar], T_y: &[G::Scalar]| -> G::Scalar {
+    let multi_evaluate = |M_vec: &[&SparseMatrix<G::Scalar>],
+                          r_x: &[G::Scalar],
+                          r_y: &[G::Scalar]|
+     -> Vec<G::Scalar> {
+      let evaluate_with_table =
+        |M: &SparseMatrix<G::Scalar>, T_x: &[G::Scalar], T_y: &[G::Scalar]| -> G::Scalar {
           M.iter()
-          .map(|(row, col, val)| T_x[row] * T_y[col] * val)
-          .sum()
-          };
-
-          let (T_x, T_y) = rayon::join(
-          || EqPolynomial::new(r_x.to_vec()).evals(),
-          || EqPolynomial::new(r_y.to_vec()).evals(),
-          );
-
-          (0..M_vec.len())
-          .into_par_iter()
-          .map(|i| evaluate_with_table(M_vec[i], &T_x, &T_y))
-          .collect()
+            .map(|(row, col, val)| T_x[row] * T_y[col] * val)
+            .sum()
         };
-      } else {
-        let multi_evaluate = |M_vec: &[&[(usize, usize, G::Scalar)]],
-                              r_x: &[G::Scalar],
-                              r_y: &[G::Scalar]|
-        -> Vec<G::Scalar> {
-          let evaluate_with_table =
-            |M: &[(usize, usize, G::Scalar)], T_x: &[G::Scalar], T_y: &[G::Scalar]| -> G::Scalar {
-              (0..M.len())
-                .into_par_iter()
-                .map(|i| {
-                  let (row, col, val) = M[i];
-                  T_x[row] * T_y[col] * val
-                })
-                .sum()
-            };
 
-          let (T_x, T_y) = rayon::join(
-            || EqPolynomial::new(r_x.to_vec()).evals(),
-            || EqPolynomial::new(r_y.to_vec()).evals(),
-          );
+      let (T_x, T_y) = rayon::join(
+        || EqPolynomial::new(r_x.to_vec()).evals(),
+        || EqPolynomial::new(r_y.to_vec()).evals(),
+      );
 
-          (0..M_vec.len())
-            .into_par_iter()
-            .map(|i| evaluate_with_table(M_vec[i], &T_x, &T_y))
-            .collect()
-        };
-      }
-    }
+      (0..M_vec.len())
+        .into_par_iter()
+        .map(|i| evaluate_with_table(M_vec[i], &T_x, &T_y))
+        .collect()
+    };
 
     let evals = multi_evaluate(&[&vk.S.A, &vk.S.B, &vk.S.C], &r_x, &r_y);
 

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -198,7 +198,7 @@ where
 
           let inner = |M: &SparseMatrix<G::Scalar>, M_evals: &mut Vec<G::Scalar>| {
             for (row_idx, ptrs) in M.indptr.windows(2).enumerate() {
-              for (val, col_idx) in M.get_row_unchecked(ptrs) {
+              for (val, col_idx) in M.get_row_unchecked(ptrs.try_into().unwrap()) {
                 M_evals[*col_idx] += rx[row_idx] * val;
               }
             }
@@ -446,7 +446,7 @@ where
             .par_windows(2)
             .enumerate()
             .map(|(row_idx, ptrs)| {
-              M.get_row_unchecked(ptrs)
+              M.get_row_unchecked(ptrs.try_into().unwrap())
                 .map(|(val, col_idx)| T_x[row_idx] * T_y[*col_idx] * val)
                 .sum::<G::Scalar>()
             })

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -197,9 +197,9 @@ where
           assert_eq!(rx.len(), S.num_cons);
 
           let inner = |M: &SparseMatrix<G::Scalar>, M_evals: &mut Vec<G::Scalar>| {
-            for (row, ptrs) in M.indptr.windows(2).enumerate() {
-              for (val, col) in M.get_row_unchecked(ptrs) {
-                M_evals[*col] += rx[row] * val;
+            for (row_idx, ptrs) in M.indptr.windows(2).enumerate() {
+              for (val, col_idx) in M.get_row_unchecked(ptrs) {
+                M_evals[*col_idx] += rx[row_idx] * val;
               }
             }
           };
@@ -445,9 +445,9 @@ where
           M.indptr
             .par_windows(2)
             .enumerate()
-            .map(|(row, ptrs)| {
+            .map(|(row_idx, ptrs)| {
               M.get_row_unchecked(ptrs)
-                .map(|(val, col)| T_x[row] * T_y[*col] * val)
+                .map(|(val, col_idx)| T_x[row_idx] * T_y[*col_idx] * val)
                 .sum::<G::Scalar>()
             })
             .sum()


### PR DESCRIPTION
Resolves #37.

This PR implements CSR matrix-vector multiplication under the `"csr"` feature. (This was for me to debug; if CSR sould become the only representation, then we can simply replace and remove the feature.) We get a slight uptick in performance, around 10%.


Notes:

There are many sparse matrix crates available in rust. However, most of these crates are do not parallelize, or are not compatiable with field elements. For example, [sprs](https://crates.io/crates/sprs/0.2.1) does not parallelize its sparse matrix / dense vector multiplication. It's traits also require `num_traits::Zero`, which is not compatiable with `ff::PrimeField`.

CSR:
```
Nova-based VDF with MinRoot delay function
=========================================================
Proving 1 iterations of MinRoot per step
Producing public parameters...
PublicParams::setup, took 898.236583ms 
Number of constraints per step (primary circuit): 9819
Number of constraints per step (secondary circuit): 10347
Number of variables per step (primary circuit): 9813
Number of variables per step (secondary circuit): 10329
Generating a RecursiveSNARK...
RecursiveSNARK::prove_step 0: true, took 3.208µs 
RecursiveSNARK::prove_step 1: true, took 31.0505ms 
RecursiveSNARK::prove_step 2: true, took 37.113ms 
RecursiveSNARK::prove_step 3: true, took 37.011ms 
RecursiveSNARK::prove_step 4: true, took 38.116292ms 
RecursiveSNARK::prove_step 5: true, took 37.588333ms 
RecursiveSNARK::prove_step 6: true, took 37.468125ms 
RecursiveSNARK::prove_step 7: true, took 37.913125ms 
RecursiveSNARK::prove_step 8: true, took 37.48625ms 
RecursiveSNARK::prove_step 9: true, took 38.424084ms 
Verifying a RecursiveSNARK...
RecursiveSNARK::verify: true, took 29.615583ms
Generating a CompressedSNARK using Spartan with IPA-PC...
CompressedSNARK::prove: true, took 721.547ms
CompressedSNARK::len 9407 bytes
Verifying a CompressedSNARK...
CompressedSNARK::verify: true, took 30.767459ms
```

No CSR:
```
Nova-based VDF with MinRoot delay function
=========================================================
Proving 1 iterations of MinRoot per step
Producing public parameters...
PublicParams::setup, took 891.275666ms 
Number of constraints per step (primary circuit): 9819
Number of constraints per step (secondary circuit): 10347
Number of variables per step (primary circuit): 9813
Number of variables per step (secondary circuit): 10329
Generating a RecursiveSNARK...
RecursiveSNARK::prove_step 0: true, took 2.875µs 
RecursiveSNARK::prove_step 1: true, took 34.667833ms 
RecursiveSNARK::prove_step 2: true, took 40.504625ms 
RecursiveSNARK::prove_step 3: true, took 40.93575ms 
RecursiveSNARK::prove_step 4: true, took 41.700541ms 
RecursiveSNARK::prove_step 5: true, took 41.201209ms 
RecursiveSNARK::prove_step 6: true, took 41.845625ms 
RecursiveSNARK::prove_step 7: true, took 41.882541ms 
RecursiveSNARK::prove_step 8: true, took 41.978542ms 
RecursiveSNARK::prove_step 9: true, took 42.167542ms 
Verifying a RecursiveSNARK...
RecursiveSNARK::verify: true, took 28.778584ms
Generating a CompressedSNARK using Spartan with IPA-PC...
CompressedSNARK::prove: true, took 729.643958ms
CompressedSNARK::len 9406 bytes
Verifying a CompressedSNARK...
CompressedSNARK::verify: true, took 29.569208ms
=========================================================
```