### PR TITLE
Zeromorph EvaluationEngine trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ cfg-if = "1.0.0"
 once_cell = "1.18.0"
 anyhow = "1.0.72"
 rand = "0.8.4"
+rand_xorshift = "0.3.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -52,3 +52,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------
+https://github.com/AztecProtocol/aztec-packages/
+
+Licensed under Apache 2.0
+
+Copyright 2022 Aztec
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/examples/minroot_serde.rs
+++ b/examples/minroot_serde.rs
@@ -194,7 +194,7 @@ fn main() {
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
     >::new(&circuit_primary, &circuit_secondary, None, None);
-    assert!(result.clone() == pp, "not equal!");
+    assert!(*result == pp, "not equal!");
     assert!(remaining.is_empty());
   } else {
     println!("Something terrible happened");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,12 +1330,6 @@ mod tests {
       S<grumpkin::Point, EE<_>>,
     >();
     test_ivc_nontrivial_with_compression_with::<
-      bn256::Point,
-      grumpkin::Point,
-      S<bn256::Point, ZM<halo2curves::bn256::Bn256>>,
-      S<grumpkin::Point, EE<_>>,
-    >();
-    test_ivc_nontrivial_with_compression_with::<
       secp256k1::Point,
       secq256k1::Point,
       S<secp256k1::Point, EE<_>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1453,15 +1453,20 @@ mod tests {
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2, EE<_>, EE<_>>();
     test_ivc_nontrivial_with_spark_compression_with::<
-      bn256::Point,
-      grumpkin::Point,
-      ZM<halo2curves::bn256::Bn256>,
-      EE<_>,
-    >();
-    test_ivc_nontrivial_with_spark_compression_with::<
       secp256k1::Point,
       secq256k1::Point,
       EE<_>,
+      EE<_>,
+    >();
+  }
+
+  #[test]
+  #[ignore]
+  fn test_ivc_nontrivial_with_spark_zm_compression() {
+    test_ivc_nontrivial_with_spark_compression_with::<
+      bn256::Point,
+      grumpkin::Point,
+      ZM<halo2curves::bn256::Bn256>,
       EE<_>,
     >();
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,13 +948,10 @@ mod tests {
   use core::fmt::Write;
 
   use super::*;
-  #[allow(dead_code)]
-  type ZM<E> = provider::non_hiding_zeromorph::ZMEvaluation<E>;
+  type ZM<E> = provider::non_hiding_zeromorph::ZMPCS<E>;
   type EE<G> = provider::ipa_pc::EvaluationEngine<G>;
   type S<G, EE> = spartan::snark::RelaxedR1CSSNARK<G, EE>;
   type SPrime<G, EE> = spartan::ppsnark::RelaxedR1CSSNARK<G, EE>;
-  #[allow(dead_code)]
-  type SZM<G1, E> = spartan::snark::RelaxedR1CSSNARK<G1, ZM<E>>;
 
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
@@ -1068,12 +1065,12 @@ mod tests {
     let trivial_circuit2_grumpkin = TrivialCircuit::<<grumpkin::Point as Group>::Scalar>::default();
     let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
 
-    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, EE<_>, EE<_>>(
+    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, ZM<halo2curves::bn256::Bn256>, EE<_>>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
       "184d05f08dca260f010cb48c6cf8c5eb61dedfc270e5a18226eb622cf7da0203",
     );
-    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, EE<_>, EE<_>>(
+    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, ZM<halo2curves::bn256::Bn256>, EE<_>>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
       "2fb992932b2a642b4ce8f52646a7ef6a5a486682716cf969df50021107afff03",
@@ -1329,7 +1326,7 @@ mod tests {
     test_ivc_nontrivial_with_compression_with::<
       bn256::Point,
       grumpkin::Point,
-      S<bn256::Point, EE<_>>, // SZM<bn256::Point, halo2curves::bn256::Bn256>,
+      S<bn256::Point, ZM<halo2curves::bn256::Bn256>>,
       S<grumpkin::Point, EE<_>>,
     >();
     test_ivc_nontrivial_with_compression_with::<
@@ -1346,7 +1343,7 @@ mod tests {
     test_ivc_nontrivial_with_compression_with::<
       bn256::Point,
       grumpkin::Point,
-      S<bn256::Point, EE<_>>, // SZM<bn256::Point, halo2curves::bn256::Bn256>,
+      S<bn256::Point, ZM<halo2curves::bn256::Bn256>>,
       S<grumpkin::Point, EE<_>>,
     >();
   }
@@ -1455,8 +1452,12 @@ mod tests {
     type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2, EE<_>, EE<_>>();
-    test_ivc_nontrivial_with_spark_compression_with::<bn256::Point, grumpkin::Point, EE<_>, EE<_>>(
-    );
+    test_ivc_nontrivial_with_spark_compression_with::<
+      bn256::Point,
+      grumpkin::Point,
+      ZM<halo2curves::bn256::Bn256>,
+      EE<_>,
+    >();
     test_ivc_nontrivial_with_spark_compression_with::<
       secp256k1::Point,
       secq256k1::Point,
@@ -1609,7 +1610,12 @@ mod tests {
     type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nondet_with_compression_with::<G1, G2, EE<_>, EE<_>>();
-    test_ivc_nondet_with_compression_with::<bn256::Point, grumpkin::Point, EE<_>, EE<_>>();
+    test_ivc_nondet_with_compression_with::<
+      bn256::Point,
+      grumpkin::Point,
+      ZM<halo2curves::bn256::Bn256>,
+      EE<_>,
+    >();
     test_ivc_nondet_with_compression_with::<secp256k1::Point, secq256k1::Point, EE<_>, EE<_>>();
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,21 +1330,16 @@ mod tests {
       S<grumpkin::Point, EE<_>>,
     >();
     test_ivc_nontrivial_with_compression_with::<
-      secp256k1::Point,
-      secq256k1::Point,
-      S<secp256k1::Point, EE<_>>,
-      S<secq256k1::Point, EE<_>>,
-    >();
-  }
-
-  #[test]
-  #[ignore]
-  fn test_ivc_nontrivial_with_zm_compression() {
-    test_ivc_nontrivial_with_compression_with::<
       bn256::Point,
       grumpkin::Point,
       S<bn256::Point, ZM<halo2curves::bn256::Bn256>>,
       S<grumpkin::Point, EE<_>>,
+    >();
+    test_ivc_nontrivial_with_compression_with::<
+      secp256k1::Point,
+      secq256k1::Point,
+      S<secp256k1::Point, EE<_>>,
+      S<secq256k1::Point, EE<_>>,
     >();
   }
 
@@ -1453,20 +1448,15 @@ mod tests {
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2, EE<_>, EE<_>>();
     test_ivc_nontrivial_with_spark_compression_with::<
-      secp256k1::Point,
-      secq256k1::Point,
-      EE<_>,
-      EE<_>,
-    >();
-  }
-
-  #[test]
-  #[ignore]
-  fn test_ivc_nontrivial_with_spark_zm_compression() {
-    test_ivc_nontrivial_with_spark_compression_with::<
       bn256::Point,
       grumpkin::Point,
       ZM<halo2curves::bn256::Bn256>,
+      EE<_>,
+    >();
+    test_ivc_nontrivial_with_spark_compression_with::<
+      secp256k1::Point,
+      secq256k1::Point,
+      EE<_>,
       EE<_>,
     >();
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1306,8 +1306,7 @@ mod tests {
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res =
-      CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -27,6 +27,8 @@ use halo2curves::grumpkin::{
   G1Affine as GrumpkinAffine, G1Compressed as GrumpkinCompressed, G1 as GrumpkinPoint,
 };
 
+use super::kzg_commitment::KZGCommitmentEngine;
+
 /// Re-exports that give access to the standard aliases used in the code base, for bn256
 pub mod bn256 {
   pub use halo2curves::bn256::{
@@ -58,7 +60,8 @@ impl_traits!(
   Bn256Compressed,
   Bn256Point,
   Bn256Affine,
-  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
+  KZGCommitmentEngine<halo2curves::bn256::Bn256>
 );
 
 impl_traits!(

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -1,0 +1,70 @@
+//! Commitment engine for KZG commitments
+//!
+
+use std::marker::PhantomData;
+
+use group::{prime::PrimeCurveAffine, Curve};
+use pairing::Engine;
+use rand::rngs::StdRng;
+use rand_core::SeedableRng;
+use serde::{Deserialize, Serialize};
+
+use crate::traits::{
+  commitment::{CommitmentEngineTrait, Len},
+  Group,
+};
+
+use super::{
+  non_hiding_kzg::{UVKZGCommitment, UVUniversalKZGParam},
+  pedersen::Commitment,
+};
+
+/// Provides a commitment engine
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KZGCommitmentEngine<E: Engine> {
+  _p: PhantomData<E>,
+}
+
+impl<E: Engine> CommitmentEngineTrait<E::G1> for KZGCommitmentEngine<E>
+where
+  E::G1: Group<PreprocessedGroupElement = E::G1Affine>,
+  E::G1Affine: Serialize + for<'de> Deserialize<'de>,
+  E::G2Affine: Serialize + for<'de> Deserialize<'de>,
+{
+  type CommitmentKey = UVUniversalKZGParam<E>;
+  type Commitment = Commitment<E::G1>;
+
+  fn setup(label: &'static [u8], n: usize) -> Self::CommitmentKey {
+    // TODO: this is just for testing, replace by grabbing from a real setup for production
+    let label_bytes: [u8; 32] = label[..32].try_into().unwrap();
+    let rng = &mut StdRng::from_seed(label_bytes);
+    UVUniversalKZGParam::gen_srs_for_testing(rng, n)
+  }
+
+  fn commit(ck: &Self::CommitmentKey, v: &[<E::G1 as Group>::Scalar]) -> Self::Commitment {
+    assert!(ck.length() >= v.len());
+    Commitment {
+      comm: E::G1::vartime_multiscalar_mul(v, &ck.powers_of_g[..v.len()]),
+    }
+  }
+}
+
+impl<E: Engine> From<Commitment<E::G1>> for UVKZGCommitment<E>
+where
+  E::G1: Group,
+{
+  fn from(c: Commitment<E::G1>) -> Self {
+    UVKZGCommitment(c.comm.to_affine())
+  }
+}
+
+impl<E: Engine> From<UVKZGCommitment<E>> for Commitment<E::G1>
+where
+  E::G1: Group,
+{
+  fn from(c: UVKZGCommitment<E>) -> Self {
+    Commitment {
+      comm: c.0.to_curve(),
+    }
+  }
+}

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -36,9 +36,11 @@ where
 
   fn setup(label: &'static [u8], n: usize) -> Self::CommitmentKey {
     // TODO: this is just for testing, replace by grabbing from a real setup for production
-    let label_bytes: [u8; 32] = label[..32].try_into().unwrap();
-    let rng = &mut StdRng::from_seed(label_bytes);
-    UVUniversalKZGParam::gen_srs_for_testing(rng, n)
+    let mut bytes = [0u8; 32];
+    let len = label.len().min(32);
+    bytes[..len].copy_from_slice(&label[..len]);
+    let rng = &mut StdRng::from_seed(bytes);
+    UVUniversalKZGParam::gen_srs_for_testing(rng, n.next_power_of_two())
   }
 
   fn commit(ck: &Self::CommitmentKey, v: &[<E::G1 as Group>::Scalar]) -> Self::Commitment {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -13,6 +13,7 @@ pub mod poseidon;
 pub mod secp_secq;
 
 // a non-hiding variant of {kzg, zeromorph}
+pub mod kzg_commitment;
 pub mod non_hiding_kzg;
 pub mod non_hiding_zeromorph;
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -157,7 +157,24 @@ macro_rules! impl_traits {
     $name_compressed:ident,
     $name_curve:ident,
     $name_curve_affine:ident,
-    $order_str:literal
+    $order_str:expr
+  ) => {
+    impl_traits!(
+      $name,
+      $name_compressed,
+      $name_curve,
+      $name_curve_affine,
+      $order_str,
+      CommitmentEngine<Self>
+    );
+  };
+  (
+    $name:ident,
+    $name_compressed:ident,
+    $name_curve:ident,
+    $name_curve_affine:ident,
+    $order_str:literal,
+    $commitment_engine:ty
   ) => {
     impl Group for $name::Point {
       type Base = $name::Base;
@@ -167,7 +184,7 @@ macro_rules! impl_traits {
       type RO = PoseidonRO<Self::Base, Self::Scalar>;
       type ROCircuit = PoseidonROCircuit<Self::Base>;
       type TE = Keccak256Transcript<Self>;
-      type CE = CommitmentEngine<Self>;
+      type CE = $commitment_engine;
 
       fn vartime_multiscalar_mul(
         scalars: &[Self::Scalar],

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -177,8 +177,6 @@ pub struct UVKZGProof<E: Engine> {
   pub proof: E::G1Affine,
 }
 
-// TODO: we are extending this into a real Dense UV Polynomial type,
-// and this is probably better organized elsewhere.
 /// Polynomial and its associated types
 pub type UVKZGPoly<F> = crate::spartan::polys::univariate::UniPoly<F>;
 
@@ -237,8 +235,6 @@ impl<E: MultiMillerLoop> UVKZGPCS<E>
 where
   E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
 {
-  // TODO: this relies on NovaError::InvalidIPA, which should really be extended to a sub-error enum
-  // called "PCSError"
   /// Generate a commitment for a polynomial
   /// Note that the scheme is not hidding
   pub fn commit(
@@ -281,7 +277,6 @@ where
     let divisor = UVKZGPoly {
       coeffs: vec![-*point, E::Fr::ONE],
     };
-    // TODO: Better error
     let witness_polynomial = polynomial
       .divide_with_q_and_r(&divisor)
       .map(|(q, _r)| q)
@@ -311,7 +306,6 @@ where
     points: &[E::Fr],
   ) -> Result<(Vec<UVKZGProof<E>>, Vec<UVKZGEvaluation<E>>), NovaError> {
     if polynomials.len() != points.len() {
-      // TODO: a better Error
       return Err(NovaError::PCSError(PCSError::LengthError));
     }
     let mut batch_proof = vec![];

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -136,27 +136,34 @@ impl<E: Engine> UVUniversalKZGParam<E> {
     let g = E::G1::random(&mut rng);
     let h = E::G2::random(rng);
 
-    let powers_of_g_projective = (0..=max_degree)
-      .scan(g, |acc, _| {
-        let val = *acc;
-        *acc *= beta;
-        Some(val)
-      })
-      .collect::<Vec<E::G1>>();
+    let (powers_of_g_projective, powers_of_h_projective) = rayon::join(
+      || {
+        (0..=max_degree)
+          .scan(g, |acc, _| {
+            let val = *acc;
+            *acc *= beta;
+            Some(val)
+          })
+          .collect::<Vec<E::G1>>()
+      },
+      || {
+        (0..=max_degree)
+          .scan(h, |acc, _| {
+            let val = *acc;
+            *acc *= beta;
+            Some(val)
+          })
+          .collect::<Vec<E::G2>>()
+      },
+    );
 
     let mut powers_of_g = vec![E::G1Affine::identity(); powers_of_g_projective.len()];
-    E::G1::batch_normalize(&powers_of_g_projective, &mut powers_of_g);
-
-    let powers_of_h_projective = (0..=max_degree)
-      .scan(h, |acc, _| {
-        let val = *acc;
-        *acc *= beta;
-        Some(val)
-      })
-      .collect::<Vec<E::G2>>();
-
     let mut powers_of_h = vec![E::G2Affine::identity(); powers_of_h_projective.len()];
-    E::G2::batch_normalize(&powers_of_h_projective, &mut powers_of_h);
+
+    rayon::join(
+      || E::G1::batch_normalize(&powers_of_g_projective, &mut powers_of_g),
+      || E::G2::batch_normalize(&powers_of_h_projective, &mut powers_of_h),
+    );
 
     Self {
       powers_of_g,

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -145,7 +145,7 @@ impl<E: Engine> UVUniversalKZGParam<E> {
 }
 
 /// Commitments
-#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Serialize, Deserialize)]
 #[serde(bound(
   serialize = "E::G1Affine: Serialize",
   deserialize = "E::G1Affine: Deserialize<'de>"
@@ -160,8 +160,15 @@ where
   E::G1: Group,
 {
   fn to_transcript_bytes(&self) -> Vec<u8> {
-    // TODO: avoid the round-trip through the group
-    E::G1::from(self.0).compress().to_transcript_bytes()
+    // TODO: avoid the round-trip through the group (to_curve .. to_coordinates)
+    let (x, y, is_infinity) = self.0.to_curve().to_coordinates();
+    let is_infinity_byte = (!is_infinity).into();
+    [
+      x.to_transcript_bytes(),
+      y.to_transcript_bytes(),
+      [is_infinity_byte].to_vec(),
+    ]
+    .concat()
   }
 }
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -189,7 +189,7 @@ where
     }
 
     debug_assert_eq!(Self::commit(pp, poly).unwrap().0, comm.0);
-    debug_assert_eq!(poly.evaluate_opt(point), eval.0);
+    debug_assert_eq!(poly.evaluate_BE(point), eval.0);
 
     let (quotients, remainder) = quotients(poly, point);
     debug_assert_eq!(remainder, eval.0);
@@ -527,7 +527,7 @@ mod test {
       let point = iter::from_fn(|| transcript.squeeze(b"pt").ok())
         .take(num_vars)
         .collect::<Vec<_>>();
-      let eval = ZMEvaluation(poly.evaluate_opt(&point));
+      let eval = ZMEvaluation(poly.evaluate_BE(&point));
 
       let mut transcript_prover = Keccak256Transcript::<E::G1>::new(b"test");
       let proof = ZMPCS::open(&pp, &comm, &poly, &point, &eval, &mut transcript_prover).unwrap();
@@ -577,11 +577,11 @@ mod test {
     }
     let (_quotients, remainder) = quotients(&poly, &point);
     assert_eq!(
-      poly.evaluate_opt(&point),
+      poly.evaluate_BE(&point),
       remainder,
       "point: {:?}, \n eval: {:?}, remainder:{:?}",
       point,
-      poly.evaluate_opt(&point),
+      poly.evaluate_BE(&point),
       remainder
     );
   }

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -425,7 +425,7 @@ where
   }
 
   fn prove(
-    ck: &UVUniversalKZGParam<E>,
+    _ck: &UVUniversalKZGParam<E>,
     pk: &Self::ProverKey,
     transcript: &mut <E::G1 as Group>::TE,
     comm: &Commitment<E::G1>,

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -436,8 +436,19 @@ where
     let commitment = ZMCommitment::from(UVKZGCommitment::from(*comm));
     // TODO: the following two lines will need to change base
     let polynomial = MultilinearPolynomial::new(poly.to_vec());
+
+    // Nova evaluates in lower endian, the implementation assumes big endian
+    let rev_point = point.iter().rev().cloned().collect::<Vec<_>>();
+
     let evaluation = ZMEvaluation(*eval);
-    ZMPCS::open(pk, &commitment, &polynomial, point, &evaluation, transcript)
+    ZMPCS::open(
+      pk,
+      &commitment,
+      &polynomial,
+      &rev_point,
+      &evaluation,
+      transcript,
+    )
   }
 
   fn verify(
@@ -450,8 +461,19 @@ where
   ) -> Result<(), NovaError> {
     let commitment = ZMCommitment::from(UVKZGCommitment::from(*comm));
     let evaluation = ZMEvaluation(*eval);
+
+    // Nova evaluates in lower endian, the implementation assumes big endian
+    let rev_point = point.iter().rev().cloned().collect::<Vec<_>>();
+
     // TODO: this clone is unsightly!
-    ZMPCS::verify(vk, transcript, &commitment, point, &evaluation, arg.clone())?;
+    ZMPCS::verify(
+      vk,
+      transcript,
+      &commitment,
+      &rev_point,
+      &evaluation,
+      arg.clone(),
+    )?;
     Ok(())
   }
 }

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -433,7 +433,11 @@ where
     point: &[<E::G1 as Group>::Scalar],
     eval: &<E::G1 as Group>::Scalar,
   ) -> Result<Self::EvaluationArgument, NovaError> {
-    todo!()
+    let commitment = ZMCommitment::from(UVKZGCommitment::from(*comm));
+    // TODO: the following two lines will need to change base
+    let polynomial = MultilinearPolynomial::new(poly.to_vec());
+    let evaluation = ZMEvaluation(*eval);
+    ZMPCS::open(pk, &commitment, &polynomial, point, &evaluation, transcript)
   }
 
   fn verify(
@@ -444,7 +448,11 @@ where
     eval: &<E::G1 as Group>::Scalar,
     arg: &Self::EvaluationArgument,
   ) -> Result<(), NovaError> {
-    todo!()
+    let commitment = ZMCommitment::from(UVKZGCommitment::from(*comm));
+    let evaluation = ZMEvaluation(*eval);
+    // TODO: this clone is unsightly!
+    ZMPCS::verify(vk, transcript, &commitment, point, &evaluation, arg.clone())?;
+    Ok(())
   }
 }
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -360,7 +360,6 @@ fn quotients<F: PrimeField>(poly: &MultilinearPolynomial<F>, point: &[F]) -> (Ve
   (quotients, remainder[0])
 }
 
-// TODO : move this somewhere else
 fn eval_and_quotient_scalars<F: Field>(y: F, x: F, z: F, point: &[F]) -> (F, Vec<F>) {
   let num_vars = point.len();
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -149,7 +149,7 @@ where
   ) -> Result<ZMCommitment<E>, NovaError> {
     let pp = pp.borrow();
     if pp.commit_pp.powers_of_g.len() < poly.Z.len() {
-      return Err(NovaError::PCSError(PCSError::LengthError)); // TODO: better error
+      return Err(PCSError::LengthError.into());
     }
     // TODO: remove the undue clone in the creation of an UVKZGPoly here
     UVKZGPCS::commit(&pp.commit_pp, &UVKZGPoly::new(poly.Z.clone())).map(|c| c.into())

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -153,7 +153,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::{bn256_grumpkin::bn256, secp_secq::secp256k1};
+  use crate::provider::{bn256_grumpkin::bn256, non_hiding_zeromorph::ZMPCS, secp_secq::secp256k1};
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;
@@ -219,7 +219,7 @@ mod tests {
     test_direct_snark_with::<G, Spp>();
 
     type G2 = bn256::Point;
-    type EE2 = crate::provider::ipa_pc::EvaluationEngine<G2>;
+    type EE2 = ZMPCS<halo2curves::bn256::Bn256>;
     type S2 = crate::spartan::snark::RelaxedR1CSSNARK<G2, EE2>;
     type S2pp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2>;
     test_direct_snark_with::<G2, S2>();

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -130,32 +130,6 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     }
     new_poly
   }
-
-  /// Evaluate the dense MLE at the given point. The MLE is assumed to be in
-  /// monomial basis.
-  ///
-  /// # Example
-  /// ```
-  /// use pasta_curves::pallas::Scalar as Fr;
-  /// use nova_snark::spartan::polys::multilinear::MultilinearPolynomial;
-  ///
-  /// // The two-variate polynomial x_1 + 3 * x_0 * x_1 + 2 evaluates to [2, 3, 2, 6]
-  /// // in the lagrange basis: 2*(1 - x_0)(1 - x_1) + 3*(1-x_0)(x_1) + 2*(x_0)(1-x_1) + 6*(x_0)(x_1)
-  /// let mle = MultilinearPolynomial::new(
-  ///     vec![2, 3, 2, 6].iter().map(|x| Fr::from(*x as u64)).collect()
-  /// );
-  ///
-  /// // By the uniqueness of MLEs, `mle` is precisely the above polynomial, which
-  /// // takes the value 54 at the point (x_1 = 1, x_0 = 17)
-  /// let eval = mle.evaluate_BE(&[Fr::one(), Fr::from(17)]);
-  /// assert_eq!(eval, Fr::from(54));
-  /// ```
-  pub fn evaluate_BE(&self, point: &[Scalar]) -> Scalar {
-    assert_eq!(self.num_vars, point.len());
-    // evaluate requires "lower endian"
-    let revp = point.iter().cloned().rev().collect::<Vec<_>>();
-    self.evaluate(&revp)
-  }
 }
 
 impl<Scalar: PrimeField> Index<usize> for MultilinearPolynomial<Scalar> {

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -139,72 +139,22 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   /// use pasta_curves::pallas::Scalar as Fr;
   /// use nova_snark::spartan::polys::multilinear::MultilinearPolynomial;
   ///
-  /// // The two-variate polynomial x_0 + 3 * x_0 * x_1 + 2 evaluates to [2, 3, 2, 6]
-  /// // in the two-dimensional hypercube with points [00, 10, 01, 11]
+  /// // The two-variate polynomial x_1 + 3 * x_0 * x_1 + 2 evaluates to [2, 3, 2, 6]
+  /// // in the lagrange basis: 2*(1 - x_0)(1 - x_1) + 3*(1-x_0)(x_1) + 2*(x_0)(1-x_1) + 6*(x_0)(x_1)
   /// let mle = MultilinearPolynomial::new(
   ///     vec![2, 3, 2, 6].iter().map(|x| Fr::from(*x as u64)).collect()
   /// );
   ///
   /// // By the uniqueness of MLEs, `mle` is precisely the above polynomial, which
-  /// // takes the value 54 at the point (1, 17)
-  /// let eval = mle.evaluate_opt(&[Fr::one(), Fr::from(17)]);
+  /// // takes the value 54 at the point (x_1 = 1, x_0 = 17)
+  /// let eval = mle.evaluate_BE(&[Fr::one(), Fr::from(17)]);
   /// assert_eq!(eval, Fr::from(54));
   /// ```
-  pub fn evaluate_opt(&self, point: &[Scalar]) -> Scalar {
+  pub fn evaluate_BE(&self, point: &[Scalar]) -> Scalar {
     assert_eq!(self.num_vars, point.len());
-    self.fix_variables(point).Z[0]
-  }
-
-  /// Return the MLE resulting from binding the first variables of self
-  /// to the values in `partial_point` (from left to right).
-  ///
-  /// # Example
-  /// ```
-  /// use pasta_curves::pallas::Scalar as Fr;
-  /// use nova_snark::spartan::polys::multilinear::MultilinearPolynomial;
-  ///
-  /// // Constructing the two-variate multilinear polynomial x_0 + 2 * x_1 + 3 * x_0 * x_1
-  /// // by specifying its evaluations at [00, 10, 01, 11]
-  /// let mle = MultilinearPolynomial::new(
-  ///     vec![0, 1, 2, 6].iter().map(|x| Fr::from(*x as u64)).collect()
-  /// );
-  ///
-  /// // Bind the first variable of the MLE to the value 5, resulting in
-  /// // the new polynomial 5 + 17 * x_1
-  /// let bound = mle.fix_variables(&[Fr::from(5)]);
-  ///
-  /// assert_eq!(bound.evaluations(), vec![Fr::from(5), Fr::from(22)]);
-  /// ```
-  /// }
-  pub fn fix_variables(&self, partial_point: &[Scalar]) -> Self {
-    assert!(
-      partial_point.len() <= self.num_vars,
-      "invalid size of partial point"
-    );
-    let nv = self.num_vars;
-    let mut poly = self.Z.clone();
-    let dim = partial_point.len();
-    // evaluate single variable of partial point from left to right
-    for (i, point) in partial_point.iter().enumerate().take(dim) {
-      poly = Self::fix_one_variable_helper(&poly, nv - i, point);
-    }
-    poly.truncate(1 << (nv - dim));
-
-    MultilinearPolynomial::new(poly)
-  }
-
-  fn fix_one_variable_helper(data: &[Scalar], nv: usize, point: &Scalar) -> Vec<Scalar> {
-    let mut res = vec![Scalar::ZERO; 1 << (nv - 1)];
-
-    // evaluate single variable of partial point from left to right
-    //  for i in 0..(1 << (nv - 1)) {
-    //     res[i] = data[i] + (data[(i << 1) + 1] - data[i << 1]) * point;
-    // }
-    res.par_iter_mut().enumerate().for_each(|(i, x)| {
-      *x = data[i << 1] + (data[(i << 1) + 1] - data[i << 1]) * point;
-    });
-
-    res
+    // evaluate requires "lower endian"
+    let revp = point.iter().cloned().rev().collect::<Vec<_>>();
+    self.evaluate(&revp)
   }
 }
 
@@ -288,7 +238,7 @@ mod tests {
   use crate::provider::{self, bn256_grumpkin::bn256, secp_secq::secp256k1};
 
   use super::*;
-  use pasta_curves::{pallas::Scalar, Fp};
+  use pasta_curves::Fp;
 
   fn make_mlp<F: PrimeField>(len: usize, value: F) -> MultilinearPolynomial<F> {
     MultilinearPolynomial {
@@ -410,31 +360,5 @@ mod tests {
     test_evaluation_with::<Fp>();
     test_evaluation_with::<provider::bn256_grumpkin::bn256::Scalar>();
     test_evaluation_with::<provider::secp_secq::secp256k1::Scalar>();
-  }
-
-  #[test]
-  fn test_dense_evaluations() {
-    let num_vars = 2;
-    let Z = vec![
-      Scalar::one(),
-      Scalar::from(2u64),
-      Scalar::one(),
-      Scalar::from(4u64),
-    ];
-    let poly = MultilinearPolynomial::new(Z);
-
-    // r = [4,3]
-    let r = vec![Scalar::from(4u64), Scalar::from(3u64)];
-    // interpreted as ~eq (in the Lagrange basis)
-    // g(x_0,x_1) => c_0*(1 - x_0)(1 - x_1) + c_1*(1-x_0)(x_1) + c_2*(x_0)(1-x_1) + c_3*(x_0)(x_1)
-    // g(4, 3) = 1*(1 - 4)(1 - 3) + 2*(1-4)(3) + 1*(4)(1-3) + 4*(4)(3) = 6 - 18 - 8 + 48 = 28
-    let eval = poly.evaluate(&r);
-    assert_eq!(eval, Scalar::from(28u64));
-
-    // interpreted in the monomial basis
-    // [1, 2, 1, 4] -> 1 + 1 * x0 + 0 * x1+ 2 x0 * x1
-    // at x0 = 4, x1 = 3 -> 1 + 1 * 4 + 0 * 3 + 2 * 4 * 3 = 29
-    let eval_opt = poly.evaluate_opt(&r[..]);
-    assert_eq!(eval_opt, Scalar::from(29u64));
   }
 }

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -213,6 +213,7 @@ mod tests {
 
   use super::*;
   use pasta_curves::Fp;
+  use rand_core::SeedableRng;
 
   fn make_mlp<F: PrimeField>(len: usize, value: F) -> MultilinearPolynomial<F> {
     MultilinearPolynomial {
@@ -334,5 +335,116 @@ mod tests {
     test_evaluation_with::<Fp>();
     test_evaluation_with::<provider::bn256_grumpkin::bn256::Scalar>();
     test_evaluation_with::<provider::secp_secq::secp256k1::Scalar>();
+  }
+
+  pub fn partial_eval<F: PrimeField>(
+    poly: &MultilinearPolynomial<F>,
+    point: &[F],
+  ) -> MultilinearPolynomial<F> {
+    // Get size of partial evaluation point u = (u_0,...,u_{m-1})
+    let m = point.len();
+
+    // Assert that the size of the polynomial being evaluated is a power of 2 greater than (1 << m)
+    assert!(poly.Z.len().is_power_of_two());
+    assert!(poly.Z.len() >= 1 << m);
+    let n = poly.Z.len().trailing_zeros() as usize;
+
+    // Partial evaluation is done in m rounds l = 0,...,m-1.
+    let mut n_l = 1 << (n - 1);
+
+    // Temporary buffer of half the size of the polynomial
+    let mut tmp = vec![F::ZERO; n_l];
+
+    let prev = &poly.Z;
+
+    // Evaluate variable X_{n-1} at u_{m-1}
+    let u_l = point[m - 1];
+    for i in 0..n_l {
+      tmp[i] = prev[i] + u_l * (prev[i + n_l] - prev[i]);
+    }
+
+    // Evaluate m-1 variables X_{n-l-1}, ..., X_{n-2} at m-1 remaining values u_0,...,u_{m-2})
+    for l in 1..m {
+      n_l = 1 << (n - l - 1);
+      let u_l = point[m - l - 1];
+      for i in 0..n_l {
+        tmp[i] = tmp[i] + u_l * (tmp[i + n_l] - tmp[i]);
+      }
+    }
+    tmp.truncate(1 << (poly.num_vars - m));
+
+    MultilinearPolynomial::new(tmp)
+  }
+
+  fn make_rand_mlp<F: PrimeField, R: RngCore>(
+    var_count: usize,
+    mut rng: &mut R,
+  ) -> MultilinearPolynomial<F> {
+    let eqpoly = EqPolynomial::new(
+      std::iter::from_fn(|| Some(F::random(&mut rng)))
+        .take(var_count)
+        .collect::<Vec<_>>(),
+    );
+    MultilinearPolynomial::new(eqpoly.evals())
+  }
+
+  fn partial_evaluate_mle_with<F: PrimeField>() {
+    // Initialize a random polynomial
+    let n = 5;
+    let mut rng = rand_xorshift::XorShiftRng::from_seed([0u8; 16]);
+    let poly = make_rand_mlp::<F, _>(n, &mut rng);
+
+    // Define a random multivariate evaluation point u = (u_0, u_1, u_2, u_3, u_4)
+    let u_0 = F::random(&mut rng);
+    let u_1 = F::random(&mut rng);
+    let u_2 = F::random(&mut rng);
+    let u_3 = F::random(&mut rng);
+    let u_4 = F::random(&mut rng);
+    let u_challenge = [u_4, u_3, u_2, u_1, u_0];
+
+    // Directly computing v = p(u_0,...,u_4) and comparing it with the result of
+    // first computing the partial evaluation in the last 3 variables
+    // g(X_0,X_1) = p(X_0,X_1,u_2,u_3,u_4), then v = g(u_0,u_1)
+
+    // Compute v = p(u_0,...,u_4)
+    let v_expected = poly.evaluate(&u_challenge[..]);
+
+    // Compute g(X_0,X_1) = p(X_0,X_1,u_2,u_3,u_4), then v = g(u_0,u_1)
+    let u_part_1 = [u_1, u_0]; // note the endianness difference
+    let u_part_2 = [u_2, u_3, u_4];
+    let partial_evaluated_poly = partial_eval(&poly, &u_part_2);
+    let v_result = partial_evaluated_poly.evaluate(&u_part_1);
+
+    assert_eq!(v_result, v_expected);
+  }
+
+  #[test]
+  fn test_partial_evaluate_mle() {
+    partial_evaluate_mle_with::<Fp>();
+    partial_evaluate_mle_with::<bn256::Scalar>();
+    partial_evaluate_mle_with::<secp256k1::Scalar>();
+  }
+
+  fn partial_and_evaluate_with<F: PrimeField>() {
+    for _i in 0..50 {
+      // Initialize a random polynomial
+      let n = 7;
+      let mut rng = rand_xorshift::XorShiftRng::from_seed([0u8; 16]);
+      let poly = make_rand_mlp::<F, _>(n, &mut rng);
+
+      // draw a random point
+      let pt: Vec<_> = std::iter::from_fn(|| Some(F::random(&mut rng)))
+        .take(n)
+        .collect();
+      let rev_pt: Vec<_> = pt.iter().cloned().rev().collect();
+      assert_eq!(poly.evaluate(&pt), partial_eval(&poly, &rev_pt).Z[0])
+    }
+  }
+
+  #[test]
+  fn test_partial_and_evaluate() {
+    partial_and_evaluate_with::<Fp>();
+    partial_and_evaluate_with::<bn256::Scalar>();
+    partial_and_evaluate_with::<secp256k1::Scalar>();
   }
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -717,7 +717,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "0b8c080ffa823b95d1dd75b6a5b49852c53ff60fbead6652af6d2a0bd177b800",
+    "f8de057dc64151079516d660f929b5f92e514a54d1c5ab70b1f1520c0043e902",
   );
 
   let rom = vec![


### PR DESCRIPTION
- makes tests generic in the `EvaluationEngine` by adopting #70,
- documents the gap between ZM / IPA: "endianness" w/ which coefficients must be supplied to the scheme,
- implements a `CommitmentKey` with a token universal setup, which allows implementing a `CommitmentEngineTrait` for KZG commitments,
- implements the prove & verify methods for the `EvaluationEngineTrait` implementation for ZMPCS. The scheme is slow (due to poor univariate KZG batching) 

Closes #19 

TODO: 
- [x] modify `gen_srs_for_testing` so the tests run in reasonable time.
- [x] cleaning up "point endianness" a bit

Next steps:
- making univariate KZG actually fast,
- document the protocol a bit more #35, 
- #22, 
