### PR TITLE
chore: Parallel clones for large data structures

### DIFF
--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -17,11 +17,20 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A type that holds commitment generators
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 #[abomonation_omit_bounds]
 pub struct CommitmentKey<G: Group> {
   #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
   ck: Vec<G::PreprocessedGroupElement>,
+}
+
+/// [CommitmentKey]s are often large, and this helps with cloning bottlenecks
+impl<G: Group> Clone for CommitmentKey<G> {
+  fn clone(&self) -> Self {
+    Self {
+      ck: self.ck.par_iter().cloned().collect(),
+    }
+  }
 }
 
 impl<G: Group> Len for CommitmentKey<G> {

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 /// CSR format sparse matrix, We follow the names used by scipy.
 /// Detailed explanation here: <https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr>
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 #[abomonation_bounds(where <F as PrimeField>::Repr: Abomonation)]
 pub struct SparseMatrix<F: PrimeField> {
   #[abomonate_with(Vec<F::Repr>)]
@@ -24,6 +24,18 @@ pub struct SparseMatrix<F: PrimeField> {
   pub indptr: Vec<usize>,
   /// number of columns
   pub cols: usize,
+}
+
+/// [SparseMatrix]s are often large, and this helps with cloning bottlenecks
+impl<F: PrimeField> Clone for SparseMatrix<F> {
+  fn clone(&self) -> Self {
+    Self {
+      data: self.data.par_iter().cloned().collect(),
+      indices: self.indices.par_iter().cloned().collect(),
+      indptr: self.indptr.par_iter().cloned().collect(),
+      cols: self.cols,
+    }
+  }
 }
 
 impl<F: PrimeField> SparseMatrix<F> {


### PR DESCRIPTION
Further work from https://github.com/lurk-lab/lurk-rs/pull/777.

This continues the story. pq observes that:
> I now believe, based on informal observation, that the loading in mmap-fix is slower than generating fresh params.

The long loading times were due to two separate issues. The first is a bug (fixed in https://github.com/lurk-lab/lurk-rs/pull/777), and the second is the lack of parallelization. This PR addresses the low hanging fruit by implementing parallel clones for the large data structures. We see ~2x speedup.

Before this PR:
```
bang!                                         24.328472s ├─────────────────────────────────────────────────────────────┤
  Instance::new                                535.148ms │
    <MultiFrame as StepCircuit>::synthesize     230.39ms  │
  read_abomonated                             15.416185s  ├──────────────────────────────────────┤
    decode                                       4.137ms  ┆
    clone                                     15.411941s  ├──────────────────────────────────────┤

```

After this PR:
```
bang!                                         18.039595s ├─────────────────────────────────────────────────────────────┤
  Instance::new                                530.639ms ├┤
    <MultiFrame as StepCircuit>::synthesize    233.376ms  │
  read_abomonated                              8.473104s   ├────────────────────────────┤
    decode                                         2.8ms   ┆
    clone                                      8.469151s   ├────────────────────────────┤

```