### PR TITLE
Derive Abomonation for SuperNova PublicParams.

### DIFF
--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -41,12 +41,13 @@ use bellpepper_core::{
 
 use bellpepper::gadgets::Assignment;
 
+use abomonation_derive::Abomonation;
 use ff::Field;
 use serde::{Deserialize, Serialize};
 
 use super::utils::get_from_vec_alloc_relaxed_r1cs;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 pub struct SuperNovaAugmentedCircuitParams {
   limb_width: usize,
   n_limbs: usize,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -19,7 +19,9 @@ use crate::{
   Commitment, CommitmentKey,
 };
 
-use ff::Field;
+use abomonation::Abomonation;
+use abomonation_derive::Abomonation;
+use ff::{Field, PrimeField};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -46,8 +48,16 @@ pub(crate) mod utils;
 mod test;
 
 /// A type that holds public parameters of Nova
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
+#[abomonation_bounds(
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  <G1::Scalar as PrimeField>::Repr: Abomonation,
+  <G2::Scalar as PrimeField>::Repr: Abomonation,
+)]
+
 pub struct PublicParams<G1, G2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,


### PR DESCRIPTION
This will be needed for fast parameter loading for SuperNova.