### PR TITLE
Add benchmark comment action

### DIFF
--- a/.github/workflows/bench_pr_comment.yml
+++ b/.github/workflows/bench_pr_comment.yml
@@ -1,0 +1,40 @@
+# Creates a PR benchmark comment with a comparison to main
+name: Benchmark pull requests
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  runBenchmark:
+    name: run benchmark
+    runs-on: [self-hosted, bench]
+    if:
+      github.event.issue.pull_request
+      && github.event.issue.state == 'open'
+      && contains(github.event.comment.body, '!benchmark')
+      && (github.event.comment.author_association == 'MEMBER'
+      || github.event.comment.author_association == 'OWNER')
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - uses: actions/checkout@v4
+        if: success()
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      # Set the Rust env vars
+      - uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: boa-dev/criterion-compare-action@v3
+        with:
+          # Optional. Compare only this benchmark target
+          benchName: "sha256"
+          # Needed. The name of the branch to compare with
+          branchName: ${{ github.ref_name }}


### PR DESCRIPTION
Copy of the action in [lurk-rs](https://github.com/lurk-lab/lurk-rs/blob/a574b5198947b4d0dea80e349807c6222ca5a157/.github/workflows/bench_pr_comment.yml) with a self-hosted runner, also triggered via the `!benchmark` keyword in a PR comment. I wasn't sure which benchmark we wanted to run so I put `sha256` for now.