### PR TITLE
[refactor] use associated types instead of generics in traits where that makes sense

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ where
 
     // check if the output hashes in R1CS instances point to the right running instances
     let (hash_primary, hash_secondary) = {
-      let mut hasher = <<G2 as Group>::RO as ROTrait<G2::Base, G2::Scalar>>::new(
+      let mut hasher = <<G2 as Group>::RO as ROTrait>::new(
         pp.ro_consts_secondary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_primary,
       );
@@ -570,7 +570,7 @@ where
       }
       self.r_U_secondary.absorb_in_ro(&mut hasher);
 
-      let mut hasher2 = <<G1 as Group>::RO as ROTrait<G1::Base, G1::Scalar>>::new(
+      let mut hasher2 = <<G1 as Group>::RO as ROTrait>::new(
         pp.ro_consts_primary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_secondary,
       );
@@ -839,7 +839,7 @@ where
 
     // check if the output hashes in R1CS instances point to the right running instances
     let (hash_primary, hash_secondary) = {
-      let mut hasher = <<G2 as Group>::RO as ROTrait<G2::Base, G2::Scalar>>::new(
+      let mut hasher = <<G2 as Group>::RO as ROTrait>::new(
         vk.ro_consts_secondary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_primary,
       );
@@ -853,7 +853,7 @@ where
       }
       self.r_U_secondary.absorb_in_ro(&mut hasher);
 
-      let mut hasher2 = <<G1 as Group>::RO as ROTrait<G1::Base, G1::Scalar>>::new(
+      let mut hasher2 = <<G1 as Group>::RO as ROTrait>::new(
         vk.ro_consts_primary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_secondary,
       );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,9 +932,9 @@ pub fn circuit_digest<
   cs.r1cs_shape().digest()
 }
 
-type CommitmentKey<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey;
-type Commitment<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment;
-type CompressedCommitment<G> = <<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
+type CommitmentKey<G> = <<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey;
+type Commitment<G> = <<G as Group>::CE as CommitmentEngineTrait>::Commitment;
+type CompressedCommitment<G> = <<<G as Group>::CE as CommitmentEngineTrait>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
 type CE<G> = <G as Group>::CE;
 
 #[cfg(test)]
@@ -1014,8 +1014,8 @@ mod tests {
     G2: Group<Base = <G1 as Group>::Scalar>,
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
+    <G1::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G2>,
     <G1::Scalar as PrimeField>::Repr: Abomonation,
     <G2::Scalar as PrimeField>::Repr: Abomonation,
   {
@@ -1232,8 +1232,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
+    <G1::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G2>,
     // this is due to the reliance on Abomonation
     <<G1 as Group>::Scalar as PrimeField>::Repr: Abomonation,
     <<G2 as Group>::Scalar as PrimeField>::Repr: Abomonation,
@@ -1329,8 +1329,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
+    <G1::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G2>,
     // this is due to the reliance on Abomonation
     <<G1 as Group>::Scalar as PrimeField>::Repr: Abomonation,
     <<G2 as Group>::Scalar as PrimeField>::Repr: Abomonation,
@@ -1434,8 +1434,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
+    <G1::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait>::CommitmentKey: CommitmentKeyExtTrait<G2>,
     // this is due to the reliance on Abomonation
     <<G1 as Group>::Scalar as PrimeField>::Repr: Abomonation,
     <<G2 as Group>::Scalar as PrimeField>::Repr: Abomonation,

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -19,8 +19,7 @@ pub struct NIFS<G: Group> {
   pub(crate) comm_T: CompressedCommitment<G>,
 }
 
-type ROConstants<G> =
-  <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants;
+type ROConstants<G> = <<G as Group>::RO as ROTrait>::Constants;
 
 impl<G: Group> NIFS<G> {
   /// Takes as input a Relaxed R1CS instance-witness tuple `(U1, W1)` and
@@ -172,8 +171,7 @@ mod tests {
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
     let (shape, ck) = cs.r1cs_shape_and_key(None);
-    let ro_consts =
-      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
+    let ro_consts = <<G as Group>::RO as ROTrait>::Constants::default();
 
     // Now get the instance and assignment for one instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
@@ -213,7 +211,7 @@ mod tests {
 
   fn execute_sequence<G>(
     ck: &CommitmentKey<G>,
-    ro_consts: &<<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants,
+    ro_consts: &<<G as Group>::RO as ROTrait>::Constants,
     pp_digest: &<G as Group>::Scalar,
     shape: &R1CSShape<G>,
     U1: &R1CSInstance<G>,
@@ -332,8 +330,7 @@ mod tests {
 
     // generate generators and ro constants
     let ck = commitment_key(&S, None);
-    let ro_consts =
-      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
+    let ro_consts = <<G as Group>::RO as ROTrait>::Constants::default();
 
     let rand_inst_witness_generator =
       |ck: &CommitmentKey<G>, I: &G::Scalar| -> (G::Scalar, R1CSInstance<G>, R1CSWitness<G>) {

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -40,11 +40,12 @@ pub struct EvaluationEngine<G: Group> {
   _p: PhantomData<G>,
 }
 
-impl<G> EvaluationEngineTrait<G> for EvaluationEngine<G>
+impl<G> EvaluationEngineTrait for EvaluationEngine<G>
 where
   G: Group,
   CommitmentKey<G>: CommitmentKeyExtTrait<G>,
 {
+  type G = G;
   type ProverKey = ProverKey<G>;
   type VerifierKey = VerifierKey<G>;
   type EvaluationArgument = InnerProductArgument<G>;

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -50,7 +50,7 @@ where
   type EvaluationArgument = InnerProductArgument<G>;
 
   fn setup(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey) {
     let ck_c = G::CE::setup(b"ipa", 1);
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -194,7 +194,9 @@ pub struct CommitmentEngine<G: Group> {
   _p: PhantomData<G>,
 }
 
-impl<G: Group> CommitmentEngineTrait<G> for CommitmentEngine<G> {
+impl<G: Group> CommitmentEngineTrait for CommitmentEngine<G> {
+  type G = G;
+
   type CommitmentKey = CommitmentKey<G>;
   type Commitment = Commitment<G>;
 
@@ -230,7 +232,7 @@ pub trait CommitmentKeyExtTrait<G: Group> {
 
   /// Reinterprets commitments as commitment keys
   fn reinterpret_commitments_as_ck(
-    c: &[<<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment],
+    c: &[<<<G as Group>::CE as CommitmentEngineTrait>::Commitment as CommitmentTrait<G>>::CompressedCommitment],
   ) -> Result<Self, NovaError>
   where
     Self: Sized;

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -56,12 +56,14 @@ where
   _p: PhantomData<Scalar>,
 }
 
-impl<Base, Scalar> ROTrait<Base, Scalar> for PoseidonRO<Base, Scalar>
+impl<Base, Scalar> ROTrait for PoseidonRO<Base, Scalar>
 where
   Base: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>,
   Base::Repr: Abomonation,
   Scalar: PrimeField,
 {
+  type Base = Base;
+  type Scalar = Scalar;
   type CircuitRO = PoseidonROCircuit<Base>;
   type Constants = PoseidonConstantsCircuit<Base>;
 
@@ -127,11 +129,12 @@ where
   squeezed: bool,
 }
 
-impl<Scalar> ROCircuitTrait<Scalar> for PoseidonROCircuit<Scalar>
+impl<Scalar> ROCircuitTrait for PoseidonROCircuit<Scalar>
 where
   Scalar: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>,
   Scalar::Repr: Abomonation,
 {
+  type Base = Scalar;
   type NativeRO<T: PrimeField> = PoseidonRO<Scalar, T>;
   type Constants = PoseidonConstantsCircuit<Scalar>;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -668,7 +668,7 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
 #[derive(Clone, Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <G::Scalar as PrimeField>::Repr: Abomonation)]
-pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G = G>> {
   pk_ee: EE::ProverKey,
   S: R1CSShape<G>,
   S_repr: R1CSShapeSparkRepr<G>,
@@ -681,7 +681,7 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
 #[derive(Clone, Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <G::Scalar as PrimeField>::Repr: Abomonation)]
-pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G = G>> {
   num_cons: usize,
   num_vars: usize,
   vk_ee: EE::VerifierKey,
@@ -691,14 +691,14 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   digest: OnceCell<G::Scalar>,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> SimpleDigestible for VerifierKey<G, EE> {}
 
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G = G>> {
   // commitment to oracles
   comm_Az: CompressedCommitment<G>,
   comm_Bz: CompressedCommitment<G>,
@@ -751,7 +751,7 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARK<G, EE>
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> RelaxedR1CSSNARK<G, EE>
 where
   <G::Scalar as PrimeField>::Repr: Abomonation,
 {
@@ -862,7 +862,7 @@ where
   }
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> VerifierKey<G, EE> {
   fn new(
     num_cons: usize,
     num_vars: usize,
@@ -891,7 +891,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
   }
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE>
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> RelaxedR1CSSNARKTrait<G>
+  for RelaxedR1CSSNARK<G, EE>
 where
   <G::Scalar as PrimeField>::Repr: Abomonation,
 {

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <G::Scalar as ff::PrimeField>::Repr: Abomonation)]
-pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G = G>> {
   pk_ee: EE::ProverKey,
   S: R1CSShape<G>,
   #[abomonate_with(<G::Scalar as ff::PrimeField>::Repr)]
@@ -43,7 +43,7 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
 #[derive(Clone, Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <G::Scalar as ff::PrimeField>::Repr: Abomonation)]
-pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G = G>> {
   vk_ee: EE::VerifierKey,
   S: R1CSShape<G>,
   #[abomonation_skip]
@@ -51,9 +51,9 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   digest: OnceCell<G::Scalar>,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> SimpleDigestible for VerifierKey<G, EE> {}
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> VerifierKey<G, EE> {
   fn new(shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> Self {
     VerifierKey {
       vk_ee,
@@ -80,7 +80,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G = G>> {
   sc_proof_outer: SumcheckProof<G>,
   claims_outer: (G::Scalar, G::Scalar, G::Scalar),
   eval_E: G::Scalar,
@@ -91,7 +91,8 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE>
+impl<G: Group, EE: EvaluationEngineTrait<G = G>> RelaxedR1CSSNARKTrait<G>
+  for RelaxedR1CSSNARK<G, EE>
 where
   <G::Scalar as ff::PrimeField>::Repr: Abomonation,
 {

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -82,7 +82,10 @@ pub trait Len {
 }
 
 /// A trait that ties different pieces of the commitment generation together
-pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
+pub trait CommitmentEngineTrait: Clone + Send + Sync {
+  /// The group type which this commitment engine operates on
+  type G: Group;
+
   /// Holds the type of the commitment key
   /// The key should quantify its length in terms of group generators.
   type CommitmentKey: Len
@@ -96,11 +99,11 @@ pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
     + Abomonation;
 
   /// Holds the type of the commitment
-  type Commitment: CommitmentTrait<G>;
+  type Commitment: CommitmentTrait<Self::G>;
 
   /// Samples a new commitment key of a specified size
   fn setup(label: &'static [u8], n: usize) -> Self::CommitmentKey;
 
   /// Commits to the provided vector using the provided generators
-  fn commit(ck: &Self::CommitmentKey, v: &[G::Scalar]) -> Self::Commitment;
+  fn commit(ck: &Self::CommitmentKey, v: &[<Self::G as Group>::Scalar]) -> Self::Commitment;
 }

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -9,7 +9,10 @@ use abomonation::Abomonation;
 use serde::{Deserialize, Serialize};
 
 /// A trait that ties different pieces of the commitment evaluation together
-pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
+pub trait EvaluationEngineTrait: Clone + Send + Sync {
+  /// The group type used in the engine's homomorphic commitment scheme
+  type G: Group;
+
   /// A type that holds the prover key
   type ProverKey: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
 
@@ -21,27 +24,27 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
 
   /// A method to perform any additional setup needed to produce proofs of evaluations
   fn setup(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
+    ck: &<<Self::G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey);
 
   /// A method to prove the evaluation of a multilinear polynomial
   fn prove(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
+    ck: &<<Self::G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
     pk: &Self::ProverKey,
-    transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait>::Commitment,
-    poly: &[G::Scalar],
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    transcript: &mut <Self::G as Group>::TE,
+    comm: &<<Self::G as Group>::CE as CommitmentEngineTrait>::Commitment,
+    poly: &[<Self::G as Group>::Scalar],
+    point: &[<Self::G as Group>::Scalar],
+    eval: &<Self::G as Group>::Scalar,
   ) -> Result<Self::EvaluationArgument, NovaError>;
 
   /// A method to verify the purported evaluation of a multilinear polynomials
   fn verify(
     vk: &Self::VerifierKey,
-    transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait>::Commitment,
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    transcript: &mut <Self::G as Group>::TE,
+    comm: &<<Self::G as Group>::CE as CommitmentEngineTrait>::Commitment,
+    point: &[<Self::G as Group>::Scalar],
+    eval: &<Self::G as Group>::Scalar,
     arg: &Self::EvaluationArgument,
   ) -> Result<(), NovaError>;
 }

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -21,15 +21,15 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
 
   /// A method to perform any additional setup needed to produce proofs of evaluations
   fn setup(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey);
 
   /// A method to prove the evaluation of a multilinear polynomial
   fn prove(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait>::CommitmentKey,
     pk: &Self::ProverKey,
     transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as Group>::CE as CommitmentEngineTrait>::Commitment,
     poly: &[G::Scalar],
     point: &[G::Scalar],
     eval: &G::Scalar,
@@ -39,7 +39,7 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
   fn verify(
     vk: &Self::VerifierKey,
     transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as Group>::CE as CommitmentEngineTrait>::Commitment,
     point: &[G::Scalar],
     eval: &G::Scalar,
     arg: &Self::EvaluationArgument,

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -65,7 +65,7 @@ pub trait Group:
   type TE: TranscriptEngineTrait<Self>;
 
   /// A type that defines a commitment engine over scalars in the group
-  type CE: CommitmentEngineTrait<Self>;
+  type CE: CommitmentEngineTrait<G = Self>;
 
   /// A method to compute a multiexponentation
   fn vartime_multiscalar_mul(


### PR DESCRIPTION
Nova uses many traits, and more specifically many generic traits, even when those often only would have one single plausible implementation for a given struct.

This PR minimally modifies those traits that:
-  do clearly not aim to have several implementations per struct (`ROTrait`, `ROCircuitTrait`, `CommitmentEngineTrait`,`EvaluationEngineTrait`),
- involve generic constraints that introduce some complexity elsewhere in the implementation,

so as to drop the generic parameter, and replace it with an associated type.

Plenty of other traits which don't really aim at having several instances per struct are left unchanged (since arguably their only consequence in the Nova code base is needing a decoration with the generic parameter).

> [!NOTE]
> The following guide explains the mechanics and rationale of the change, note the paragraph on token structs:
> https://gist.github.com/huitseeker/6e5c92a2b17c96f29984223d53e59880