### PR TITLE
Upgrade to Buildjet runner with 8 CPUs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     env:
       RUSTFLAGS: -D warnings
     steps:


### PR DESCRIPTION
#48 tests seem to be bottlenecked on hardware, so this PR upgrades from the stock GitHub runner (2 vCPUs, 7GB RAM) to Buildjet (8 vCPUs, 32GB RAM).

Note: Adding Buildjet to a repo also requires going to organization Settings->GitHub Apps->Buildjet-Configure and granting access to the repo.