### PR TITLE
refactor: Refactor DigestBuilder

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -71,7 +71,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &c_secondary,
       Some(S1::commitment_key_floor()),
       Some(S2::commitment_key_floor()),
-    );
+    )
+    .unwrap();
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -163,7 +164,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &c_secondary,
       Some(SS1::commitment_key_floor()),
       Some(SS2::commitment_key_floor()),
-    );
+    )
+    .unwrap();
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
 

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -99,7 +99,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(1, num_cons);
-    let running_claims = bench.setup_running_claims();
+    let running_claims = bench.setup_running_claims().unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -192,7 +192,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(2, num_cons);
-    let running_claims = bench.setup_running_claims();
+    let running_claims = bench.setup_running_claims().unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None).unwrap();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialTestCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None).unwrap();
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -160,7 +160,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot_serde.rs
+++ b/examples/minroot_serde.rs
@@ -167,7 +167,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     println!("PublicParams::setup, took {:?} ", start.elapsed());
     encode(&pp, &mut file).unwrap()
   };
@@ -193,7 +194,8 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
     assert!(result.clone() == pp, "not equal!");
     assert!(remaining.is_empty());
   } else {

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -46,6 +46,10 @@ impl<T: SimpleDigestible> Digestible for T {
 impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
   /// Return a new `DigestBuilder` for a value
   pub fn new(value: T) -> Self {
+    dbg!(
+      NUM_HASH_BITS,
+      <Sha3_256 as OutputSizeUser>::OutputSize::to_usize()
+    );
     assert!(
       NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize(),
       "DigestBuilder only supports hashes with output over 250 bits"

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -79,19 +79,16 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
     digest
   }
 
-  /// Extend `DigestBuilder` with the bytes provided by the underlying inner `HasDigest`.
-  fn compute_digest(&mut self, value: &T) -> Result<F, io::Error> {
-    let mut hasher = Self::hasher();
-    value.write_bytes(&mut hasher)?;
-    let mut bytes: [u8; 32] = hasher.finalize().into();
-    Ok(Self::map_to_field(&mut bytes))
-  }
-
   /// Build and return inner `Digestible`.
   pub fn build(mut self) -> Result<T, io::Error> {
-    let digest = self.compute_digest(&self.inner)?;
+    let mut hasher = Self::hasher();
+    self.inner.write_bytes(&mut hasher)?;
+    let mut bytes: [u8; 32] = hasher.finalize().into();
+    self.inner.set_digest(Self::map_to_field(&mut bytes));
 
-    self.inner.set_digest(digest);
+    // let digest = self.compute_digest(&self.inner)?;
+
+    // self.inner.set_digest(digest);
     Ok(self.inner)
   }
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -51,8 +51,8 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
       <Sha3_256 as OutputSizeUser>::OutputSize::to_usize()
     );
     assert!(
-      NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize(),
-      "DigestBuilder only supports hashes with output over 250 bits"
+      NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize() * 8,
+      "DigestBuilder only supports hashes with output over {NUM_HASH_BITS} bits"
     );
     Self {
       inner: value,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,4 +59,7 @@ pub enum NovaError {
   /// return when error during synthesis
   #[error("SynthesisError")]
   SynthesisError,
+  /// returned when there is an error creating a digest
+  #[error("DigestError")]
+  DigestError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod traits;
 
 pub mod supernova;
 
+use std::io;
+
 use crate::bellpepper::{
   r1cs::{NovaShape, NovaWitness},
   shape_cs::ShapeCS,
@@ -105,12 +107,11 @@ where
   /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
   /// ```
   pub fn setup(
-    &mut self,
     c_primary: &C1,
     c_secondary: &C2,
     optfn1: Option<CommitmentKeyHint<G1>>,
     optfn2: Option<CommitmentKeyHint<G2>>,
-  ) -> &mut Self {
+  ) -> Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let augmented_circuit_params_secondary =
@@ -166,8 +167,7 @@ where
       _p_c2: Default::default(),
     };
 
-    self.init(pp);
-    self
+    Self::new(pp)
   }
 }
 
@@ -241,10 +241,8 @@ where
     c_secondary: &C2,
     optfn1: Option<CommitmentKeyHint<G1>>,
     optfn2: Option<CommitmentKeyHint<G2>>,
-  ) -> Self {
-    DigestBuilder::<G1::Scalar, Self>::new()
-      .setup(c_primary, c_secondary, optfn1, optfn2)
-      .build()
+  ) -> Result<Self, io::Error> {
+    DigestBuilder::<G1::Scalar, Self>::setup(c_primary, c_secondary, optfn1, optfn2).build()
   }
   /// Returns the number of constraints in the primary and secondary circuits
   pub const fn num_constraints(&self) -> (usize, usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,7 @@ mod tests {
     // this tests public parameters with a size specifically intended for a spark-compressed SNARK
     let pp_hint1 = Some(S1Prime::<G1>::commitment_key_floor());
     let pp_hint2 = Some(S2Prime::<G2>::commitment_key_floor());
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2);
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2).unwrap();
 
     let digest_str = pp
       .digest
@@ -1070,7 +1070,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, None, None)
+    .unwrap();
 
     let num_steps = 1;
 
@@ -1127,7 +1128,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1216,7 +1218,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1318,7 +1321,8 @@ mod tests {
       &circuit_secondary,
       Some(S1Prime::commitment_key_floor()),
       Some(S2Prime::commitment_key_floor()),
-    );
+    )
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1481,7 +1485,8 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, None, None)
+    .unwrap();
 
     let num_steps = 3;
 
@@ -1560,7 +1565,8 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, None, None)
+    .unwrap();
 
     let num_steps = 1;
 

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -57,14 +57,13 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> HasDigest<G::Scalar> for VerifierKe
 }
 
 impl<G: Group, EE: EvaluationEngineTrait<G>> DigestBuilder<G::Scalar, VerifierKey<G, EE>> {
-  fn setup(&mut self, shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> &mut Self {
+  fn setup(shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> Self {
     let vk = VerifierKey {
       vk_ee,
       S: shape,
       digest: G::Scalar::ZERO,
     };
-    self.init(vk);
-    self
+    Self::new(vk)
   }
 }
 
@@ -99,9 +98,9 @@ where
 
     let S = S.pad();
 
-    let vk = DigestBuilder::<G::Scalar, VerifierKey<G, EE>>::new()
-      .setup(S.clone(), vk_ee)
-      .build();
+    let vk = DigestBuilder::<G::Scalar, VerifierKey<G, EE>>::setup(S.clone(), vk_ee)
+      .build()
+      .map_err(|_| NovaError::DigestError)?;
 
     let pk = ProverKey {
       pk_ee,

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -383,7 +383,7 @@ where
   let num_steps = test_rom.num_steps();
   let initial_program_counter = test_rom.initial_program_counter();
 
-  let running_claims = test_rom.setup_running_claims();
+  let running_claims = test_rom.setup_running_claims().unwrap();
 
   // extend z0_primary/secondary with rom content
   let mut z0_primary = vec![<G1 as Group>::Scalar::ONE];


### PR DESCRIPTION
- Refactored `src/digest.rs` to replace `Vec<u8>` storage with dedicated Write I/O.
- Removed optional `hasher` and introduced dedicated factory method.
- Reworked digest computation and mapping into separate functions.
- Merged build and digest computation to enhance coherence.
- Improved type safety with Result error propagation.