### PR TITLE
ci: Implement GitHub action to check 'lurk-rs' compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,30 @@ jobs:
       run: |
         cargo nextest run --profile ci --workspace --cargo-profile dev-ci
 
+  check-lurk-compiles:
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ github.workspace }}/arecibo
+    - uses: actions/checkout@v2
+      with:
+        repository: lurk-lab/lurk-rs
+        path: ${{ github.workspace }}/lurk
+        submodules: recursive
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Patch Cargo.toml
+      working-directory: ${{ github.workspace }}/lurk
+      run: |
+        echo "[patch.'https://github.com/lurk-lab/arecibo']" >> Cargo.toml
+        echo "nova = { path='../arecibo', package='nova-snark' }" >> Cargo.toml
+    - name: Check Lurk-rs types don't break spectacularly
+      working-directory: ${{ github.workspace }}/lurk
+      run: cargo check --all --tests --benches --examples
+
   misc:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
- Introduced a GitHub Action job `check-lurk-compiles` to verify the compilation of `lurk-rs` types.
- Implementation involved checking out two repositories, patching `Cargo.toml` in `lurk`, and conducting `cargo check` with different flags.

Checked: the [test run](https://github.com/lurk-lab/arecibo/actions/runs/6667665254) does print
```
    Checking nova-snark v0.24.0 (/home/runner/actions-runner/_work/arecibo/arecibo/arecibo)
```