### PR TITLE
Adjust `supernova::RecursiveSNARK::verify` API

### DIFF
--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -738,7 +738,7 @@ where
     circuit_index: usize,
     z0_primary: &[G1::Scalar],
     z0_secondary: &[G2::Scalar],
-  ) -> Result<(), SuperNovaError> {
+  ) -> Result<(Vec<G1::Scalar>, Vec<G2::Scalar>), SuperNovaError> {
     // number of steps cannot be zero
     if self.i == 0 {
       debug!("must verify on valid RecursiveSNARK where i > 0");
@@ -896,7 +896,7 @@ where
       e => SuperNovaError::NovaError(e),
     })?;
 
-    Ok(())
+    Ok((self.zi_primary.clone(), self.zi_secondary.clone()))
   }
 
   /// get program counter


### PR DESCRIPTION
This PR addresses #68 (and is the arecibo fix of issue [#695](https://github.com/lurk-lab/lurk-rs/issues/695) in lurk-rs)

The only change is we return `zi_primary` and `zi_secondary` in `supernova::RecursiveSNARK::verify` to match what's done in [`RecursiveSNARK::verify`](https://github.com/lurk-lab/arecibo/blob/c657b04a005182cb7bc1937f22b70dde747c1bdc/src/lib.rs#L532)