### PR TITLE
Add non-deterministic ivc test.

### DIFF
--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -339,6 +339,10 @@ where
     1
   }
 
+  fn circuit_index(&self) -> usize {
+    0
+  }
+
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -168,8 +168,8 @@ where
   C2: StepCircuit<G2::Scalar>,
 {
   /// Construct a new [PublicParams]
-  pub fn new<NC: NonUniformCircuit<G1, G2, C1, C2>>(non_unifrom_circuit: &NC) -> Self {
-    let num_circuits = non_unifrom_circuit.num_circuits();
+  pub fn new<NC: NonUniformCircuit<G1, G2, C1, C2>>(non_uniform_circuit: &NC) -> Self {
+    let num_circuits = non_uniform_circuit.num_circuits();
 
     let augmented_circuit_params_primary =
       SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
@@ -179,7 +179,7 @@ where
 
     let circuit_shapes = (0..num_circuits)
       .map(|i| {
-        let c_primary = non_unifrom_circuit.primary_circuit(i);
+        let c_primary = non_uniform_circuit.primary_circuit(i);
         let F_arity = c_primary.arity();
         // Initialize ck for the primary
         let circuit_primary: SuperNovaAugmentedCircuit<'_, G2, C1> = SuperNovaAugmentedCircuit::new(
@@ -191,6 +191,7 @@ where
         );
         let mut cs: ShapeCS<G1> = ShapeCS::new();
         let _ = circuit_primary.synthesize(&mut cs);
+
         // We use the largest commitment_key for all instances
         let r1cs_shape_primary = cs.r1cs_shape();
         CircuitShape::new(r1cs_shape_primary, F_arity)
@@ -202,7 +203,7 @@ where
     let augmented_circuit_params_secondary =
       SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
     let ro_consts_secondary: ROConstants<G2> = ROConstants::<G2>::default();
-    let c_secondary = non_unifrom_circuit.secondary_circuit();
+    let c_secondary = non_uniform_circuit.secondary_circuit();
     let F_arity_secondary = c_secondary.arity();
     let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::default();
 
@@ -615,7 +616,7 @@ where
 
     let (l_u_primary, l_w_primary) = cs_primary
       .r1cs_instance_and_witness(&pp[circuit_index].r1cs_shape, &pp.ck_primary)
-      .map_err(|_| SuperNovaError::NovaError(NovaError::UnSat))?;
+      .map_err(SuperNovaError::NovaError)?;
 
     // Split into `if let`/`else` statement
     // to avoid `returns a value referencing data owned by closure` error on `&RelaxedR1CSInstance::default` and `RelaxedR1CSWitness::default`

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -13,9 +13,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   fn arity(&self) -> usize;
 
   /// Return this `StepCircuit`'s assigned index, for use when enforcing the program counter.
-  fn circuit_index(&self) -> usize {
-    0
-  }
+  fn circuit_index(&self) -> usize;
 
   /// Sythesize the circuit for a computation step and return variable
   /// that corresponds to the output of the step `pc_{i+1}` and `z_{i+1}`
@@ -70,6 +68,10 @@ where
     1
   }
 
+  fn circuit_index(&self) -> usize {
+    0
+  }
+
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     _cs: &mut CS,
@@ -94,6 +96,10 @@ where
 {
   fn arity(&self) -> usize {
     1
+  }
+
+  fn circuit_index(&self) -> usize {
+    0
   }
 
   fn synthesize<CS: ConstraintSystem<F>>(


### PR DESCRIPTION
This PR adds a test exercising support for non-deterministic hints in NIVC. It is based on the equivalent test for IVC in Nova. Instead of proving a series of sequential fifth-root computations (which would be expensive to calculate directly, so instead are calculated in reverse to produce the sequence of hints) — we produce a sequence of alternating cube and fifth roots. This alternation exercises NIVC. We hardcode the next program-counter into the circuit, so that alternation is enforce.

The other changes are fixing typos in the code ('unifrom' -> 'uniform') and removing the default implementation of `circuit_index` for `circuit_supernova::StepCircuit` — which proved error-prone (confirming a suggestion @arthurpaulino made previously).

TODO:
- Add a test of compression once the NIVC CompressedSNARK lands. (#27 #80)