### PR TITLE
fix: remove a duplicate `R1CSShape` in the `RelaxedR1CSSNARK`'s chosen `ProverKey`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,7 @@ where
         S1::prove(
           &pp.ck_primary,
           &pk.pk_primary,
+          &pp.circuit_shape_primary.r1cs_shape,
           &recursive_snark.r_U_primary,
           &recursive_snark.r_W_primary,
         )
@@ -793,6 +794,7 @@ where
         S2::prove(
           &pp.ck_secondary,
           &pk.pk_secondary,
+          &pp.circuit_shape_secondary.r1cs_shape,
           &f_U_secondary,
           &f_W_secondary,
         )

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -177,11 +177,12 @@ impl<G: Group> R1CSShape<G> {
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
   // Panics if num_cons, num_vars, or num_io are not powers of two, or if num_io > num_vars
   #[inline]
-  pub(crate) fn check_regular_shape(&self) {
-    assert_eq!(self.num_cons.next_power_of_two(), self.num_cons);
-    assert_eq!(self.num_vars.next_power_of_two(), self.num_vars);
-    assert_eq!(self.num_io.next_power_of_two(), self.num_io);
-    assert!(self.num_io < self.num_vars);
+  pub(crate) fn check_regular_shape(&self) -> bool {
+    let cons_valid = self.num_cons.next_power_of_two() == self.num_cons;
+    let vars_valid = self.num_vars.next_power_of_two() == self.num_vars;
+    let io_valid = self.num_io.next_power_of_two() == self.num_io;
+    let io_lt_vars = self.num_io < self.num_vars;
+    cons_valid && vars_valid && io_valid && io_lt_vars
   }
 
   pub(crate) fn multiply_vec(

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -175,9 +175,9 @@ impl<G: Group> R1CSShape<G> {
   }
 
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
-  // Panics if num_cons, num_vars, or num_io are not powers of two, or if num_io > num_vars
+  // Returns false if num_cons, num_vars, or num_io are not powers of two, or if num_io > num_vars
   #[inline]
-  pub(crate) fn check_regular_shape(&self) -> bool {
+  pub(crate) fn is_regular_shape(&self) -> bool {
     let cons_valid = self.num_cons.next_power_of_two() == self.num_cons;
     let vars_valid = self.num_vars.next_power_of_two() == self.num_vars;
     let io_valid = self.num_io.next_power_of_two() == self.num_io;
@@ -680,7 +680,7 @@ mod tests {
 
   fn test_pad_tiny_r1cs_with<G: Group>() {
     let padded_r1cs = tiny_r1cs::<G>(3).pad();
-    padded_r1cs.check_regular_shape();
+    assert!(padded_r1cs.is_regular_shape());
 
     let expected_r1cs = tiny_r1cs::<G>(4);
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -129,7 +129,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
     );
 
     // prove the instance using Spartan
-    let snark = S::prove(&pk.ck, &pk.pk, &u_relaxed, &w_relaxed)?;
+    let snark = S::prove(&pk.ck, &pk.pk, &pk.S, &u_relaxed, &w_relaxed)?;
 
     Ok(DirectSNARK {
       comm_W: u.comm_W,

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -670,7 +670,6 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
 #[abomonation_bounds(where <G::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
   pk_ee: EE::ProverKey,
-  S: R1CSShape<G>,
   S_repr: R1CSShapeSparkRepr<G>,
   S_comm: R1CSShapeSparkCommitment<G>,
   #[abomonate_with(<G::Scalar as PrimeField>::Repr)]
@@ -911,6 +910,7 @@ where
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     // check the provided commitment key meets minimal requirements
     assert!(ck.length() >= Self::commitment_key_floor()(S));
+
     let (pk_ee, vk_ee) = EE::setup(ck);
 
     // pad the R1CS matrices
@@ -923,7 +923,6 @@ where
 
     let pk = ProverKey {
       pk_ee,
-      S,
       S_repr,
       S_comm,
       vk_digest: vk.digest(),
@@ -937,17 +936,20 @@ where
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,
+    S: &R1CSShape<G>,
     U: &RelaxedR1CSInstance<G>,
     W: &RelaxedR1CSWitness<G>,
   ) -> Result<Self, NovaError> {
-    let W = W.pad(&pk.S); // pad the witness
+    // pad the R1CSShape
+    let S = S.pad();
+    // sanity check that R1CSShape has all required size characteristics
+    assert!(S.check_regular_shape());
+
+    let W = W.pad(&S); // pad the witness
     let mut transcript = G::TE::new(b"RelaxedR1CSSNARK");
 
     // a list of polynomial evaluation claims that will be batched
     let mut w_u_vec = Vec::new();
-
-    // sanity check that R1CSShape has certain size characteristics
-    pk.S.check_regular_shape();
 
     // append the verifier key (which includes commitment to R1CS matrices) and the RelaxedR1CSInstance to the transcript
     transcript.absorb(b"vk", &pk.vk_digest);
@@ -957,7 +959,7 @@ where
     let z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     // compute Az, Bz, Cz
-    let (mut Az, mut Bz, mut Cz) = pk.S.multiply_vec(&z)?;
+    let (mut Az, mut Bz, mut Cz) = S.multiply_vec(&z)?;
 
     // commit to Az, Bz, Cz
     let (comm_Az, (comm_Bz, comm_Cz)) = rayon::join(
@@ -1000,7 +1002,7 @@ where
     // (2) send commitments to the following two oracles
     // E_row(i) = eq(tau, row(i)) for all i
     // E_col(i) = z(col(i)) for all i
-    let (mem_row, mem_col, E_row, E_col) = pk.S_repr.evaluation_oracles(&pk.S, &tau, &z);
+    let (mem_row, mem_col, E_row, E_col) = pk.S_repr.evaluation_oracles(&S, &tau, &z);
     let (comm_E_row, comm_E_col) =
       rayon::join(|| G::CE::commit(ck, &E_row), || G::CE::commit(ck, &E_col));
 
@@ -1314,7 +1316,7 @@ where
     // we need to prove that eval_z = z(r_prod) = (1-r_prod[0]) * W.w(r_prod[1..]) + r_prod[0] * U.x(r_prod[1..]).
     // r_prod was padded, so we now remove the padding
     let r_prod_unpad = {
-      let l = pk.S_repr.N.log_2() - (2 * pk.S.num_vars).log_2();
+      let l = pk.S_repr.N.log_2() - (2 * S.num_vars).log_2();
       r_prod[l..].to_vec()
     };
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -943,7 +943,7 @@ where
     // pad the R1CSShape
     let S = S.pad();
     // sanity check that R1CSShape has all required size characteristics
-    assert!(S.check_regular_shape());
+    assert!(S.is_regular_shape());
 
     let W = W.pad(&S); // pad the witness
     let mut transcript = G::TE::new(b"RelaxedR1CSSNARK");

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -127,7 +127,7 @@ where
     // pad the R1CSShape
     let S = S.pad();
     // sanity check that R1CSShape has all required size characteristics
-    assert!(S.check_regular_shape());
+    assert!(S.is_regular_shape());
 
     let W = W.pad(&S); // pad the witness
     let mut transcript = G::TE::new(b"RelaxedR1CSSNARK");

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -34,7 +34,6 @@ use serde::{Deserialize, Serialize};
 #[abomonation_bounds(where <G::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
   pk_ee: EE::ProverKey,
-  S: R1CSShape<G>,
   #[abomonate_with(<G::Scalar as ff::PrimeField>::Repr)]
   vk_digest: G::Scalar, // digest of the verifier's key
 }
@@ -106,11 +105,10 @@ where
 
     let S = S.pad();
 
-    let vk: VerifierKey<G, EE> = VerifierKey::new(S.clone(), vk_ee);
+    let vk: VerifierKey<G, EE> = VerifierKey::new(S, vk_ee);
 
     let pk = ProverKey {
       pk_ee,
-      S,
       vk_digest: vk.digest(),
     };
 
@@ -122,14 +120,17 @@ where
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,
+    S: &R1CSShape<G>,
     U: &RelaxedR1CSInstance<G>,
     W: &RelaxedR1CSWitness<G>,
   ) -> Result<Self, NovaError> {
-    let W = W.pad(&pk.S); // pad the witness
-    let mut transcript = G::TE::new(b"RelaxedR1CSSNARK");
+    // pad the R1CSShape
+    let S = S.pad();
+    // sanity check that R1CSShape has all required size characteristics
+    assert!(S.check_regular_shape());
 
-    // sanity check that R1CSShape has certain size characteristics
-    pk.S.check_regular_shape();
+    let W = W.pad(&S); // pad the witness
+    let mut transcript = G::TE::new(b"RelaxedR1CSSNARK");
 
     // append the digest of vk (which includes R1CS matrices) and the RelaxedR1CSInstance to the transcript
     transcript.absorb(b"vk", &pk.vk_digest);
@@ -139,8 +140,8 @@ where
     let mut z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     let (num_rounds_x, num_rounds_y) = (
-      usize::try_from(pk.S.num_cons.ilog2()).unwrap(),
-      (usize::try_from(pk.S.num_vars.ilog2()).unwrap() + 1),
+      usize::try_from(S.num_cons.ilog2()).unwrap(),
+      (usize::try_from(S.num_vars.ilog2()).unwrap() + 1),
     );
 
     // outer sum-check
@@ -150,8 +151,8 @@ where
 
     let mut poly_tau = MultilinearPolynomial::new(EqPolynomial::new(tau).evals());
     let (mut poly_Az, mut poly_Bz, poly_Cz, mut poly_uCz_E) = {
-      let (poly_Az, poly_Bz, poly_Cz) = pk.S.multiply_vec(&z)?;
-      let poly_uCz_E = (0..pk.S.num_cons)
+      let (poly_Az, poly_Bz, poly_Cz) = S.multiply_vec(&z)?;
+      let poly_uCz_E = (0..S.num_cons)
         .map(|i| U.u * poly_Cz[i] + W.E[i])
         .collect::<Vec<G::Scalar>>();
       (
@@ -234,7 +235,7 @@ where
           (A_evals, B_evals, C_evals)
         };
 
-      let (evals_A, evals_B, evals_C) = compute_eval_table_sparse(&pk.S, &evals_rx);
+      let (evals_A, evals_B, evals_C) = compute_eval_table_sparse(&S, &evals_rx);
 
       assert_eq!(evals_A.len(), evals_B.len());
       assert_eq!(evals_A.len(), evals_C.len());
@@ -245,7 +246,7 @@ where
     };
 
     let poly_z = {
-      z.resize(pk.S.num_vars * 2, G::Scalar::ZERO);
+      z.resize(S.num_vars * 2, G::Scalar::ZERO);
       z
     };
 

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -38,6 +38,7 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,
+    S: &R1CSShape<G>,
     U: &RelaxedR1CSInstance<G>,
     W: &RelaxedR1CSWitness<G>,
   ) -> Result<Self, NovaError>;


### PR DESCRIPTION
As explained by @zaverucha in https://github.com/microsoft/Spartan2/pull/2 (with edits for precision):

The `R1CSShape` object was being stored in both:
- the `ProverKey` of the `spartan::direct::DirectSNARK`, which generically employs any instance of `RelaxedR1CSSNARKTrait`,
- the `ProverKey` of each of the two `RelaxedR1CSSNARKTrait` implementations in `spartan::{snark, ppsnark}::RelaxedR1CSSNARK`,
- the `PublicParams` that are passed to the proof method of `crate::CompressedSNARK<G1, G2, C1, C2, S1, S2>`, which generically employs any instance of `RelaxedR1CSSNARKTrait`.

IOW, `RelaxedR1CSSNARKTrait` is always accessed through generic structs (`DirectSNARK`, `CompressedSNARK`) which already have a copy of the relevant `R1CSShape`. We store it once in the top level object (`DirectSNARK`'s `ProverKey` or `PublicParams`) and pass it to the Spartan implementation.

This saves memory and makes serialization of the `ProverKey` about twice as fast. Both are significant when there are a large number of constraints.

Fixes #65 


```
group                                                        main                                   r1cs_shape_duplication
-----                                                        ----                                   ----------------------
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.00       3.3±0.08s          1.00       3.3±0.06s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.01     45.6±0.62ms          1.00     45.3±0.49ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.00       8.1±0.06s          1.01       8.2±0.11s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.00     62.5±1.17ms          1.02     63.6±2.98ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.00       5.4±0.13s          1.02       5.5±0.10s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.01     51.2±0.65ms          1.00     50.8±0.34ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.00      15.7±0.05s          1.01      15.9±0.23s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.00    110.4±0.43ms          1.06    117.0±0.64ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.00      10.1±0.04s          1.01      10.2±0.12s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.16     72.0±0.91ms          1.00     62.0±0.81ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.00       5.9±0.11s          1.00       6.0±0.08s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.03     52.3±2.47ms          1.00     50.8±0.54ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.00    357.8±2.18ms          1.01    361.2±1.92ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.00     20.8±0.11ms          1.00     20.9±0.29ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.00       9.9±0.01s          1.01      10.0±0.01s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.00    131.3±1.08ms          1.02    133.5±0.84ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.00   1494.0±9.19ms          1.01   1503.4±8.83ms
CompressedSNARK-StepCircuitSize-121253/Verify                1.00     39.1±0.44ms          1.00     39.2±0.52ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00    518.9±5.53ms          1.01    526.3±6.09ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.00     29.2±0.33ms          1.01     29.5±0.58ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.00       2.7±0.01s          1.01       2.7±0.01s
CompressedSNARK-StepCircuitSize-252325/Verify                1.00     50.6±0.68ms          1.01     51.3±0.67ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.00       5.1±0.01s          1.00       5.1±0.01s
CompressedSNARK-StepCircuitSize-514469/Verify                1.00     75.8±0.88ms          1.04     78.6±0.56ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.00   867.3±14.41ms          1.01   878.3±15.70ms
CompressedSNARK-StepCircuitSize-55717/Verify                 1.00     31.0±0.76ms          1.00     31.0±0.73ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00    356.6±2.66ms          1.01    359.3±2.73ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.01     21.0±0.14ms          1.00     20.8±0.15ms
RecursiveSNARK-StepCircuitSize-0/Prove                       1.01     38.6±0.90ms          1.00     38.1±0.42ms
RecursiveSNARK-StepCircuitSize-0/Verify                      1.00     15.5±0.06ms          1.00     15.5±0.08ms
RecursiveSNARK-StepCircuitSize-1038757/Prove                 1.00    238.5±1.97ms          1.00    238.8±1.78ms
RecursiveSNARK-StepCircuitSize-1038757/Verify                1.01    170.1±1.52ms          1.00    168.0±1.81ms
RecursiveSNARK-StepCircuitSize-121253/Prove                  1.00     88.5±0.86ms          1.00     88.6±0.94ms
RecursiveSNARK-StepCircuitSize-121253/Verify                 1.00     53.8±0.94ms          1.00     53.7±1.34ms
RecursiveSNARK-StepCircuitSize-22949/Prove                   1.01     61.7±1.09ms          1.00     61.2±1.46ms
RecursiveSNARK-StepCircuitSize-22949/Verify                  1.00     32.8±0.08ms          1.00     32.7±0.19ms
RecursiveSNARK-StepCircuitSize-252325/Prove                  1.00    108.0±1.64ms          1.00    107.8±1.37ms
RecursiveSNARK-StepCircuitSize-252325/Verify                 1.00     68.5±0.46ms          1.00     68.7±0.39ms
RecursiveSNARK-StepCircuitSize-514469/Prove                  1.00    146.6±1.03ms          1.00    146.9±0.85ms
RecursiveSNARK-StepCircuitSize-514469/Verify                 1.01    100.1±0.48ms          1.00     99.5±0.20ms
RecursiveSNARK-StepCircuitSize-55717/Prove                   1.00     86.5±1.57ms          1.00     86.6±1.86ms
RecursiveSNARK-StepCircuitSize-55717/Verify                  1.00     56.7±0.22ms          1.00     56.8±0.30ms
RecursiveSNARK-StepCircuitSize-6565/Prove                    1.01     45.3±0.93ms          1.00     44.8±0.71ms
RecursiveSNARK-StepCircuitSize-6565/Verify                   1.00     20.7±0.08ms          1.00     20.7±0.24ms
```