### PR TITLE
ci: Switch `!benchmark` action to larger cloud-hosted runners

### DIFF
--- a/.github/workflows/bench_pr_comment.yml
+++ b/.github/workflows/bench_pr_comment.yml
@@ -39,7 +39,7 @@ jobs:
 
   recursive-benchmark:
     name: run benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-benchmark-runner
     if:
       github.event.issue.pull_request
       && github.event.issue.state == 'open'
@@ -64,7 +64,7 @@ jobs:
 
   spartan-benchmark:
     name: run benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-benchmark-runner
     needs: changes
     if:
       github.event.issue.pull_request
@@ -91,7 +91,7 @@ jobs:
 
   supernova-benchmark:
     name: run benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-benchmark-runner
     needs: changes
     if:
       github.event.issue.pull_request


### PR DESCRIPTION
Currently the `!benchmark` comment action takes over an hour on some runs while testing:
- `ubuntu-latest`: https://github.com/samuelburnham/arecibo/actions/runs/6152060907
- `self-hosted`: https://github.com/samuelburnham/arecibo/actions/runs/6154107492

This PR switches to an 8-core, 32GB RAM cloud-hosted runner that will autoscale up to 50 concurrent tasks, each with their own machine. Unfortunately it is impossible to test on forks, but it will likely be significantly faster than `ubuntu-latest` (2-core, 7GB RAM) and will save money versus running on self-hosted infra.