### PR TITLE
Support non-determinism in NIVC circuits.

### DIFF
--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -251,7 +251,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       } else if selected_augmented_circuit == 1 {
         let res = recursive_snark.prove_step(
           &running_claims[1],
-          &bench.primary_circuit(0),
+          &bench.primary_circuit(1),
           &z0_primary,
           &z0_secondary,
         );

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -120,6 +120,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
           &running_claims[0],
+          &bench.primary_circuit(0),
           running_claims.digest(),
           Some(program_counter),
           0,
@@ -130,7 +131,12 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         .unwrap()
       });
 
-      let res = recursive_snark.prove_step(&running_claims[0], &z0_primary, &z0_secondary);
+      let res = recursive_snark.prove_step(
+        &running_claims[0],
+        &bench.primary_circuit(0),
+        &z0_primary,
+        &z0_secondary,
+      );
       if let Err(e) = &res {
         println!("res failed {:?}", e);
       }
@@ -153,6 +159,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         assert!(black_box(&mut recursive_snark.clone())
           .prove_step(
             black_box(&running_claims[0]),
+            &bench.primary_circuit(0),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
@@ -214,6 +221,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
         RecursiveSNARK::iter_base_step(
           &running_claims[0],
+          &bench.primary_circuit(0),
           running_claims.digest(),
           Some(program_counter),
           0,
@@ -225,7 +233,12 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
       });
 
       if selected_augmented_circuit == 0 {
-        let res = recursive_snark.prove_step(&running_claims[0], &z0_primary, &z0_secondary);
+        let res = recursive_snark.prove_step(
+          &running_claims[0],
+          &bench.primary_circuit(0),
+          &z0_primary,
+          &z0_secondary,
+        );
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -236,7 +249,12 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
         }
         assert!(res.is_ok());
       } else if selected_augmented_circuit == 1 {
-        let res = recursive_snark.prove_step(&running_claims[1], &z0_primary, &z0_secondary);
+        let res = recursive_snark.prove_step(
+          &running_claims[1],
+          &bench.primary_circuit(0),
+          &z0_primary,
+          &z0_secondary,
+        );
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -263,6 +281,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
         assert!(black_box(&mut recursive_snark.clone())
           .prove_step(
             black_box(&running_claims[0]),
+            &bench.primary_circuit(0),
             black_box(&[<G1 as Group>::Scalar::from(2u64)]),
             black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -181,12 +181,10 @@ pub struct RunningClaim<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: EnforcingStepCircuit<G1::Scalar>,
   C2: EnforcingStepCircuit<G2::Scalar>,
 {
-  _phantom: PhantomData<G1>,
+  _phantom: PhantomData<C1>,
   augmented_circuit_index: usize,
-  c_primary: C1,
   c_secondary: C2,
   params: PublicParams<G1, G2>,
 }
@@ -311,18 +309,17 @@ where
     circuit_secondary: C2,
     num_augmented_circuits: usize,
   ) -> Self {
-    let claim = circuit_primary;
-
     let pp = PublicParams::<G1, G2>::setup_without_commitkey(
-      &claim,
+      &circuit_primary,
       &circuit_secondary,
       num_augmented_circuits,
     );
 
+    // The `PublicParams` reflect the primary circuit, so there is no need to hold an independent copy, since that copy
+    // would lack step-specific non-deterministic hints.
     Self {
       augmented_circuit_index,
       _phantom: PhantomData,
-      c_primary: claim,
       c_secondary: circuit_secondary,
       params: pp,
     }
@@ -386,11 +383,13 @@ where
   G2: Group<Base = <G1 as Group>::Scalar>,
 {
   /// iterate base step to get new instance of recursive SNARK
+  #[allow(clippy::too_many_arguments)]
   pub fn iter_base_step<
     C1: EnforcingStepCircuit<G1::Scalar>,
     C2: EnforcingStepCircuit<G2::Scalar>,
   >(
     claim: &RunningClaim<G1, G2, C1, C2>,
+    c_primary: &C1,
     pp_digest: G1::Scalar,
     initial_program_counter: Option<G1::Scalar>,
     first_augmented_circuit_index: usize,
@@ -399,7 +398,6 @@ where
     z0_secondary: &[G2::Scalar],
   ) -> Result<Self, SuperNovaError> {
     let pp = &claim.get_public_params();
-    let c_primary = &claim.c_primary;
     let c_secondary = &claim.c_secondary;
     // commitment key for primary & secondary circuit
     let ck_primary = pp.ck_primary.as_ref().ok_or(SuperNovaError::MissingCK)?;
@@ -549,9 +547,11 @@ where
     })
   }
   /// executing a step of the incremental computation
+  #[allow(clippy::too_many_arguments)]
   pub fn prove_step<C1: EnforcingStepCircuit<G1::Scalar>, C2: EnforcingStepCircuit<G2::Scalar>>(
     &mut self,
     claim: &RunningClaim<G1, G2, C1, C2>,
+    c_primary: &C1,
     z0_primary: &[G1::Scalar],
     z0_secondary: &[G2::Scalar],
   ) -> Result<(), SuperNovaError> {
@@ -566,7 +566,6 @@ where
     }
 
     let pp = &claim.params;
-    let c_primary = &claim.c_primary;
     let c_secondary = &claim.c_secondary;
     // commitment key for primary & secondary circuit
     let ck_primary = pp.ck_primary.as_ref().ok_or(SuperNovaError::MissingCK)?;

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -181,6 +181,7 @@ pub struct RunningClaim<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: EnforcingStepCircuit<G1::Scalar>,
   C2: EnforcingStepCircuit<G2::Scalar>,
 {
   _phantom: PhantomData<C1>,

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -277,6 +277,7 @@ where
 fn print_constraints_name_on_error_index<G1, G2, C1, C2>(
   err: &SuperNovaError,
   running_claim: &RunningClaim<G1, G2, C1, C2>,
+  c_primary: &C1,
   num_augmented_circuits: usize,
 ) where
   G1: Group<Base = <G2 as Group>::Scalar>,
@@ -289,7 +290,7 @@ fn print_constraints_name_on_error_index<G1, G2, C1, C2>(
       let circuit_primary: SuperNovaAugmentedCircuit<'_, G2, C1> = SuperNovaAugmentedCircuit::new(
         &running_claim.params.augmented_circuit_params_primary,
         None,
-        &running_claim.c_primary,
+        c_primary,
         running_claim.params.ro_consts_circuit_primary.clone(),
         num_augmented_circuits,
       );
@@ -473,6 +474,7 @@ where
       recursive_snark_option.unwrap_or_else(|| match augmented_circuit_index {
         OPCODE_0 | OPCODE_1 => RecursiveSNARK::iter_base_step(
           &running_claims[augmented_circuit_index],
+          &test_rom.primary_circuit(augmented_circuit_index),
           running_claims.digest(),
           Some(program_counter),
           augmented_circuit_index,
@@ -487,9 +489,11 @@ where
       });
     match augmented_circuit_index {
       OPCODE_0 | OPCODE_1 => {
+        let circuit_primary = test_rom.primary_circuit(augmented_circuit_index);
         recursive_snark
           .prove_step(
             &running_claims[augmented_circuit_index],
+            &circuit_primary,
             &z0_primary,
             &z0_secondary,
           )
@@ -504,6 +508,7 @@ where
             print_constraints_name_on_error_index(
               &err,
               &running_claims[augmented_circuit_index],
+              &circuit_primary,
               test_rom.num_circuits(),
             )
           })


### PR DESCRIPTION
The initial SuperNova implementation diverged from Nova's pattern for non-deterministic step proofs — by saving a prototype circuit in the `RunningClaim` then reusing it with new 'public' inputs at each step. However, since each step's computation may depend on non-deterministic private inputs, `prove_step` actually needs to receive an instance of the primary circuit per-step.

This PR accomplishes that but continues to use the previous method for the secondary circuit, on the theory that the approach to NIVC implemented and supported here assumes and requires that a trivial deterministic function will be proved in the secondary circuit.

Because downstream work depends on this change, this PR is a minimal patch. Future work should add a test modeled on the equivalent Nova test, exercising the change through an example that requires it.