### PR TITLE
feat: add a digest to R1CSShape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tracing = "0.1.37"
 tracing-texray = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
+once_cell = "1.18.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -66,13 +66,12 @@ fn bench_compressed_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+    let pp = PublicParams::<G1, G2, C1, C2>::new(
       &c_primary,
       &c_secondary,
       Some(S1::commitment_key_floor()),
       Some(S2::commitment_key_floor()),
-    )
-    .unwrap();
+    );
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -159,13 +158,12 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+    let pp = PublicParams::<G1, G2, C1, C2>::new(
       &c_primary,
       &c_secondary,
       Some(SS1::commitment_key_floor()),
       Some(SS2::commitment_key_floor()),
-    )
-    .unwrap();
+    );
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
 

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -27,7 +27,7 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<G1, G2, C1, C2>::setup(
+      PublicParams::<G1, G2, C1, C2>::new(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
         black_box(None),

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -99,7 +99,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(1, num_cons);
-    let running_claims = bench.setup_running_claims().unwrap();
+    let running_claims = bench.setup_running_claims();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing
@@ -199,7 +199,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
     let bench: NonUniformBench<G1, G2, TrivialTestCircuit<<G2 as Group>::Scalar>> =
       NonUniformBench::new(2, num_cons);
-    let running_claims = bench.setup_running_claims().unwrap();
+    let running_claims = bench.setup_running_claims();
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None).unwrap();
+    let pp = PublicParams::<G1, G2, C1, C2>::new(&c_primary, &c_secondary, None, None);
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialTestCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None).unwrap();
+    let pp = PublicParams::<G1, G2, C1, C2>::new(&circuit_primary, &ttc, None, None);
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -169,8 +169,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None)
-    .unwrap();
+    >::new(&circuit_primary, &circuit_secondary, None, None);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot_serde.rs
+++ b/examples/minroot_serde.rs
@@ -167,8 +167,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None)
-    .unwrap();
+    >::new(&circuit_primary, &circuit_secondary, None, None);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
     encode(&pp, &mut file).unwrap()
   };
@@ -194,8 +193,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None)
-    .unwrap();
+    >::new(&circuit_primary, &circuit_secondary, None, None);
     assert!(result.clone() == pp, "not equal!");
     assert!(remaining.is_empty());
   } else {

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -24,12 +24,6 @@ pub trait HasDigest<F: PrimeField> {
 pub trait Digestible {
   /// Write the byte representation of Self in a byte buffer
   fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error>;
-  /// allocate and exhibit the bytes for the type in question
-  fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {
-    let mut v: Vec<u8> = Vec::new();
-    self.write_bytes(&mut v)?;
-    Ok(v)
-  }
 }
 
 /// Marker trait to be implemented for types that implement `Digestible` and `Serialize`.

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,3 +1,4 @@
+use bincode::Options;
 use digest::{typenum::Unsigned, OutputSizeUser};
 use ff::PrimeField;
 use serde::Serialize;
@@ -32,7 +33,12 @@ pub trait SimpleDigestible: Serialize {}
 
 impl<T: SimpleDigestible> Digestible for T {
   fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error> {
-    bincode::serialize_into(byte_sink, self)
+    let config = bincode::DefaultOptions::new()
+      .with_little_endian()
+      .with_fixint_encoding();
+    // Note: bincode recursively length-prefixes every field!
+    config
+      .serialize_into(byte_sink, self)
       .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
   }
 }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,5 +1,4 @@
 use bincode::Options;
-use digest::{typenum::Unsigned, OutputSizeUser};
 use ff::PrimeField;
 use serde::Serialize;
 use sha3::{Digest, Sha3_256};
@@ -7,19 +6,6 @@ use std::io;
 use std::marker::PhantomData;
 
 use crate::constants::NUM_HASH_BITS;
-
-/// For building digests
-#[derive(Clone)]
-pub struct DigestBuilder<F: PrimeField, T: HasDigest<F>> {
-  inner: T,
-  _phantom: PhantomData<(F, T)>,
-}
-
-/// Trait to be implemented by types whose digests can be built with `DigestBuilder`.
-pub trait HasDigest<F: PrimeField> {
-  /// Extend `bytes` with raw bytes or digest summarizing `Digestible`.
-  fn set_digest(&mut self, digest: F);
-}
 
 /// Trait for components with potentially discrete digests to be included in their container's digest.
 pub trait Digestible {
@@ -43,19 +29,12 @@ impl<T: SimpleDigestible> Digestible for T {
   }
 }
 
-impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
-  /// Return a new `DigestBuilder` for a value
-  pub fn new(value: T) -> Self {
-    assert!(
-      NUM_HASH_BITS <= <Sha3_256 as OutputSizeUser>::OutputSize::to_usize() * 8,
-      "DigestBuilder only supports hashes with output over {NUM_HASH_BITS} bits"
-    );
-    Self {
-      inner: value,
-      _phantom: Default::default(),
-    }
-  }
+pub struct DigestComputer<'a, F: PrimeField, T> {
+  inner: &'a T,
+  _phantom: PhantomData<F>,
+}
 
+impl<'a, F: PrimeField, T: Digestible> DigestComputer<'a, F, T> {
   fn hasher() -> Sha3_256 {
     Sha3_256::new()
   }
@@ -79,13 +58,109 @@ impl<F: PrimeField, T: HasDigest<F> + Digestible> DigestBuilder<F, T> {
     digest
   }
 
-  /// Build and return inner `Digestible`.
-  pub fn build(mut self) -> Result<T, io::Error> {
-    let mut hasher = Self::hasher();
-    self.inner.write_bytes(&mut hasher)?;
-    let mut bytes: [u8; 32] = hasher.finalize().into();
-    self.inner.set_digest(Self::map_to_field(&mut bytes));
+  /// Create a new DigestComputer
+  pub fn new(inner: &'a T) -> Self {
+    DigestComputer {
+      inner,
+      _phantom: PhantomData,
+    }
+  }
 
-    Ok(self.inner)
+  /// Compute the digest of a `Digestible` instance.
+  pub fn digest(&self) -> Result<F, io::Error> {
+    let mut hasher = Self::hasher();
+    self
+      .inner
+      .write_bytes(&mut hasher)
+      .expect("Serialization error");
+    let mut bytes: [u8; 32] = hasher.finalize().into();
+    Ok(Self::map_to_field(&mut bytes))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use ff::Field;
+  use once_cell::sync::OnceCell;
+  use pasta_curves::pallas;
+  use serde::{Deserialize, Serialize};
+
+  use crate::traits::Group;
+
+  use super::{DigestComputer, SimpleDigestible};
+
+  #[derive(Serialize, Deserialize)]
+  struct S<G: Group> {
+    i: usize,
+    #[serde(skip, default = "OnceCell::new")]
+    digest: OnceCell<G::Scalar>,
+  }
+
+  impl<G: Group> SimpleDigestible for S<G> {}
+
+  impl<G: Group> S<G> {
+    fn new(i: usize) -> Self {
+      S {
+        i,
+        digest: OnceCell::new(),
+      }
+    }
+
+    fn digest(&self) -> G::Scalar {
+      self
+        .digest
+        .get_or_try_init(|| DigestComputer::new(self).digest())
+        .cloned()
+        .unwrap()
+    }
+  }
+
+  type G = pallas::Point;
+
+  #[test]
+  fn test_digest_field_not_ingested_in_computation() {
+    let s1 = S::<G>::new(42);
+
+    // let's set up a struct with a weird digest field to make sure the digest computation does not depend of it
+    let oc = OnceCell::new();
+    oc.set(<G as Group>::Scalar::ONE).unwrap();
+
+    let s2: S<G> = S { i: 42, digest: oc };
+
+    assert_eq!(
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s1)
+        .digest()
+        .unwrap(),
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
+        .digest()
+        .unwrap()
+    );
+
+    // note: because of the semantics of `OnceCell::get_or_try_init`, the above
+    // equality will not result in `s1.digest() == s2.digest`
+    assert_ne!(
+      s2.digest(),
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
+        .digest()
+        .unwrap()
+    );
+  }
+
+  #[test]
+  fn test_digest_impervious_to_serialization() {
+    let good_s = S::<G>::new(42);
+
+    // let's set up a struct with a weird digest field to confuse deserializers
+    let oc = OnceCell::new();
+    oc.set(<G as Group>::Scalar::ONE).unwrap();
+
+    let bad_s: S<G> = S { i: 42, digest: oc };
+    // this justifies the adjective "bad"
+    assert_ne!(good_s.digest(), bad_s.digest());
+
+    let naughty_bytes = bincode::serialize(&bad_s).unwrap();
+
+    let retrieved_s: S<G> = bincode::deserialize(&naughty_bytes).unwrap();
+    assert_eq!(good_s.digest(), retrieved_s.digest())
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,7 +648,7 @@ where
   ro_consts_primary: ROConstants<G1>,
   ro_consts_secondary: ROConstants<G2>,
   #[abomonate_with(<G1::Scalar as PrimeField>::Repr)]
-  digest: G1::Scalar,
+  pp_digest: G1::Scalar,
   vk_primary: S1::VerifierKey,
   vk_secondary: S2::VerifierKey,
   _p_c1: PhantomData<C1>,
@@ -716,7 +716,7 @@ where
       F_arity_secondary: pp.F_arity_secondary,
       ro_consts_primary: pp.ro_consts_primary.clone(),
       ro_consts_secondary: pp.ro_consts_secondary.clone(),
-      digest: pp.digest(),
+      pp_digest: pp.digest(),
       vk_primary,
       vk_secondary,
       _p_c1: Default::default(),
@@ -810,7 +810,7 @@ where
         vk.ro_consts_secondary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_primary,
       );
-      hasher.absorb(vk.digest);
+      hasher.absorb(vk.pp_digest);
       hasher.absorb(G1::Scalar::from(num_steps as u64));
       for e in z0_primary {
         hasher.absorb(e);
@@ -824,7 +824,7 @@ where
         vk.ro_consts_primary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_secondary,
       );
-      hasher2.absorb(scalar_as_base::<G1>(vk.digest));
+      hasher2.absorb(scalar_as_base::<G1>(vk.pp_digest));
       hasher2.absorb(G2::Scalar::from(num_steps as u64));
       for e in z0_secondary {
         hasher2.absorb(e);
@@ -849,7 +849,7 @@ where
     // fold the running instance and last instance to get a folded instance
     let f_U_secondary = self.nifs_secondary.verify(
       &vk.ro_consts_secondary,
-      &scalar_as_base::<G1>(vk.digest),
+      &scalar_as_base::<G1>(vk.pp_digest),
       &self.r_U_secondary,
       &self.l_u_secondary,
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ where
   /// let pp_hint1 = Some(S1Prime::<G1>::commitment_key_floor());
   /// let pp_hint2 = Some(S2Prime::<G2>::commitment_key_floor());
   ///
-  /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
+  /// let pp = PublicParams::new(&circuit1, &circuit2, pp_hint1, pp_hint2);
   /// ```
   pub fn new(
     c_primary: &C1,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -7,7 +7,7 @@ use std::ops::Index;
 use crate::{
   bellpepper::shape_cs::ShapeCS,
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
-  digest::{DigestBuilder, Digestible, HasDigest, SimpleDigestible},
+  digest::{DigestComputer, Digestible, SimpleDigestible},
   errors::NovaError,
   r1cs::{
     commitment_key, commitment_key_size, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance,
@@ -25,6 +25,7 @@ use crate::{
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use ff::{Field, PrimeField};
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -201,7 +202,9 @@ where
   /// Indexed `RunningClaim`s
   claims: Vec<RunningClaim<G1, G2, C1, C2>>,
   /// Digest constructed from these `RunningClaim`s' parameters
-  digest: G1::Scalar,
+  // Once we serialize this struct, it's important to add this
+  // annotaiton to the digest field for it to be treated properly: #[serde(skip, default = "OnceCell::new")]
+  digest: OnceCell<G1::Scalar>,
 }
 
 impl<G1, G2, C1, C2> Index<usize> for RunningClaims<G1, G2, C1, C2>
@@ -215,18 +218,6 @@ where
 
   fn index(&self, index: usize) -> &Self::Output {
     &self.claims[index]
-  }
-}
-
-impl<G1, G2, C1, C2> HasDigest<G1::Scalar> for RunningClaims<G1, G2, C1, C2>
-where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
-{
-  fn set_digest(&mut self, digest: G1::Scalar) {
-    self.digest = digest;
   }
 }
 
@@ -245,14 +236,14 @@ where
   }
 }
 
-impl<G1, G2, C1, C2> DigestBuilder<G1::Scalar, RunningClaims<G1, G2, C1, C2>>
+impl<G1, G2, C1, C2> RunningClaims<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  fn setup(mut claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
+  fn new(mut claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
     let running_claim_params = claims
       .iter()
       .map(|c| c.get_public_params())
@@ -263,36 +254,22 @@ where
     for claim in &mut claims {
       claim.set_commitment_key(ck_primary.clone(), ck_secondary.clone());
     }
-
-    let running_claims = RunningClaims::new(claims);
-
-    Self::new(running_claims)
-  }
-}
-
-impl<G1, G2, C1, C2> RunningClaims<G1, G2, C1, C2>
-where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
-{
-  fn new(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Self {
-    Self {
+    RunningClaims {
       claims,
-      digest: Default::default(),
+      digest: OnceCell::new(),
     }
-  }
-
-  fn setup(claims: Vec<RunningClaim<G1, G2, C1, C2>>) -> Result<Self, io::Error> {
-    let digest_builder = DigestBuilder::<G1::Scalar, RunningClaims<G1, G2, C1, C2>>::setup(claims);
-
-    digest_builder.build()
   }
 
   /// Return the `RunningClaims`' digest.
   pub fn digest(&self) -> G1::Scalar {
-    self.digest
+    self
+      .digest
+      .get_or_try_init(|| {
+        let dc = DigestComputer::new(self);
+        dc.digest()
+      })
+      .cloned()
+      .expect("Failure in retrieving digest")
   }
 }
 
@@ -961,9 +938,7 @@ where
   }
 
   /// Initialize and return initial running claims.
-  fn setup_running_claims(
-    &self,
-  ) -> Result<RunningClaims<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>>, io::Error> {
+  fn setup_running_claims(&self) -> RunningClaims<G1, G2, C1, TrivialSecondaryCircuit<G2::Scalar>> {
     let running_claims = (0..self.num_circuits())
       .map(|i| {
         RunningClaim::new(
@@ -975,7 +950,7 @@ where
       })
       .collect();
 
-    RunningClaims::setup(running_claims)
+    RunningClaims::new(running_claims)
   }
 
   /// How many circuits are provided?

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -229,6 +229,7 @@ where
   C2: StepCircuit<G2::Scalar>,
 {
   fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error> {
+    assert!(!self.claims.is_empty());
     for claim in &self.claims {
       claim.get_public_params().write_bytes(byte_sink)?;
     }
@@ -280,7 +281,7 @@ where
   C1: EnforcingStepCircuit<G1::Scalar>,
   C2: EnforcingStepCircuit<G2::Scalar>,
 {
-  /// new a running claim
+  /// create a running claim
   pub fn new(
     augmented_circuit_index: usize,
     circuit_primary: C1,

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -441,7 +441,7 @@ where
   let test_rom = TestROM::<G1, G2, TrivialSecondaryCircuit<G2::Scalar>>::new(rom);
   let num_steps = test_rom.num_steps();
 
-  let running_claims = test_rom.setup_running_claims().unwrap();
+  let running_claims = test_rom.setup_running_claims();
 
   let initial_program_counter = test_rom.initial_program_counter();
 


### PR DESCRIPTION
## What this does
- refactors the `DigestBuilder` introduced in #40 to something that sets aside the builder pattern, but is hopefully simpler: having an unambiguous transient `DigestComputer` that is effectively taking the (configurable) `Digestible` bytes, and computing a digest from it
- stores and caches this digest in the structure in a way that is then not polluting the `Digestible` bytes, even for a struct that implements `SimpleDigest`. The cache also 1/ can't be populated twice, 2/ can't be befuddled by structs deserialized from incorrect digest information.
- this applies this pattern to add a (cached) digest to `R1CSShape`, which is orthogonal to the digest of public parameters.

## What this does not do
- embed the digest of `R1CSShape`s constituent of `PublicParameters` inside their `Digestible` bytes, since [as discussed in review](https://github.com/lurk-lab/arecibo/pull/34#pullrequestreview-1629925553) this would require proper domain separation to be secure,

At the cost of needing to re-hash the `R1CSShape`s  when computing the digest of `PublicParams`, this solves #31 as stated. It can indeed, when looking at full-fledged PPs, allow serializing them in a file name built from the digest of their member `R1CSShape`s, and allows a fail-fast when looking up PPs in that cache and no file with the sought `R1CSShape` digest can be found.

I'm not opposed to also imbricating digests recursively, if this is done with proper domain separation (probably using something like [`serde_name`](https://crates.io/crates/serde_name) as a domain separator for the constituent digests).