### PR TITLE
Supernova Compressed SNARKs

### DIFF
--- a/src/supernova/error.rs
+++ b/src/supernova/error.rs
@@ -16,4 +16,7 @@ pub enum SuperNovaError {
   /// Extended error for supernova
   #[error("UnSatIndex")]
   UnSatIndex(&'static str, usize),
+  ///
+  #[error("ProofCreationError")]
+  ProofCreationError,
 }

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -41,6 +41,7 @@ use circuit::{
 use self::error::SuperNovaError;
 
 pub mod error;
+pub mod snark;
 pub(crate) mod utils;
 
 #[cfg(test)]

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -301,24 +301,259 @@ fn field_as_usize<F: PrimeField>(x: F) -> usize {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::provider::{
-    bn256_grumpkin::{bn256, grumpkin},
-    secp_secq::{secp256k1, secq256k1},
+  use crate::{
+    provider::{
+      bn256_grumpkin::{bn256, grumpkin},
+      ipa_pc::EvaluationEngine,
+      secp_secq::{secp256k1, secq256k1},
+    },
+    spartan::snark::RelaxedR1CSSNARK,
+    supernova::NonUniformCircuit,
+    traits::{circuit_supernova::TrivialSecondaryCircuit, evaluation::EvaluationEngineTrait},
   };
+
+  use abomonation::Abomonation;
+  use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use ff::Field;
   use pasta_curves::{pallas, vesta};
 
-  fn test_nivc_nontrivial_with_compression_with<G1, G2>()
+  type EE<G> = EvaluationEngine<G>;
+  type S<G, EE> = RelaxedR1CSSNARK<G, EE>;
+
+  #[derive(Clone)]
+  struct SquareCircuit<G: Group> {
+    _p: PhantomData<G>,
+  }
+
+  impl<G: Group> StepCircuit<G::Scalar> for SquareCircuit<G> {
+    fn arity(&self) -> usize {
+      1
+    }
+
+    fn circuit_index(&self) -> usize {
+      0
+    }
+
+    fn synthesize<CS: ConstraintSystem<G::Scalar>>(
+      &self,
+      cs: &mut CS,
+      _pc: Option<&AllocatedNum<G::Scalar>>,
+      z: &[AllocatedNum<G::Scalar>],
+    ) -> Result<
+      (
+        Option<AllocatedNum<G::Scalar>>,
+        Vec<AllocatedNum<G::Scalar>>,
+      ),
+      SynthesisError,
+    > {
+      let z_i = &z[0];
+
+      let z_next = z_i.square(cs.namespace(|| "z_i^2"))?;
+
+      let next_pc = AllocatedNum::alloc(cs.namespace(|| "next_pc"), || Ok(G::Scalar::from(1u64)))?;
+
+      cs.enforce(
+        || "next_pc = 1",
+        |lc| lc + CS::one(),
+        |lc| lc + next_pc.get_variable(),
+        |lc| lc + CS::one(),
+      );
+
+      Ok((Some(next_pc), vec![z_next]))
+    }
+  }
+
+  #[derive(Clone)]
+  struct CubeCircuit<G: Group> {
+    _p: PhantomData<G>,
+  }
+
+  impl<G: Group> StepCircuit<G::Scalar> for CubeCircuit<G> {
+    fn arity(&self) -> usize {
+      1
+    }
+
+    fn circuit_index(&self) -> usize {
+      1
+    }
+
+    fn synthesize<CS: ConstraintSystem<G::Scalar>>(
+      &self,
+      cs: &mut CS,
+      _pc: Option<&AllocatedNum<G::Scalar>>,
+      z: &[AllocatedNum<G::Scalar>],
+    ) -> Result<
+      (
+        Option<AllocatedNum<G::Scalar>>,
+        Vec<AllocatedNum<G::Scalar>>,
+      ),
+      SynthesisError,
+    > {
+      let z_i = &z[0];
+
+      let z_sq = z_i.square(cs.namespace(|| "z_i^2"))?;
+      let z_cu = z_sq.mul(cs.namespace(|| "z_i^3"), z_i)?;
+
+      let next_pc = AllocatedNum::alloc(cs.namespace(|| "next_pc"), || Ok(G::Scalar::from(0u64)))?;
+
+      cs.enforce(
+        || "next_pc = 0",
+        |lc| lc + CS::one(),
+        |lc| lc + next_pc.get_variable(),
+        |lc| lc,
+      );
+
+      Ok((Some(next_pc), vec![z_cu]))
+    }
+  }
+
+  #[derive(Clone)]
+  enum TestCircuit<G: Group> {
+    Square(SquareCircuit<G>),
+    Cube(CubeCircuit<G>),
+  }
+
+  impl<G: Group> StepCircuit<G::Scalar> for TestCircuit<G> {
+    fn arity(&self) -> usize {
+      1
+    }
+
+    fn circuit_index(&self) -> usize {
+      match self {
+        TestCircuit::Square(c) => c.circuit_index(),
+        TestCircuit::Cube(c) => c.circuit_index(),
+      }
+    }
+
+    fn synthesize<CS: ConstraintSystem<G::Scalar>>(
+      &self,
+      cs: &mut CS,
+      pc: Option<&AllocatedNum<G::Scalar>>,
+      z: &[AllocatedNum<G::Scalar>],
+    ) -> Result<
+      (
+        Option<AllocatedNum<G::Scalar>>,
+        Vec<AllocatedNum<G::Scalar>>,
+      ),
+      SynthesisError,
+    > {
+      match self {
+        TestCircuit::Square(c) => c.synthesize(cs, pc, z),
+        TestCircuit::Cube(c) => c.synthesize(cs, pc, z),
+      }
+    }
+  }
+
+  struct TestNIVC<G1, G2> {
+    _p: PhantomData<(G1, G2)>,
+  }
+
+  impl<G1, G2> TestNIVC<G1, G2> {
+    fn new() -> Self {
+      TestNIVC { _p: PhantomData }
+    }
+  }
+
+  impl<G1, G2> NonUniformCircuit<G1, G2, TestCircuit<G1>, TrivialSecondaryCircuit<G2::Scalar>>
+    for TestNIVC<G1, G2>
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
   {
-    assert!(true)
+    fn initial_program_counter(&self) -> <G1 as Group>::Scalar {
+      G1::Scalar::from(0u64)
+    }
+
+    fn num_circuits(&self) -> usize {
+      2
+    }
+
+    fn primary_circuit(&self, circuit_index: usize) -> TestCircuit<G1> {
+      match circuit_index {
+        0 => TestCircuit::Square(SquareCircuit { _p: PhantomData }),
+        1 => TestCircuit::Cube(CubeCircuit { _p: PhantomData }),
+        _ => panic!("Invalid circuit index"),
+      }
+    }
+
+    fn secondary_circuit(&self) -> TrivialSecondaryCircuit<G2::Scalar> {
+      Default::default()
+    }
+  }
+
+  fn test_nivc_trivial_with_compression_with<G1, G2, E1, E2>()
+  where
+    G1: Group<Base = <G2 as Group>::Scalar>,
+    G2: Group<Base = <G1 as Group>::Scalar>,
+    E1: EvaluationEngineTrait<G1>,
+    E2: EvaluationEngineTrait<G2>,
+    <G1::Scalar as PrimeField>::Repr: Abomonation,
+    <G2::Scalar as PrimeField>::Repr: Abomonation,
+  {
+    const NUM_STEPS: usize = 6;
+
+    let test_nivc = TestNIVC::<G1, G2>::new();
+
+    let pp = PublicParams::new(&test_nivc);
+
+    let initial_pc = test_nivc.initial_program_counter();
+    let mut augmented_circuit_index = field_as_usize(initial_pc);
+
+    let z0_primary = vec![G1::Scalar::from(17u64)];
+    let z0_secondary = vec![<G2 as Group>::Scalar::ZERO];
+
+    let mut recursive_snark = RecursiveSNARK::iter_base_step(
+      &pp,
+      augmented_circuit_index,
+      &test_nivc.primary_circuit(augmented_circuit_index),
+      &test_nivc.secondary_circuit(),
+      Some(initial_pc),
+      augmented_circuit_index,
+      2,
+      &z0_primary,
+      &z0_secondary,
+    )
+    .unwrap();
+
+    for _ in 0..NUM_STEPS {
+      let prove_res = recursive_snark.prove_step(
+        &pp,
+        augmented_circuit_index,
+        &test_nivc.primary_circuit(augmented_circuit_index),
+        &test_nivc.secondary_circuit(),
+        &z0_primary,
+        &z0_secondary,
+      );
+
+      let verify_res =
+        recursive_snark.verify(&pp, augmented_circuit_index, &z0_primary, &z0_secondary);
+
+      assert!(prove_res.is_ok());
+      assert!(verify_res.is_ok());
+
+      let program_counter = recursive_snark.get_program_counter();
+      augmented_circuit_index = field_as_usize(program_counter);
+    }
+
+    let (prover_key, verifier_key) =
+      CompressedSNARK::<_, _, _, _, S<G1, E1>, S<G2, E2>>::setup(&pp).unwrap();
+
+    let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
+
+    assert!(compressed_prove_res.is_ok());
+
+    let compressed_snark = compressed_prove_res.unwrap();
+
+    let compressed_verify_res =
+      compressed_snark.verify(&pp, &verifier_key, z0_primary, z0_secondary);
+
+    assert!(compressed_verify_res.is_ok());
   }
 
   #[test]
-  fn test_nivc_nontrivial_with_compression() {
-    test_nivc_nontrivial_with_compression_with::<pallas::Point, vesta::Point>();
-    test_nivc_nontrivial_with_compression_with::<bn256::Point, grumpkin::Point>();
-    test_nivc_nontrivial_with_compression_with::<secp256k1::Point, secq256k1::Point>();
+  fn test_nivc_trivial_with_compression() {
+    test_nivc_trivial_with_compression_with::<pallas::Point, vesta::Point, EE<_>, EE<_>>();
+    test_nivc_trivial_with_compression_with::<bn256::Point, grumpkin::Point, EE<_>, EE<_>>();
+    test_nivc_trivial_with_compression_with::<secp256k1::Point, secq256k1::Point, EE<_>, EE<_>>();
   }
 }

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -2,7 +2,14 @@
 
 use std::marker::PhantomData;
 
-use crate::traits::{circuit_supernova::StepCircuit, snark::RelaxedR1CSSNARKTrait, Group};
+use crate::{
+  constants::NUM_HASH_BITS,
+  gadgets::utils::scalar_as_base,
+  r1cs::RelaxedR1CSInstance,
+  traits::{
+    circuit_supernova::StepCircuit, snark::RelaxedR1CSSNARKTrait, AbsorbInROTrait, Group, ROTrait,
+  },
+};
 
 use super::{error::SuperNovaError, PublicParams, RecursiveSNARK};
 
@@ -48,7 +55,16 @@ where
 {
   primary_proofs: Vec<S1>,
   secondary_proof: S2,
-  _p: PhantomData<(C1, C2)>,
+
+  num_steps: usize,
+  last_circuit_idx: usize,
+
+  r_U_primary: RelaxedR1CSInstance<G1>,
+  r_U_secondary: RelaxedR1CSInstance<G2>,
+
+  zn_primary: Vec<G1::Scalar>,
+  zn_secondary: Vec<G2::Scalar>,
+  _p: PhantomData<(G1, G2, C1, C2)>,
 }
 
 impl<G1, G2, C1, C2, S1, S2> CompressedSNARK<G1, G2, C1, C2, S1, S2>
@@ -106,8 +122,8 @@ where
     let primary_proofs = pk
       .pks_primary
       .iter()
-      .zip(recursive_snark.r_W_primary.clone())
-      .zip(recursive_snark.r_U_primary.clone())
+      .zip(&recursive_snark.r_W_primary)
+      .zip(&recursive_snark.r_U_primary)
       .map(|((pk, r_W), r_U)| {
         let r_W = r_W.unwrap_or_else(|| panic!("Wrong number of circuits"));
         let r_U = r_U.unwrap_or_else(|| panic!("Wrong number of circuits"));
@@ -115,16 +131,30 @@ where
       })
       .collect::<Result<Vec<S1>, _>>()?;
 
+    let secondary_r_U = &recursive_snark.r_U_secondary[0].unwrap();
+    let secondary_r_W = &recursive_snark.r_W_secondary[0].unwrap();
+
     let secondary_proof = S2::prove(
       &pp.ck_secondary,
       &pk.pk_secondary,
-      &recursive_snark.r_U_secondary[0].clone().unwrap(),
-      &recursive_snark.r_W_secondary[0].clone().unwrap(),
+      secondary_r_U,
+      secondary_r_W,
     )?;
+
+    let last_circuit_idx = recursive_snark.augmented_circuit_index;
 
     let compressed_snark = CompressedSNARK {
       primary_proofs,
       secondary_proof,
+
+      r_U_primary: recursive_snark.r_U_primary[last_circuit_idx].unwrap(),
+      r_U_secondary: recursive_snark.r_U_secondary[0].unwrap(),
+
+      num_steps: recursive_snark.i,
+      last_circuit_idx,
+
+      zn_primary: recursive_snark.zi_primary, // TODO: I'm fairly certain this is right, but I should double check
+      zn_secondary: recursive_snark.zi_secondary,
       _p: PhantomData,
     };
 
@@ -132,17 +162,85 @@ where
   }
 
   /// verify a `CompressedSNARK` proof
-  pub fn verify(&self, vk: &VerifierKey<G1, G2, C1, C2, S1, S2>) -> () {
-    todo!()
+  pub fn verify(
+    &self,
+    pp: &PublicParams<G1, G2, C1, C2>,
+    vk: &VerifierKey<G1, G2, C1, C2, S1, S2>,
+    z0_primary: Vec<G1::Scalar>,
+    z0_secondary: Vec<G2::Scalar>,
+  ) -> Result<(Vec<G1::Scalar>, Vec<G2::Scalar>), SuperNovaError> {
+    let num_field_primary_ro = 3 // params_next, i_new, program_counter_new
+    + 2 * pp[self.last_circuit_idx].F_arity // zo, z1
+    + (7 + 2 * pp.augmented_circuit_params_primary.get_n_limbs()); // # 1 * (7 + [X0, X1]*#num_limb)
+
+    // secondary circuit
+    let num_field_secondary_ro = 2 // params_next, i_new
+    + 2 * pp.circuit_shape_secondary.F_arity // zo, z1
+    + pp.circuit_shapes.len() * (7 + 2 * pp.augmented_circuit_params_primary.get_n_limbs()); // #num_augment
+
+    let (hash_primary, hash_secondary) = {
+      let mut hasher = <G2 as Group>::RO::new(pp.ro_consts_secondary.clone(), num_field_primary_ro);
+
+      hasher.absorb(pp.digest());
+      hasher.absorb(G1::Scalar::from(self.num_steps as u64));
+      hasher.absorb(G1::Scalar::from(self.last_circuit_idx as u64));
+
+      for e in z0_primary {
+        hasher.absorb(e);
+      }
+
+      for e in &self.zn_primary {
+        hasher.absorb(*e);
+      }
+
+      self.r_U_secondary.absorb_in_ro(&mut hasher);
+
+      let mut hasher2 =
+        <G1 as Group>::RO::new(pp.ro_consts_primary.clone(), num_field_secondary_ro);
+
+      hasher2.absorb(scalar_as_base::<G1>(pp.digest()));
+      hasher2.absorb(G2::Scalar::from(self.num_steps as u64));
+
+      for e in z0_secondary {
+        hasher2.absorb(e);
+      }
+
+      for e in &self.zn_secondary {
+        hasher2.absorb(*e);
+      }
+
+      let default_value =
+        RelaxedR1CSInstance::default(&pp.ck_primary, &pp[self.last_circuit_idx].r1cs_shape);
+
+      self.r_U_primary.absorb_in_ro(&mut hasher2); // TODO: This is wrong, I need to hash all the `r_U_primary` (add them in the proof?)
+
+      (
+        hasher.squeeze(NUM_HASH_BITS),
+        hasher2.squeeze(NUM_HASH_BITS),
+      )
+    };
+
+    let res = self
+      .primary_proofs
+      .iter()
+      .zip(vk.vks_primary)
+      .map(|(proof, vk)| {
+        let U = &self.r_U_primary;
+        proof.verify(&vk, U)
+      })
+      .collect::<Vec<_>>();
+
+    Ok((z0_primary, z0_secondary))
   }
 }
 
 #[cfg(test)]
 mod test {
-
   use super::*;
-  use crate::provider::bn256_grumpkin::{bn256, grumpkin};
-  use crate::provider::secp_secq::{secp256k1, secq256k1};
+  use crate::provider::{
+    bn256_grumpkin::{bn256, grumpkin},
+    secp_secq::{secp256k1, secq256k1},
+  };
   use pasta_curves::{pallas, vesta};
 
   fn test_nivc_nontrivial_with_compression_with<G1, G2>()

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -130,7 +130,7 @@ where
       &scalar_as_base::<G1>(pp.digest()),
       &pp.circuit_shape_secondary.r1cs_shape,
       recursive_snark.r_U_secondary[0].as_ref().unwrap(),
-      &recursive_snark.r_W_secondary[0].as_ref().unwrap(),
+      recursive_snark.r_W_secondary[0].as_ref().unwrap(),
       &recursive_snark.l_u_secondary,
       &recursive_snark.l_w_secondary,
     );
@@ -149,7 +149,7 @@ where
         let r_U = r_U
           .as_ref()
           .unwrap_or_else(|| panic!("Wrong number of circuits"));
-        S1::prove(&pp.ck_primary, pk, &r_U, &r_W)
+        S1::prove(&pp.ck_primary, pk, r_U, r_W)
       })
       .collect::<Result<Vec<S1>, _>>()?;
 
@@ -267,7 +267,7 @@ where
       .zip(&vk.vks_primary)
       .map(|((idx, proof), vk)| {
         let U = &self.r_U_primary[idx];
-        proof.verify(&vk, U)
+        proof.verify(vk, U)
       })
       .collect::<Vec<_>>();
 

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -1,0 +1,162 @@
+//! In this module we define a compressing SNARK for Supernova proofs
+
+use std::marker::PhantomData;
+
+use crate::traits::{circuit_supernova::StepCircuit, snark::RelaxedR1CSSNARKTrait, Group};
+
+use super::{error::SuperNovaError, PublicParams, RecursiveSNARK};
+
+/// The prover key for the Supernova CompressedSNARK
+pub struct ProverKey<G1, G2, C1, C2, S1, S2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+  S1: RelaxedR1CSSNARKTrait<G1>,
+  S2: RelaxedR1CSSNARKTrait<G2>,
+{
+  pks_primary: Vec<S1::ProverKey>,
+  pk_secondary: S2::ProverKey,
+  _p: PhantomData<(C1, C2)>,
+}
+
+/// The verifier key for the Supernova CompressedSNARK
+pub struct VerifierKey<G1, G2, C1, C2, S1, S2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+  S1: RelaxedR1CSSNARKTrait<G1>,
+  S2: RelaxedR1CSSNARKTrait<G2>,
+{
+  vks_primary: Vec<S1::VerifierKey>,
+  vk_secondary: S2::VerifierKey,
+  _p: PhantomData<(C1, C2)>,
+}
+
+/// The SNARK that proves the knowledge of a valid Supernova `RecursiveSNARK`
+pub struct CompressedSNARK<G1, G2, C1, C2, S1, S2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+  S1: RelaxedR1CSSNARKTrait<G1>,
+  S2: RelaxedR1CSSNARKTrait<G2>,
+{
+  primary_proofs: Vec<S1>,
+  secondary_proof: S2,
+  _p: PhantomData<(C1, C2)>,
+}
+
+impl<G1, G2, C1, C2, S1, S2> CompressedSNARK<G1, G2, C1, C2, S1, S2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+  C1: StepCircuit<G1::Scalar>,
+  C2: StepCircuit<G2::Scalar>,
+  S1: RelaxedR1CSSNARKTrait<G1>,
+  S2: RelaxedR1CSSNARKTrait<G2>,
+{
+  /// Generate the prover and verifier keys for the `CompressedSNARK` prover and verifier
+  pub fn setup(
+    pp: &PublicParams<G1, G2, C1, C2>,
+  ) -> Result<
+    (
+      ProverKey<G1, G2, C1, C2, S1, S2>,
+      VerifierKey<G1, G2, C1, C2, S1, S2>,
+    ),
+    SuperNovaError,
+  > {
+    let (pks_primary, vks_primary) = pp
+      .circuit_shapes
+      .iter()
+      .map(|c| S1::setup(&pp.ck_primary, &c.r1cs_shape))
+      .collect::<Result<Vec<_>, _>>()?
+      .into_iter()
+      .unzip();
+
+    let (pk_secondary, vk_secondary) =
+      S2::setup(&pp.ck_secondary, &pp.circuit_shape_secondary.r1cs_shape)?;
+
+    let prover_key = ProverKey {
+      pks_primary,
+      pk_secondary,
+      _p: PhantomData,
+    };
+    let verifier_key = VerifierKey {
+      vks_primary,
+      vk_secondary,
+      _p: PhantomData,
+    };
+
+    Ok((prover_key, verifier_key))
+  }
+
+  /// create a new `CompressedSNARK` proof
+  pub fn prove(
+    pp: &PublicParams<G1, G2, C1, C2>,
+    pk: &ProverKey<G1, G2, C1, C2, S1, S2>,
+    recursive_snark: &RecursiveSNARK<G1, G2>,
+  ) -> Result<Self, SuperNovaError> {
+    // TODO: Check if there's any pre-processing that needs to be done
+
+    let primary_proofs = pk
+      .pks_primary
+      .iter()
+      .zip(recursive_snark.r_W_primary.clone())
+      .zip(recursive_snark.r_U_primary.clone())
+      .map(|((pk, r_W), r_U)| {
+        let r_W = r_W.unwrap_or_else(|| panic!("Wrong number of circuits"));
+        let r_U = r_U.unwrap_or_else(|| panic!("Wrong number of circuits"));
+        S1::prove(&pp.ck_primary, pk, &r_U, &r_W)
+      })
+      .collect::<Result<Vec<S1>, _>>()?;
+
+    let secondary_proof = S2::prove(
+      &pp.ck_secondary,
+      &pk.pk_secondary,
+      &recursive_snark.r_U_secondary[0].clone().unwrap(),
+      &recursive_snark.r_W_secondary[0].clone().unwrap(),
+    )?;
+
+    let compressed_snark = CompressedSNARK {
+      primary_proofs,
+      secondary_proof,
+      _p: PhantomData,
+    };
+
+    Ok(compressed_snark)
+  }
+
+  /// verify a `CompressedSNARK` proof
+  pub fn verify(&self, vk: &VerifierKey<G1, G2, C1, C2, S1, S2>) -> () {
+    todo!()
+  }
+}
+
+#[cfg(test)]
+mod test {
+
+  use super::*;
+  use crate::provider::bn256_grumpkin::{bn256, grumpkin};
+  use crate::provider::secp_secq::{secp256k1, secq256k1};
+  use pasta_curves::{pallas, vesta};
+
+  fn test_nivc_nontrivial_with_compression_with<G1, G2>()
+  where
+    G1: Group<Base = <G2 as Group>::Scalar>,
+    G2: Group<Base = <G1 as Group>::Scalar>,
+  {
+    assert!(true)
+  }
+
+  #[test]
+  fn test_nivc_nontrivial_with_compression() {
+    test_nivc_nontrivial_with_compression_with::<pallas::Point, vesta::Point>();
+    test_nivc_nontrivial_with_compression_with::<bn256::Point, grumpkin::Point>();
+    test_nivc_nontrivial_with_compression_with::<secp256k1::Point, secq256k1::Point>();
+  }
+}

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -148,22 +148,24 @@ where
     let r_W_snark_primary = pk
       .pks_primary
       .iter()
+      .zip(&pp.circuit_shapes)
       .zip(&recursive_snark.r_W_primary)
       .zip(&recursive_snark.r_U_primary)
-      .map(|((pk, r_W), r_U)| {
+      .map(|(((pk, shape), r_W), r_U)| {
         let r_W = r_W
           .as_ref()
-          .unwrap_or_else(|| panic!("Wrong number of circuits"));
+          .unwrap_or_else(|| panic!("Expected circuit witness"));
         let r_U = r_U
           .as_ref()
-          .unwrap_or_else(|| panic!("Wrong number of circuits"));
-        S1::prove(&pp.ck_primary, pk, r_U, r_W)
+          .unwrap_or_else(|| panic!("Expected circuit instance"));
+        S1::prove(&pp.ck_primary, pk, &shape.r1cs_shape, r_U, r_W)
       })
       .collect::<Result<Vec<S1>, _>>()?;
 
     let f_W_snark_secondary = S2::prove(
       &pp.ck_secondary,
       &pk.pk_secondary,
+      &pp.circuit_shape_secondary.r1cs_shape,
       &f_U_secondary,
       &f_W_secondary,
     )?;


### PR DESCRIPTION
This PR implements a final compressing SNARK for Supernova NIVC proofs. It also adds a test for the compressed SNARK.

This version 0 of compression simply generates a SNARK proof for each primary running instance, and the secondary instance. The verifier then checks the validity of each of the SNARKs.