### PR TITLE
Add DigestBuilder.

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -71,7 +71,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &c_secondary,
       Some(S1::commitment_key_floor()),
       Some(S2::commitment_key_floor()),
-    );
+    )
+    .unwrap();
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -163,7 +164,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &c_secondary,
       Some(SS1::commitment_key_floor()),
       Some(SS2::commitment_key_floor()),
-    );
+    )
+    .unwrap();
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
 

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -99,7 +99,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(1, num_cons);
-    let running_claims = bench.setup_running_claims();
+    let running_claims = bench.setup_running_claims().unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -192,7 +192,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(2, num_cons);
-    let running_claims = bench.setup_running_claims();
+    let running_claims = bench.setup_running_claims().unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -120,7 +120,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
           &running_claims[0],
-          running_claims.digest,
+          running_claims.digest(),
           Some(program_counter),
           0,
           1,
@@ -214,7 +214,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
           &running_claims[0],
-          running_claims.digest,
+          running_claims.digest(),
           Some(program_counter),
           0,
           2,

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -5,10 +5,8 @@ use core::marker::PhantomData;
 use criterion::*;
 use ff::PrimeField;
 use nova_snark::{
-  compute_digest,
-  r1cs::commitment_key,
+  supernova::NonUniformCircuit,
   supernova::RecursiveSNARK,
-  supernova::{PublicParams, RunningClaim},
   traits::{
     circuit_supernova::{StepCircuit, TrivialTestCircuit},
     Group,
@@ -41,6 +39,50 @@ cfg_if::cfg_if! {
 
 criterion_main!(recursive_snark_supernova);
 
+struct NonUniformBench<G1, G2, S>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  S: StepCircuit<G2::Scalar> + Default,
+{
+  num_circuits: usize,
+  num_cons: usize,
+  _p: PhantomData<(G1, G2, S)>,
+}
+
+impl<G1, G2, S> NonUniformBench<G1, G2, S>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  S: StepCircuit<G2::Scalar> + Default,
+{
+  fn new(num_circuits: usize, num_cons: usize) -> Self {
+    Self {
+      num_circuits,
+      num_cons,
+      _p: Default::default(),
+    }
+  }
+}
+
+impl<G1, G2, S> NonUniformCircuit<G1, G2, NonTrivialTestCircuit<G1::Scalar>>
+  for NonUniformBench<G1, G2, S>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  S: StepCircuit<G2::Scalar> + Default,
+{
+  fn num_circuits(&self) -> usize {
+    self.num_circuits
+  }
+
+  fn primary_circuit(&self, circuit_index: usize) -> NonTrivialTestCircuit<G1::Scalar> {
+    assert!(circuit_index < self.num_circuits);
+
+    NonTrivialTestCircuit::new(self.num_cons)
+  }
+}
+
 fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
   let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
@@ -55,24 +97,9 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
     ));
     group.sample_size(10);
 
-    let c_primary = NonTrivialTestCircuit::new(num_cons);
-    let c_secondary = TrivialTestCircuit::default();
-
-    // Structuring running claims
-    let mut running_claim1 = RunningClaim::<
-      G1,
-      G2,
-      NonTrivialTestCircuit<<G1 as Group>::Scalar>,
-      TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::new(0, c_primary, c_secondary.clone(), 1);
-
-    let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = commitment_key(r1cs_shape_primary, None);
-    let ck_secondary = commitment_key(r1cs_shape_secondary, None);
-
-    // set unified ck_primary, ck_secondary and update digest
-    running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
-    let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[running_claim1.get_public_params()]);
+    let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
+      NonUniformBench::new(1, num_cons);
+    let running_claims = bench.setup_running_claims();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -92,8 +119,8 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
-          &running_claim1,
-          digest,
+          &running_claims[0],
+          running_claims.digest,
           Some(program_counter),
           0,
           1,
@@ -103,12 +130,12 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         .unwrap()
       });
 
-      let res = recursive_snark.prove_step(&running_claim1, &z0_primary, &z0_secondary);
+      let res = recursive_snark.prove_step(&running_claims[0], &z0_primary, &z0_secondary);
       if let Err(e) = &res {
         println!("res failed {:?}", e);
       }
       assert!(res.is_ok());
-      let res = recursive_snark.verify(&running_claim1, &z0_primary, &z0_secondary);
+      let res = recursive_snark.verify(&running_claims[0], &z0_primary, &z0_secondary);
       if let Err(e) = &res {
         println!("res failed {:?}", e);
       }
@@ -125,7 +152,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         // produce a recursive SNARK for a step of the recursion
         assert!(black_box(&mut recursive_snark.clone())
           .prove_step(
-            black_box(&running_claim1),
+            black_box(&running_claims[0]),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
@@ -138,7 +165,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
       b.iter(|| {
         assert!(black_box(&mut recursive_snark.clone())
           .verify(
-            black_box(&running_claim1),
+            black_box(&running_claims[0]),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
@@ -163,37 +190,9 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
     ));
     group.sample_size(10);
 
-    let c_primary = NonTrivialTestCircuit::new(num_cons);
-    let c_secondary = TrivialTestCircuit::default();
-
-    // Structuring running claims
-    let mut running_claim1 = RunningClaim::<
-      G1,
-      G2,
-      NonTrivialTestCircuit<<G1 as Group>::Scalar>,
-      TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::new(0, c_primary.clone(), c_secondary.clone(), 2);
-
-    // Structuring running claims
-    let mut running_claim2 = RunningClaim::<
-      G1,
-      G2,
-      NonTrivialTestCircuit<<G1 as Group>::Scalar>,
-      TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::new(1, c_primary, c_secondary.clone(), 2);
-
-    let (r1cs_shape_primary, r1cs_shape_secondary) = running_claim1.get_r1cs_shape();
-    let ck_primary = commitment_key(r1cs_shape_primary, None);
-    let ck_secondary = commitment_key(r1cs_shape_secondary, None);
-
-    // set unified ck_primary, ck_secondary and update digest
-    running_claim1.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
-    running_claim2.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
-
-    let digest = compute_digest::<G1, PublicParams<G1, G2>>(&[
-      running_claim1.get_public_params(),
-      running_claim2.get_public_params(),
-    ]);
+    let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
+      NonUniformBench::new(2, num_cons);
+    let running_claims = bench.setup_running_claims();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -214,8 +213,8 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
-          &running_claim1,
-          digest,
+          &running_claims[0],
+          running_claims.digest,
           Some(program_counter),
           0,
           2,
@@ -226,23 +225,23 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       });
 
       if selected_augmented_circuit == 0 {
-        let res = recursive_snark.prove_step(&running_claim1, &z0_primary, &z0_secondary);
+        let res = recursive_snark.prove_step(&running_claims[0], &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&running_claim1, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&running_claims[0], &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
       } else if selected_augmented_circuit == 1 {
-        let res = recursive_snark.prove_step(&running_claim2, &z0_primary, &z0_secondary);
+        let res = recursive_snark.prove_step(&running_claims[1], &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&running_claim2, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&running_claims[1], &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -263,7 +262,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
         // produce a recursive SNARK for a step of the recursion
         assert!(black_box(&mut recursive_snark.clone())
           .prove_step(
-            black_box(&running_claim1),
+            black_box(&running_claims[0]),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
@@ -276,7 +275,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       b.iter(|| {
         assert!(black_box(&mut recursive_snark.clone())
           .verify(
-            black_box(&running_claim1),
+            black_box(&running_claims[0]),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None).unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialTestCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None).unwrap();
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -160,7 +160,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot_serde.rs
+++ b/examples/minroot_serde.rs
@@ -167,7 +167,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     println!("PublicParams::setup, took {:?} ", start.elapsed());
     encode(&pp, &mut file).unwrap()
   };
@@ -193,7 +194,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     assert!(result.clone() == pp, "not equal!");
     assert!(remaining.is_empty());
   } else {

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -90,9 +90,6 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
     let mut bytes: [u8; 32] = hasher.finalize().into();
     self.inner.set_digest(Self::map_to_field(&mut bytes));
 
-    // let digest = self.compute_digest(&self.inner)?;
-
-    // self.inner.set_digest(digest);
     Ok(self.inner)
   }
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,119 @@
+use ff::PrimeField;
+use serde::Serialize;
+use sha3::{Digest, Sha3_256};
+use std::iter::Extend;
+use std::marker::PhantomData;
+
+use crate::constants::NUM_HASH_BITS;
+
+/// For building digests
+#[derive(Clone)]
+pub struct DigestBuilder<F: PrimeField, T: HasDigest<F>> {
+  bytes: Vec<u8>,
+  hasher: Option<Sha3_256>,
+  bytes_digest: [u8; 32],
+  inner: Option<T>,
+  _p: PhantomData<(F, T)>,
+}
+
+/// Trait to be implemented by types whose digests can be built with `DigestBuilder`.
+pub trait HasDigest<F: PrimeField> {
+  /// Extend `bytes` with raw bytes or digest summarizing `Digestible`.
+  fn set_digest(&mut self, digest: F);
+  fn set_bytes_digest(&mut self, _bytes_digest: [u8; 32]) {
+    unimplemented!()
+  }
+}
+
+/// Trait for components with potentially discrete digests to be included in their container's digest.
+pub trait Digestible {
+  /// Extend a byte sink with the bytes to be digested.
+  fn extend_bytes<X: Extend<u8>>(&self, bytes: &mut X);
+}
+
+/// Marker trait to be implemented for types that implement `Digestible` and `Serialize`.
+/// Their instances will be serialized to bytes then digested.
+pub trait SimpleDigestible: Serialize {}
+
+impl<T: SimpleDigestible> Digestible for T {
+  fn extend_bytes<X: Extend<u8>>(&self, bytes: &mut X) {
+    (*bytes).extend(bincode::serialize(self).unwrap());
+  }
+}
+
+impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
+  /// Return a new `DigestBuilder`.
+  pub fn new() -> Self {
+    Self {
+      bytes: Default::default(),
+      hasher: Some(Sha3_256::new()),
+      bytes_digest: [0; 32],
+      inner: None,
+      _p: Default::default(),
+    }
+  }
+
+  /// Initialize `DigestBuilder` with `inner`.
+  pub fn init(&mut self, inner: T) {
+    self.inner = Some(inner)
+  }
+
+  /// Update builder's hasher.
+  pub fn update(&mut self) {
+    if let Some(hasher) = self.hasher.as_mut() {
+      hasher.update(&self.bytes);
+    } else {
+      panic!("hasher missing");
+    };
+
+    self.bytes.truncate(0);
+  }
+
+  pub fn finalize_bytes_digest(&mut self) {
+    self.update();
+
+    let Some(hasher) = self.hasher.take() else {panic!("hasher missing");};
+    self.bytes_digest = hasher.finalize().into();
+  }
+
+  /// Finalize digest.
+  pub fn finalize(&mut self) -> F {
+    self.finalize_bytes_digest();
+
+    let digest = self.bytes_digest;
+    let bv = (0..NUM_HASH_BITS).map(|i| {
+      let (byte_pos, bit_pos) = (i / 8, i % 8);
+      let bit = (digest[byte_pos] >> bit_pos) & 1;
+      bit == 1
+    });
+
+    // turn the bit vector into a scalar
+    let mut digest = F::ZERO;
+    let mut coeff = F::ONE;
+    for bit in bv {
+      if bit {
+        digest += coeff;
+      }
+      coeff += coeff;
+    }
+    digest
+  }
+
+  /// Extend `DigestBuilder` with the bytes provided by the underlying inner `HasDigest`.
+  pub fn compute_digest(&mut self) -> F {
+    let o = self.inner.as_ref().expect("inner Digestible missing");
+    o.extend_bytes(&mut self.bytes);
+
+    self.finalize()
+  }
+
+  /// Build and return inner `Digestible`.
+  pub fn build(&mut self) -> T {
+    let digest = self.compute_digest();
+
+    if let Some(d) = self.inner.as_mut() {
+      d.set_digest(digest)
+    }
+    self.inner.take().expect("inner Digestible missing")
+  }
+}

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -46,6 +46,10 @@ impl<T: SimpleDigestible> Digestible for T {
 impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
   /// Return a new `DigestBuilder` for a value
   pub fn new(value: T) -> Self {
+    dbg!(
+      NUM_HASH_BITS,
+      <Sha3_256 as OutputSizeUser>::OutputSize::to_usize()
+    );
     assert!(
       NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize(),
       "DigestBuilder only supports hashes with output over 250 bits"

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -79,19 +79,16 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
     digest
   }
 
-  /// Extend `DigestBuilder` with the bytes provided by the underlying inner `HasDigest`.
-  fn compute_digest(&mut self, value: &T) -> Result<F, io::Error> {
-    let mut hasher = Self::hasher();
-    value.write_bytes(&mut hasher)?;
-    let mut bytes: [u8; 32] = hasher.finalize().into();
-    Ok(Self::map_to_field(&mut bytes))
-  }
-
   /// Build and return inner `Digestible`.
   pub fn build(mut self) -> Result<T, io::Error> {
-    let digest = self.compute_digest(&self.inner)?;
+    let mut hasher = Self::hasher();
+    self.inner.write_bytes(&mut hasher)?;
+    let mut bytes: [u8; 32] = hasher.finalize().into();
+    self.inner.set_digest(Self::map_to_field(&mut bytes));
 
-    self.inner.set_digest(digest);
+    // let digest = self.compute_digest(&self.inner)?;
+
+    // self.inner.set_digest(digest);
     Ok(self.inner)
   }
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -46,10 +46,6 @@ impl<T: SimpleDigestible> Digestible for T {
 impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
   /// Return a new `DigestBuilder` for a value
   pub fn new(value: T) -> Self {
-    dbg!(
-      NUM_HASH_BITS,
-      <Sha3_256 as OutputSizeUser>::OutputSize::to_usize()
-    );
     assert!(
       NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize() * 8,
       "DigestBuilder only supports hashes with output over {NUM_HASH_BITS} bits"

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -51,8 +51,8 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
       <Sha3_256 as OutputSizeUser>::OutputSize::to_usize()
     );
     assert!(
-      NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize(),
-      "DigestBuilder only supports hashes with output over 250 bits"
+      NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize() * 8,
+      "DigestBuilder only supports hashes with output over {NUM_HASH_BITS} bits"
     );
     Self {
       inner: value,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,4 +59,7 @@ pub enum NovaError {
   /// return when error during synthesis
   #[error("SynthesisError")]
   SynthesisError,
+  /// returned when there is an error creating a digest
+  #[error("DigestError")]
+  DigestError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod traits;
 
 pub mod supernova;
 
+use std::io;
+
 use crate::bellpepper::{
   r1cs::{NovaShape, NovaWitness},
   shape_cs::ShapeCS,
@@ -105,12 +107,11 @@ where
   /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
   /// ```
   pub fn setup(
-    &mut self,
     c_primary: &C1,
     c_secondary: &C2,
     optfn1: Option<CommitmentKeyHint<G1>>,
     optfn2: Option<CommitmentKeyHint<G2>>,
-  ) -> &mut Self {
+  ) -> Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let augmented_circuit_params_secondary =
@@ -166,8 +167,7 @@ where
       _p_c2: Default::default(),
     };
 
-    self.init(pp);
-    self
+    Self::new(pp)
   }
 }
 
@@ -241,10 +241,8 @@ where
     c_secondary: &C2,
     optfn1: Option<CommitmentKeyHint<G1>>,
     optfn2: Option<CommitmentKeyHint<G2>>,
-  ) -> Self {
-    DigestBuilder::<G1::Scalar, Self>::new()
-      .setup(c_primary, c_secondary, optfn1, optfn2)
-      .build()
+  ) -> Result<Self, io::Error> {
+    DigestBuilder::<G1::Scalar, Self>::setup(c_primary, c_secondary, optfn1, optfn2).build()
   }
   /// Returns the number of constraints in the primary and secondary circuits
   pub const fn num_constraints(&self) -> (usize, usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 mod bellpepper;
 mod circuit;
 mod constants;
+mod digest;
 mod nifs;
 
 // public modules
@@ -46,7 +47,8 @@ use r1cs::{
   CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };
 use serde::{Deserialize, Serialize};
-use sha3::{Digest, Sha3_256};
+
+use crate::digest::{DigestBuilder, HasDigest, SimpleDigestible};
 use traits::{
   circuit::StepCircuit,
   commitment::{CommitmentEngineTrait, CommitmentTrait},
@@ -54,51 +56,14 @@ use traits::{
   AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROTrait,
 };
 
-/// A type that holds public parameters of Nova
-#[derive(Clone, PartialEq, Serialize, Deserialize, Abomonation)]
-#[serde(bound = "")]
-#[abomonation_bounds(
-where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
-  <G1::Scalar as PrimeField>::Repr: Abomonation,
-  <G2::Scalar as PrimeField>::Repr: Abomonation,
-)]
-pub struct PublicParams<G1, G2, C1, C2>
+impl<G1, G2, C1, C2> DigestBuilder<G1::Scalar, PublicParams<G1, G2, C1, C2>>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  F_arity_primary: usize,
-  F_arity_secondary: usize,
-  ro_consts_primary: ROConstants<G1>,
-  ro_consts_circuit_primary: ROConstantsCircuit<G2>,
-  ck_primary: CommitmentKey<G1>,
-  r1cs_shape_primary: R1CSShape<G1>,
-  ro_consts_secondary: ROConstants<G2>,
-  ro_consts_circuit_secondary: ROConstantsCircuit<G1>,
-  ck_secondary: CommitmentKey<G2>,
-  r1cs_shape_secondary: R1CSShape<G2>,
-  augmented_circuit_params_primary: NovaAugmentedCircuitParams,
-  augmented_circuit_params_secondary: NovaAugmentedCircuitParams,
-  #[abomonate_with(<G1::Scalar as PrimeField>::Repr)]
-  digest: G1::Scalar, // digest of everything else with this field set to G1::Scalar::ZERO
-  _p_c1: PhantomData<C1>,
-  _p_c2: PhantomData<C2>,
-}
-
-impl<G1, G2, C1, C2> PublicParams<G1, G2, C1, C2>
-where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
-{
-  /// Creates a new `PublicParams` for a pair of circuits `C1` and `C2`.
+  /// Set up builder to create `PublicParams` for a pair of circuits `C1` and `C2`.
   ///
   /// # Note
   ///
@@ -140,11 +105,12 @@ where
   /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
   /// ```
   pub fn setup(
+    &mut self,
     c_primary: &C1,
     c_secondary: &C2,
     optfn1: Option<CommitmentKeyHint<G1>>,
     optfn2: Option<CommitmentKeyHint<G2>>,
-  ) -> Self {
+  ) -> &mut Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let augmented_circuit_params_secondary =
@@ -182,7 +148,7 @@ where
     let _ = circuit_secondary.synthesize(&mut cs);
     let (r1cs_shape_secondary, ck_secondary) = cs.r1cs_shape_and_key(optfn2);
 
-    let mut pp = Self {
+    let pp = PublicParams {
       F_arity_primary,
       F_arity_secondary,
       ro_consts_primary,
@@ -200,12 +166,86 @@ where
       _p_c2: Default::default(),
     };
 
-    // set the digest in pp
-    pp.digest = compute_digest::<G1, PublicParams<G1, G2, C1, C2>>(&[&pp]);
-
-    pp
+    self.init(pp);
+    self
   }
+}
 
+/// A type that holds public parameters of Nova
+#[derive(Clone, PartialEq, Serialize, Deserialize, Abomonation)]
+#[serde(bound = "")]
+#[abomonation_bounds(
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+  <G1::Scalar as PrimeField>::Repr: Abomonation,
+  <G2::Scalar as PrimeField>::Repr: Abomonation,
+)]
+pub struct PublicParams<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  F_arity_primary: usize,
+  F_arity_secondary: usize,
+  ro_consts_primary: ROConstants<G1>,
+  ro_consts_circuit_primary: ROConstantsCircuit<G2>,
+  ck_primary: CommitmentKey<G1>,
+  r1cs_shape_primary: R1CSShape<G1>,
+  ro_consts_secondary: ROConstants<G2>,
+  ro_consts_circuit_secondary: ROConstantsCircuit<G1>,
+  ck_secondary: CommitmentKey<G2>,
+  r1cs_shape_secondary: R1CSShape<G2>,
+  augmented_circuit_params_primary: NovaAugmentedCircuitParams,
+  augmented_circuit_params_secondary: NovaAugmentedCircuitParams,
+  #[abomonate_with(<G1::Scalar as PrimeField>::Repr)]
+  digest: G1::Scalar, // digest of everything else with this field set to G1::Scalar::ZERO
+  _p_c1: PhantomData<C1>,
+  _p_c2: PhantomData<C2>,
+}
+
+impl<G1, G2, C1, C2> SimpleDigestible for PublicParams<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+}
+
+impl<G1, G2, C1, C2> HasDigest<G1::Scalar> for PublicParams<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  fn set_digest(&mut self, digest: G1::Scalar) {
+    self.digest = digest;
+  }
+}
+impl<G1, G2, C1, C2> PublicParams<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  /// Convenience method to construct `PublicParams` via `PublicParamsBuilder`.
+  pub fn setup(
+    c_primary: &C1,
+    c_secondary: &C2,
+    optfn1: Option<CommitmentKeyHint<G1>>,
+    optfn2: Option<CommitmentKeyHint<G2>>,
+  ) -> Self {
+    DigestBuilder::<G1::Scalar, Self>::new()
+      .setup(c_primary, c_secondary, optfn1, optfn2)
+      .build()
+  }
   /// Returns the number of constraints in the primary and secondary circuits
   pub const fn num_constraints(&self) -> (usize, usize) {
     (
@@ -863,36 +903,6 @@ type CommitmentKey<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::Commitme
 type Commitment<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment;
 type CompressedCommitment<G> = <<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
 type CE<G> = <G as Group>::CE;
-
-/// compute digest giving a collection of Serialize object
-pub fn compute_digest<G: Group, T: Serialize>(o: &[&T]) -> G::Scalar {
-  // obtain a vector of bytes representing public parameters
-  let mut bytes = vec![];
-  o.iter()
-    .for_each(|o| bytes.extend(bincode::serialize(*o).unwrap()));
-  // convert pp_bytes into a short digest
-  let mut hasher = Sha3_256::new();
-  hasher.update(&bytes);
-  let digest = hasher.finalize();
-
-  // truncate the digest to NUM_HASH_BITS bits
-  let bv = (0..NUM_HASH_BITS).map(|i| {
-    let (byte_pos, bit_pos) = (i / 8, i % 8);
-    let bit = (digest[byte_pos] >> bit_pos) & 1;
-    bit == 1
-  });
-
-  // turn the bit vector into a scalar
-  let mut digest = G::Scalar::ZERO;
-  let mut coeff = G::Scalar::ONE;
-  for bit in bv {
-    if bit {
-      digest += coeff;
-    }
-    coeff += coeff;
-  }
-  digest
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,7 @@ mod tests {
     // this tests public parameters with a size specifically intended for a spark-compressed SNARK
     let pp_hint1 = Some(S1Prime::<G1>::commitment_key_floor());
     let pp_hint2 = Some(S2Prime::<G2>::commitment_key_floor());
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2);
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2).unwrap();
 
     let digest_str = pp
       .digest
@@ -1070,7 +1070,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, None, None)
+    .unwrap();
 
     let num_steps = 1;
 
@@ -1127,7 +1128,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1216,7 +1218,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1318,7 +1321,8 @@ mod tests {
       &circuit_secondary,
       Some(S1Prime::commitment_key_floor()),
       Some(S2Prime::commitment_key_floor()),
-    );
+    )
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1481,7 +1485,8 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1560,7 +1565,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, None, None)
+    .unwrap();
 
     let num_steps = 1;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -3,7 +3,7 @@
 //! The verifier in this preprocessing SNARK maintains a commitment to R1CS matrices. This is beneficial when using a
 //! polynomial commitment scheme in which the verifier's costs is succinct.
 use crate::{
-  compute_digest,
+  digest::{DigestBuilder, HasDigest, SimpleDigestible},
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
   spartan::{
@@ -690,6 +690,8 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   digest: G::Scalar,
 }
 
+impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
+
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
@@ -859,6 +861,32 @@ where
   }
 }
 
+impl<G: Group, EE: EvaluationEngineTrait<G>> HasDigest<G::Scalar> for VerifierKey<G, EE> {
+  fn set_digest(&mut self, digest: G::Scalar) {
+    self.digest = digest;
+  }
+}
+
+impl<G: Group, EE: EvaluationEngineTrait<G>> DigestBuilder<G::Scalar, VerifierKey<G, EE>> {
+  fn setup(
+    &mut self,
+    num_cons: usize,
+    num_vars: usize,
+    S_comm: R1CSShapeSparkCommitment<G>,
+    vk_ee: EE::VerifierKey,
+  ) -> &mut Self {
+    let vk = VerifierKey {
+      num_cons,
+      num_vars,
+      S_comm,
+      vk_ee,
+      digest: Default::default(),
+    };
+    self.init(vk);
+    self
+  }
+}
+
 impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE>
 where
   <G::Scalar as PrimeField>::Repr: Abomonation,
@@ -887,17 +915,9 @@ where
     let S_repr = R1CSShapeSparkRepr::new(&S);
     let S_comm = S_repr.commit(ck);
 
-    let vk = {
-      let mut vk = VerifierKey {
-        num_cons: S.num_cons,
-        num_vars: S.num_vars,
-        S_comm: S_comm.clone(),
-        vk_ee,
-        digest: G::Scalar::ZERO,
-      };
-      vk.digest = compute_digest::<G, VerifierKey<G, EE>>(&[&vk]);
-      vk
-    };
+    let vk = DigestBuilder::<G::Scalar, VerifierKey<G, EE>>::new()
+      .setup(S.num_cons, S.num_vars, S_comm.clone(), vk_ee)
+      .build();
 
     let pk = ProverKey {
       pk_ee,

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -57,14 +57,13 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> HasDigest<G::Scalar> for VerifierKe
 }
 
 impl<G: Group, EE: EvaluationEngineTrait<G>> DigestBuilder<G::Scalar, VerifierKey<G, EE>> {
-  fn setup(&mut self, shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> &mut Self {
+  fn setup(shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> Self {
     let vk = VerifierKey {
       vk_ee,
       S: shape,
       digest: G::Scalar::ZERO,
     };
-    self.init(vk);
-    self
+    Self::new(vk)
   }
 }
 
@@ -99,9 +98,9 @@ where
 
     let S = S.pad();
 
-    let vk = DigestBuilder::<G::Scalar, VerifierKey<G, EE>>::new()
-      .setup(S.clone(), vk_ee)
-      .build();
+    let vk = DigestBuilder::<G::Scalar, VerifierKey<G, EE>>::setup(S.clone(), vk_ee)
+      .build()
+      .map_err(|_| NovaError::DigestError)?;
 
     let pk = ProverKey {
       pk_ee,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -189,9 +189,9 @@ where
   C2: StepCircuit<G2::Scalar>,
 {
   /// Indexed `RunningClaim`s
-  pub claims: Vec<RunningClaim<G1, G2, C1, C2>>,
+  claims: Vec<RunningClaim<G1, G2, C1, C2>>,
   /// Digest constructed from these `RunningClaim`s' parameters
-  pub digest: G1::Scalar,
+  digest: G1::Scalar,
 }
 
 impl<G1, G2, C1, C2> Index<usize> for RunningClaims<G1, G2, C1, C2>
@@ -279,6 +279,11 @@ where
     digest_builder.setup(claims);
 
     digest_builder.build()
+  }
+
+  /// Return the `RunningClaims`' digest.
+  pub fn digest(&self) -> G1::Scalar {
+    self.digest
   }
 }
 

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -1,5 +1,6 @@
 //! This library implements SuperNova, a Non-Uniform IVC based on Nova.
 
+use std::io;
 use std::marker::PhantomData;
 use std::ops::Index;
 
@@ -227,10 +228,11 @@ where
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  fn extend_bytes<X: Extend<u8>>(&self, bytes: &mut X) {
+  fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error> {
     for claim in &self.claims {
-      claim.get_public_params().extend_bytes(bytes);
+      claim.get_public_params().write_bytes(byte_sink)?;
     }
+    Ok(())
   }
 }
 
@@ -241,7 +243,7 @@ where
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  fn setup(&mut self, mut claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> &mut Self {
+  fn setup(mut claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
     let running_claim_params = claims
       .iter()
       .map(|c| c.get_public_params())
@@ -255,8 +257,7 @@ where
 
     let running_claims = RunningClaims::new(claims);
 
-    self.init(running_claims);
-    self
+    Self::new(running_claims)
   }
 }
 
@@ -274,9 +275,8 @@ where
     }
   }
 
-  fn setup(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
-    let mut digest_builder = DigestBuilder::<G1::Scalar, RunningClaims<G1, G2, C1, C2>>::new();
-    digest_builder.setup(claims);
+  fn setup(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Result<Self, io::Error> {
+    let digest_builder = DigestBuilder::<G1::Scalar, RunningClaims<G1, G2, C1, C2>>::setup(claims);
 
     digest_builder.build()
   }
@@ -951,7 +951,9 @@ where
   }
 
   /// Initialize and return initial running claims.
-  fn setup_running_claims(&self) -> RunningClaims<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>> {
+  fn setup_running_claims(
+    &self,
+  ) -> Result<RunningClaims<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>>, io::Error> {
     let running_claims = (0..self.num_circuits())
       .map(|i| {
         RunningClaim::new(

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -1,10 +1,12 @@
 //! This library implements SuperNova, a Non-Uniform IVC based on Nova.
 
 use std::marker::PhantomData;
+use std::ops::Index;
 
 use crate::{
   bellpepper::shape_cs::ShapeCS,
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
+  digest::{DigestBuilder, Digestible, HasDigest, SimpleDigestible},
   errors::NovaError,
   r1cs::{
     commitment_key, commitment_key_size, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance,
@@ -12,7 +14,7 @@ use crate::{
   },
   scalar_as_base,
   traits::{
-    circuit_supernova::{EnforcingStepCircuit, TrivialSecondaryCircuit},
+    circuit_supernova::{EnforcingStepCircuit, StepCircuit, TrivialSecondaryCircuit},
     commitment::CommitmentTrait,
     AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROTrait,
   },
@@ -29,7 +31,6 @@ use crate::bellpepper::{
 };
 use bellpepper_core::ConstraintSystem;
 
-use crate::compute_digest;
 use crate::nifs::NIFS;
 
 mod circuit; // declare the module first
@@ -65,6 +66,13 @@ where
   r1cs_shape_secondary: R1CSShape<G2>,
   augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
   augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
+}
+
+impl<G1, G2> SimpleDigestible for PublicParams<G1, G2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+{
 }
 
 impl<G1, G2> PublicParams<G1, G2>
@@ -170,6 +178,108 @@ where
   c_primary: C1,
   c_secondary: C2,
   params: PublicParams<G1, G2>,
+}
+
+/// Indexed list of `RunningClaim`s representing an NIVC computation in process.
+pub struct RunningClaims<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  /// Indexed `RunningClaim`s
+  pub claims: Vec<RunningClaim<G1, G2, C1, C2>>,
+  /// Digest constructed from these `RunningClaim`s' parameters
+  pub digest: G1::Scalar,
+}
+
+impl<G1, G2, C1, C2> Index<usize> for RunningClaims<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  type Output = RunningClaim<G1, G2, C1, C2>;
+
+  fn index(&self, index: usize) -> &Self::Output {
+    &self.claims[index]
+  }
+}
+
+impl<G1, G2, C1, C2> HasDigest<G1::Scalar> for RunningClaims<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  fn set_digest(&mut self, digest: G1::Scalar) {
+    self.digest = digest;
+  }
+}
+
+impl<G1, G2, C1, C2> Digestible for RunningClaims<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  fn extend_bytes<X: Extend<u8>>(&self, bytes: &mut X) {
+    for claim in &self.claims {
+      claim.get_public_params().extend_bytes(bytes);
+    }
+  }
+}
+
+impl<G1, G2, C1, C2> DigestBuilder<G1::Scalar, RunningClaims<G1, G2, C1, C2>>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  fn setup(&mut self, mut claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> &mut Self {
+    let running_claim_params = claims
+      .iter()
+      .map(|c| c.get_public_params())
+      .collect::<Vec<_>>();
+
+    let (ck_primary, ck_secondary) = compute_commitment_keys(&running_claim_params);
+
+    for claim in &mut claims {
+      claim.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
+    }
+
+    let running_claims = RunningClaims::new(claims);
+
+    self.init(running_claims);
+    self
+  }
+}
+
+impl<G1, G2, C1, C2> RunningClaims<G1, G2, C1, C2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+{
+  fn new(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
+    Self {
+      claims,
+      digest: Default::default(),
+    }
+  }
+
+  fn setup(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
+    let mut digest_builder = DigestBuilder::<G1::Scalar, RunningClaims<G1, G2, C1, C2>>::new();
+    digest_builder.setup(claims);
+
+    digest_builder.build()
+  }
 }
 
 impl<G1, G2, C1, C2> RunningClaim<G1, G2, C1, C2>
@@ -835,11 +945,9 @@ where
     G1::Scalar::ZERO
   }
 
-  /// Return the initial running claims for `NonUniformCircuit`'s sub-circuits.
-  fn initial_running_claims(
-    &self,
-  ) -> Vec<RunningClaim<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>>> {
-    (0..self.num_circuits())
+  /// Initialize and return initial running claims.
+  fn setup_running_claims(&self) -> RunningClaims<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>> {
+    let running_claims = (0..self.num_circuits())
       .map(|i| {
         RunningClaim::new(
           i,
@@ -848,37 +956,9 @@ where
           self.num_circuits(),
         )
       })
-      .collect()
-  }
+      .collect();
 
-  /// Return digest and initial running claims.
-  fn compute_digest_and_initial_running_claims(
-    &self,
-  ) -> (
-    G1::Scalar,
-    Vec<RunningClaim<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>>>,
-  ) {
-    let mut running_claims = self.initial_running_claims();
-
-    let running_claim_params = running_claims
-      .iter()
-      .map(|c| c.get_public_params())
-      .collect::<Vec<_>>();
-
-    let (ck_primary, ck_secondary) = compute_commitment_keys(&running_claim_params);
-
-    for claim in &mut running_claims {
-      claim.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
-    }
-
-    let public_params = running_claims
-      .iter()
-      .map(|c| c.get_public_params())
-      .collect::<Vec<_>>();
-
-    let digest = compute_digest::<G1, PublicParams<G1, G2>>(&public_params);
-
-    (digest, running_claims)
+    RunningClaims::setup(running_claims)
   }
 
   /// How many circuits are provided?

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -439,7 +439,6 @@ where
 
   let test_rom = TestROM::<G1, G2, TrivialSecondaryCircuit<G2::Scalar>>::new(rom);
   let num_steps = test_rom.num_steps();
-  let initial_program_counter = test_rom.initial_program_counter();
 
   let running_claims = test_rom.setup_running_claims().unwrap();
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -441,7 +441,7 @@ where
   let num_steps = test_rom.num_steps();
   let initial_program_counter = test_rom.initial_program_counter();
 
-  let running_claims = test_rom.setup_running_claims();
+  let running_claims = test_rom.setup_running_claims().unwrap();
 
   let initial_program_counter = test_rom.initial_program_counter();
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -474,7 +474,7 @@ where
       recursive_snark_option.unwrap_or_else(|| match augmented_circuit_index {
         OPCODE_0 | OPCODE_1 => RecursiveSNARK::iter_base_step(
           &running_claims[augmented_circuit_index],
-          running_claims.digest,
+          running_claims.digest(),
           Some(program_counter),
           augmented_circuit_index,
           test_rom.num_circuits(),

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -439,7 +439,9 @@ where
 
   let test_rom = TestROM::<G1, G2, TrivialSecondaryCircuit<G2::Scalar>>::new(rom);
   let num_steps = test_rom.num_steps();
-  let (digest, running_claims) = test_rom.compute_digest_and_initial_running_claims();
+  let initial_program_counter = test_rom.initial_program_counter();
+
+  let running_claims = test_rom.setup_running_claims();
 
   let initial_program_counter = test_rom.initial_program_counter();
 
@@ -472,7 +474,7 @@ where
       recursive_snark_option.unwrap_or_else(|| match augmented_circuit_index {
         OPCODE_0 | OPCODE_1 => RecursiveSNARK::iter_base_step(
           &running_claims[augmented_circuit_index],
-          digest,
+          running_claims.digest,
           Some(program_counter),
           augmented_circuit_index,
           test_rom.num_circuits(),


### PR DESCRIPTION
This PR implements a `DigestBuilder` and supplementary traits:
- `HasDigest`
- `Digestible`
- `SimpleDigestible`

Some elements of this PR are intended to support #31 (see #34) and #29. The goal is to begin work on a framework that will rationalize digest creation, at least across existing use cases and those in the linked issues. The present work moves us in that direction while maintaining the status quo by not affecting the values of existing digests.

Some details of the requirements implied by #29 and #31 will likely require further refactoring, but that will best be done in the context of that work rather than here. I mention this mainly to explain that the current PR is still somewhat rough and has some loose ends that will either need to be tightened up or removed later.
