### PR TITLE
Enforce program counter in SuperNova StepCircuit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rand = "0.8.4"
 flate2 = "1.0"
 hex = "0.4.3"
 pprof = { version = "0.11" }
+tracing-test = "0.2.4"
 cfg-if = "1.0.0"
 sha2 = "0.10.7"
 proptest = "1.2.0"

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -450,22 +450,3 @@ pub fn select_num_or_one<F: PrimeField, CS: ConstraintSystem<F>>(
 
   Ok(c)
 }
-
-#[allow(dead_code)]
-/// c = a + b where a, b is AllocatedNum
-pub fn add_allocated_num<F: PrimeField, CS: ConstraintSystem<F>>(
-  mut cs: CS,
-  a: &AllocatedNum<F>,
-  b: &AllocatedNum<F>,
-) -> Result<AllocatedNum<F>, SynthesisError> {
-  let c = AllocatedNum::alloc(cs.namespace(|| "c"), || {
-    Ok(*a.get_value().get()? + b.get_value().get()?)
-  })?;
-  cs.enforce(
-    || "Check u_fold",
-    |lc| lc + a.get_variable() + b.get_variable(),
-    |lc| lc + CS::one(),
-    |lc| lc + c.get_variable(),
-  );
-  Ok(c)
-}

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -28,7 +28,7 @@ use crate::{
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{
-    circuit_supernova::StepCircuit, commitment::CommitmentTrait, Group, ROCircuitTrait,
+    circuit_supernova::EnforcingStepCircuit, commitment::CommitmentTrait, Group, ROCircuitTrait,
     ROConstantsCircuit,
   },
   Commitment,
@@ -111,7 +111,7 @@ impl<'a, G: Group> SuperNovaAugmentedCircuitInputs<'a, G> {
 /// The augmented circuit F' in SuperNova that includes a step circuit F
 /// and the circuit for the verifier in SuperNova's non-interactive folding scheme,
 /// SuperNova NIFS will fold strictly r1cs instance u with respective relaxed r1cs instance U[last_augmented_circuit_index]
-pub struct SuperNovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
+pub struct SuperNovaAugmentedCircuit<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> {
   params: &'a SuperNovaAugmentedCircuitParams,
   ro_consts: ROConstantsCircuit<G>,
   inputs: Option<SuperNovaAugmentedCircuitInputs<'a, G>>,
@@ -119,7 +119,7 @@ pub struct SuperNovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
   num_augmented_circuits: usize, // number of overall augmented circuits
 }
 
-impl<'a, G: Group, SC: StepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC> {
+impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC> {
   /// Create a new verification circuit for the input relaxed r1cs instances
   pub const fn new(
     params: &'a SuperNovaAugmentedCircuitParams,
@@ -418,7 +418,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC
   }
 }
 
-impl<'a, G: Group, SC: StepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC> {
+impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC> {
   pub fn synthesize<CS: ConstraintSystem<<G as Group>::Base>>(
     self,
     cs: &mut CS,
@@ -549,7 +549,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> SuperNovaAugmentedCircuit<'a, G, SC
       &Boolean::from(is_base_case),
     )?;
 
-    let (program_counter_new, z_next) = self.step_circuit.synthesize(
+    let (program_counter_new, z_next) = self.step_circuit.enforcing_synthesize(
       &mut cs.namespace(|| "F"),
       program_counter.as_ref(),
       &z_input,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -12,7 +12,7 @@ use crate::{
   },
   scalar_as_base,
   traits::{
-    circuit_supernova::{StepCircuit, TrivialSecondaryCircuit},
+    circuit_supernova::{EnforcingStepCircuit, TrivialSecondaryCircuit},
     commitment::CommitmentTrait,
     AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROTrait,
   },
@@ -73,7 +73,10 @@ where
   G2: Group<Base = <G1 as Group>::Scalar>,
 {
   /// Create a new `PublicParams`
-  pub fn setup_without_commitkey<C1: StepCircuit<G1::Scalar>, C2: StepCircuit<G2::Scalar>>(
+  pub fn setup_without_commitkey<
+    C1: EnforcingStepCircuit<G1::Scalar>,
+    C2: EnforcingStepCircuit<G2::Scalar>,
+  >(
     c_primary: &C1,
     c_secondary: &C2,
     num_augmented_circuits: usize,
@@ -159,8 +162,8 @@ pub struct RunningClaim<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: EnforcingStepCircuit<G1::Scalar>,
+  C2: EnforcingStepCircuit<G2::Scalar>,
 {
   _phantom: PhantomData<G1>,
   augmented_circuit_index: usize,
@@ -173,8 +176,8 @@ impl<G1, G2, C1, C2> RunningClaim<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: EnforcingStepCircuit<G1::Scalar>,
+  C2: EnforcingStepCircuit<G2::Scalar>,
 {
   /// new a running claim
   pub fn new(
@@ -258,7 +261,10 @@ where
   G2: Group<Base = <G1 as Group>::Scalar>,
 {
   /// iterate base step to get new instance of recursive SNARK
-  pub fn iter_base_step<C1: StepCircuit<G1::Scalar>, C2: StepCircuit<G2::Scalar>>(
+  pub fn iter_base_step<
+    C1: EnforcingStepCircuit<G1::Scalar>,
+    C2: EnforcingStepCircuit<G2::Scalar>,
+  >(
     claim: &RunningClaim<G1, G2, C1, C2>,
     pp_digest: G1::Scalar,
     initial_program_counter: Option<G1::Scalar>,
@@ -418,7 +424,7 @@ where
     })
   }
   /// executing a step of the incremental computation
-  pub fn prove_step<C1: StepCircuit<G1::Scalar>, C2: StepCircuit<G2::Scalar>>(
+  pub fn prove_step<C1: EnforcingStepCircuit<G1::Scalar>, C2: EnforcingStepCircuit<G2::Scalar>>(
     &mut self,
     claim: &RunningClaim<G1, G2, C1, C2>,
     z0_primary: &[G1::Scalar],
@@ -609,7 +615,7 @@ where
   }
 
   /// verify recursive snark
-  pub fn verify<C1: StepCircuit<G1::Scalar>, C2: StepCircuit<G2::Scalar>>(
+  pub fn verify<C1: EnforcingStepCircuit<G1::Scalar>, C2: EnforcingStepCircuit<G2::Scalar>>(
     &mut self,
     claim: &RunningClaim<G1, G2, C1, C2>,
     z0_primary: &[G1::Scalar],
@@ -822,7 +828,7 @@ pub trait NonUniformCircuit<G1, G2, C1>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
+  C1: EnforcingStepCircuit<G1::Scalar>,
 {
   /// Initial program counter, defaults to zero.
   fn initial_program_counter(&self) -> G1::Scalar {

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -88,7 +88,7 @@ where
   F: PrimeField,
 {
   fn arity(&self) -> usize {
-    2 + self.rom_size // value + pseudo-pc + rom[].len()
+    2 + self.rom_size // value + rom_pc + rom[].len()
   }
 
   fn circuit_index(&self) -> usize {
@@ -103,17 +103,17 @@ where
   ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
     let one = alloc_one(cs.namespace(|| "alloc one"))?;
 
-    let pseudo_pc = &z[1];
+    let rom_index = &z[1];
     let allocated_rom = &z[2..];
 
-    let pseudo_pc_next = add_allocated_num(
-      // pseudo_pc = pseudo_pc + 1
-      cs.namespace(|| "pseudo_pc = pseudo_pc + 1".to_string()),
-      pseudo_pc,
+    let rom_index_next = add_allocated_num(
+      // rom_index = rom_index + 1
+      cs.namespace(|| "rom_index = rom_index + 1".to_string()),
+      rom_index,
       &one,
     )?;
     let pc_next = AllocatedNum::alloc(&mut cs.namespace(|| "pc_next"), || {
-      pseudo_pc_next
+      rom_index_next
         .get_value()
         .and_then(|f| {
           let n: u64 = u64::from_le_bytes(f.to_repr().as_ref()[0..8].try_into().unwrap());
@@ -126,7 +126,7 @@ where
     })?;
     constrain_augmented_circuit_index(
       cs.namespace(|| "CubicCircuit agumented circuit constraint"),
-      &pseudo_pc_next,
+      &rom_index_next,
       allocated_rom,
       &pc_next,
     )?;
@@ -155,7 +155,7 @@ where
     );
 
     let mut z_next = vec![y];
-    z_next.push(pseudo_pc_next);
+    z_next.push(rom_index_next);
     z_next.extend(z[2..].iter().cloned());
     Ok((Some(pc_next), z_next))
   }
@@ -186,7 +186,7 @@ where
   F: PrimeField,
 {
   fn arity(&self) -> usize {
-    2 + self.rom_size // value + pseudo-pc + rom[].len()
+    2 + self.rom_size // value + rom_pc + rom[].len()
   }
 
   fn circuit_index(&self) -> usize {
@@ -199,18 +199,18 @@ where
     _pc: Option<&AllocatedNum<F>>,
     z: &[AllocatedNum<F>],
   ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
-    let pseudo_pc = &z[1];
+    let rom_index = &z[1];
     let allocated_rom = &z[2..];
     let one = alloc_one(cs.namespace(|| "alloc one"))?;
 
-    let pseudo_pc_next = add_allocated_num(
-      // pseudo_pc = pseudo_pc + 1
-      cs.namespace(|| "pseudo_pc = pseudo_pc + 1".to_string()),
-      pseudo_pc,
+    let rom_index_next = add_allocated_num(
+      // rom_index = rom_index + 1
+      cs.namespace(|| "rom_index = rom_index + 1".to_string()),
+      rom_index,
       &one,
     )?;
     let pc_next = AllocatedNum::alloc(&mut cs.namespace(|| "pc_next"), || {
-      pseudo_pc_next
+      rom_index_next
         .get_value()
         .and_then(|f| {
           let n: u64 = u64::from_le_bytes(f.to_repr().as_ref()[0..8].try_into().unwrap());
@@ -223,7 +223,7 @@ where
     })?;
     constrain_augmented_circuit_index(
       cs.namespace(|| "SquareCircuit agumented circuit constraint"),
-      &pseudo_pc_next,
+      &rom_index_next,
       allocated_rom,
       &pc_next,
     )?;
@@ -251,7 +251,7 @@ where
     );
 
     let mut z_next = vec![y];
-    z_next.push(pseudo_pc_next);
+    z_next.push(rom_index_next);
     z_next.extend(z[2..].iter().cloned());
     Ok((Some(pc_next), z_next))
   }

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -3,7 +3,8 @@ use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use ff::PrimeField;
 
-/// A helper trait for a step of the incremental computation for SuperNova (i.e., circuit for F)
+/// A helper trait for a step of the incremental computation for SuperNova (i.e., circuit for F) -- to be implemented by
+/// applications.
 pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   /// Return the the number of inputs or outputs of each step
   /// (this method is called only at circuit synthesis time)
@@ -26,7 +27,9 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError>;
 }
 
-/// A helper trait for a step of the incremental computation for SuperNova (i.e., circuit for F)
+/// A helper trait for a step of the incremental computation for SuperNova (i.e., circuit for F) -- automatically
+/// implemented for `StepCircuit` and used internally to enforce that the circuit selected by the program counter is used
+/// at each step.
 pub trait EnforcingStepCircuit<F: PrimeField>: Send + Sync + Clone + StepCircuit<F> {
   /// Delegate synthesis to `StepCircuit::synthesize`, and additionally, enforce the constraint that program counter
   /// `pc`, if supplied, is equal to the circuit's assigned index.

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -11,6 +11,11 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   /// input a vector of size equal to arity and output a vector of size equal to arity
   fn arity(&self) -> usize;
 
+  /// Return this `StepCircuit`'s assigned index, for use when enforcing the program counter.
+  fn circuit_index(&self) -> usize {
+    0
+  }
+
   /// Sythesize the circuit for a computation step and return variable
   /// that corresponds to the output of the step pc_{i+1} and z_{i+1}
   fn synthesize<CS: ConstraintSystem<F>>(
@@ -20,6 +25,33 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
     z: &[AllocatedNum<F>],
   ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError>;
 }
+
+/// A helper trait for a step of the incremental computation for SuperNova (i.e., circuit for F)
+pub trait EnforcingStepCircuit<F: PrimeField>: Send + Sync + Clone + StepCircuit<F> {
+  /// Delegate synthesis to `StepCircuit::synthesize`, and additionally, enforce the constraint that program counter
+  /// `pc`, if supplied, is equal to the circuit's assigned index.
+  fn enforcing_synthesize<CS: ConstraintSystem<F>>(
+    &self,
+    cs: &mut CS,
+    pc: Option<&AllocatedNum<F>>,
+    z: &[AllocatedNum<F>],
+  ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
+    if let Some(pc) = pc {
+      let circuit_index = F::from(self.circuit_index() as u64);
+
+      // pc * 1 = circuit_index
+      cs.enforce(
+        || "pc matches circuit index",
+        |lc| lc + pc.get_variable(),
+        |lc| lc + CS::one(),
+        |lc| lc + (circuit_index, CS::one()),
+      );
+    }
+    self.synthesize(cs, pc, z)
+  }
+}
+
+impl<F: PrimeField, S: StepCircuit<F>> EnforcingStepCircuit<F> for S {}
 
 /// A trivial step circuit that simply returns the input
 #[derive(Clone, Debug, Default)]
@@ -47,7 +79,7 @@ where
 
 /// A trivial step circuit that simply returns the input, for use on the secondary circuit when implementing NIVC.
 /// NOTE: This should not be needed. The secondary circuit doesn't need the program counter at all.
-/// Ideally, the need this fills could be met byt `traits::circuit::TrivialTestCircuit` (or equivalent).
+/// Ideally, the need this fills could be met by `traits::circuit::TrivialTestCircuit` (or equivalent).
 #[derive(Clone, Debug, Default)]
 pub struct TrivialSecondaryCircuit<F: PrimeField> {
   _p: PhantomData<F>,


### PR DESCRIPTION
This PR formalizes the requirement that the new program counter returned from `circuit_supernova::StepCircuit::synthesize()` is the one assigned to the circuit that is actually synthesized at each step.

The previous `TestROM` example actually did *not* follow this convention but rather used the program counter for its own purposes, as an index into a predetermined sequence of operations — then enforced the correctness of this ad-hoc indexing scheme in each circuit.

The current work enforces the constraint that `pc` has been correctly calculated and returned from each circuit, requiring that it is interpreted precisely as that circuit's assigned index in the `RunningClaim`s.

In order to make the existing tests pass, they were reworked to re-envision the pseudo-pc enforcement at the start of each circuit — to a calculation (morally $\varphi$) of the new `pc` to be returned at the 'end' of the circuit. Without this change, the existing tests fail, exactly as expected, since `pc` was a monotonically increasing value, rather than the index of the chosen next circuit.

The circuit necessarily grows by one constraint.

Since the goal is that for the SuperNova user (the application/protocol/proof developer), the enforcement is performed by a new, internal trait `circuit_supernova::EnforcingStepCircuit` — which is automatically implemented for types that implement `circuit_supernova::StepCircuit`.