### PR TITLE
Forward ports from Nova (easy)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -17,14 +17,12 @@ mod tests {
     },
     traits::{snark::default_commitment_key_hint, Group},
   };
-  use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
   use ff::PrimeField;
 
-  fn synthesize_alloc_bit<Fr: PrimeField, CS: ConstraintSystem<Fr>>(
-    cs: &mut CS,
-  ) -> Result<(), SynthesisError> {
+  fn synthesize_alloc_bit<Fr: PrimeField, CS: ConstraintSystem<Fr>>(cs: &mut CS) {
     // get two bits as input and check that they are indeed bits
-    let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::ONE))?;
+    let a = AllocatedNum::alloc_infallible(cs.namespace(|| "a"), || Fr::ONE);
     let _ = a.inputize(cs.namespace(|| "a is input"));
     cs.enforce(
       || "check a is 0 or 1",
@@ -32,7 +30,7 @@ mod tests {
       |lc| lc + a.get_variable(),
       |lc| lc,
     );
-    let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::ONE))?;
+    let b = AllocatedNum::alloc_infallible(cs.namespace(|| "b"), || Fr::ONE);
     let _ = b.inputize(cs.namespace(|| "b is input"));
     cs.enforce(
       || "check b is 0 or 1",
@@ -40,7 +38,6 @@ mod tests {
       |lc| lc + b.get_variable(),
       |lc| lc,
     );
-    Ok(())
   }
 
   fn test_alloc_bit_with<G>()
@@ -49,12 +46,12 @@ mod tests {
   {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
-    let _ = synthesize_alloc_bit(&mut cs);
+    synthesize_alloc_bit(&mut cs);
     let (shape, ck) = cs.r1cs_shape_and_key(&*default_commitment_key_hint());
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-    let _ = synthesize_alloc_bit(&mut cs);
+    synthesize_alloc_bit(&mut cs);
     let (inst, witness) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that this is satisfiable

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -267,7 +267,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
       self.alloc_witness(cs.namespace(|| "allocate the circuit witness"), arity)?;
 
     // Compute variable indicating if this is the base case
-    let zero = alloc_zero(cs.namespace(|| "zero"))?;
+    let zero = alloc_zero(cs.namespace(|| "zero"));
     let is_base_case = alloc_num_equals(cs.namespace(|| "Check if base case"), &i.clone(), &zero)?;
 
     // Synthesize the circuit for the base case and get the new running instance

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,4 +62,7 @@ pub enum NovaError {
   /// returned when there is an error creating a digest
   #[error("DigestError")]
   DigestError,
+  /// returned when the prover cannot prove the provided statement due to completeness error
+  #[error("InternalError")]
+  InternalError,
 }

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -68,8 +68,8 @@ where
   where
     CS: ConstraintSystem<G::Base>,
   {
-    let zero = alloc_zero(cs.namespace(|| "zero"))?;
-    let one = alloc_one(cs.namespace(|| "one"))?;
+    let zero = alloc_zero(cs.namespace(|| "zero"));
+    let one = alloc_one(cs.namespace(|| "one"));
 
     Ok(AllocatedPoint {
       x: zero.clone(),
@@ -887,13 +887,12 @@ mod tests {
   pub fn inputize_allocted_point<G: Group, CS: ConstraintSystem<G::Base>>(
     p: &AllocatedPoint<G>,
     mut cs: CS,
-  ) -> Result<(), SynthesisError> {
+  ) {
     let _ = p.x.inputize(cs.namespace(|| "Input point.x"));
     let _ = p.y.inputize(cs.namespace(|| "Input point.y"));
     let _ = p
       .is_infinity
       .inputize(cs.namespace(|| "Input point.is_infinity"));
-    Ok(())
   }
 
   #[test]
@@ -967,7 +966,7 @@ mod tests {
     CS: ConstraintSystem<G::Base>,
   {
     let a = alloc_random_point(cs.namespace(|| "a")).unwrap();
-    inputize_allocted_point(&a, cs.namespace(|| "inputize a")).unwrap();
+    inputize_allocted_point(&a, cs.namespace(|| "inputize a"));
 
     let s = G::Scalar::random(&mut OsRng);
     // Allocate bits for s
@@ -979,7 +978,7 @@ mod tests {
       .collect::<Result<Vec<AllocatedBit>, SynthesisError>>()
       .unwrap();
     let e = a.scalar_mul(cs.namespace(|| "Scalar Mul"), &bits).unwrap();
-    inputize_allocted_point(&e, cs.namespace(|| "inputize e")).unwrap();
+    inputize_allocted_point(&e, cs.namespace(|| "inputize e"));
     (a, e, s)
   }
 
@@ -1033,9 +1032,9 @@ mod tests {
     CS: ConstraintSystem<G::Base>,
   {
     let a = alloc_random_point(cs.namespace(|| "a")).unwrap();
-    inputize_allocted_point(&a, cs.namespace(|| "inputize a")).unwrap();
+    inputize_allocted_point(&a, cs.namespace(|| "inputize a"));
     let e = a.add(cs.namespace(|| "add a to a"), &a).unwrap();
-    inputize_allocted_point(&e, cs.namespace(|| "inputize e")).unwrap();
+    inputize_allocted_point(&e, cs.namespace(|| "inputize e"));
     (a, e)
   }
 
@@ -1088,13 +1087,13 @@ mod tests {
     CS: ConstraintSystem<G::Base>,
   {
     let a = alloc_random_point(cs.namespace(|| "a")).unwrap();
-    inputize_allocted_point(&a, cs.namespace(|| "inputize a")).unwrap();
+    inputize_allocted_point(&a, cs.namespace(|| "inputize a"));
     let b = &mut a.clone();
     b.y = AllocatedNum::alloc(cs.namespace(|| "allocate negation of a"), || {
       Ok(G::Base::ZERO)
     })
     .unwrap();
-    inputize_allocted_point(b, cs.namespace(|| "inputize b")).unwrap();
+    inputize_allocted_point(b, cs.namespace(|| "inputize b"));
     let e = a.add(cs.namespace(|| "add a to b"), b).unwrap();
     e
   }

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -244,7 +244,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
     // (1) decompose `bignat` into a bitvector `bv`
     let bv = bignat.decompose(cs.namespace(|| "bv"))?;
     // (2) recompose bits and check if it equals n
-    n.is_equal(cs.namespace(|| "n"), &bv)?;
+    n.is_equal(cs.namespace(|| "n"), &bv);
 
     Ok(bignat)
   }

--- a/src/gadgets/nonnative/util.rs
+++ b/src/gadgets/nonnative/util.rs
@@ -157,11 +157,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
 
   /// Computes the natural number represented by an array of bits.
   /// Checks if the natural number equals `self`
-  pub fn is_equal<CS: ConstraintSystem<Scalar>>(
-    &self,
-    mut cs: CS,
-    other: &Bitvector<Scalar>,
-  ) -> Result<(), SynthesisError> {
+  pub fn is_equal<CS: ConstraintSystem<Scalar>>(&self, mut cs: CS, other: &Bitvector<Scalar>) {
     let allocations = other.allocations.clone();
     let mut f = Scalar::ONE;
     let sum = allocations
@@ -173,7 +169,6 @@ impl<Scalar: PrimeField> Num<Scalar> {
       });
     let sum_lc = LinearCombination::zero() + &self.num - &sum;
     cs.enforce(|| "sum", |lc| lc + &sum_lc, |lc| lc + CS::one(), |lc| lc);
-    Ok(())
   }
 
   /// Compute the natural number represented by an array of limbs.

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -144,7 +144,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   ) -> Result<Self, SynthesisError> {
     let E = AllocatedPoint::default(cs.namespace(|| "allocate W"))?;
 
-    let u = alloc_one(cs.namespace(|| "one"))?;
+    let u = alloc_one(cs.namespace(|| "one"));
 
     let X0 = BigNat::from_num(
       cs.namespace(|| "allocate X0 from relaxed r1cs"),

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -44,24 +44,20 @@ where
 }
 
 /// Allocate a variable that is set to zero
-pub fn alloc_zero<F: PrimeField, CS: ConstraintSystem<F>>(
-  mut cs: CS,
-) -> Result<AllocatedNum<F>, SynthesisError> {
-  let zero = AllocatedNum::alloc(cs.namespace(|| "alloc"), || Ok(F::ZERO))?;
+pub fn alloc_zero<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS) -> AllocatedNum<F> {
+  let zero = AllocatedNum::alloc_infallible(cs.namespace(|| "alloc"), || F::ZERO);
   cs.enforce(
     || "check zero is valid",
     |lc| lc,
     |lc| lc,
     |lc| lc + zero.get_variable(),
   );
-  Ok(zero)
+  zero
 }
 
 /// Allocate a variable that is set to one
-pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(
-  mut cs: CS,
-) -> Result<AllocatedNum<F>, SynthesisError> {
-  let one = AllocatedNum::alloc(cs.namespace(|| "alloc"), || Ok(F::ONE))?;
+pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS) -> AllocatedNum<F> {
+  let one = AllocatedNum::alloc_infallible(cs.namespace(|| "alloc"), || F::ONE);
   cs.enforce(
     || "check one is valid",
     |lc| lc + CS::one(),
@@ -69,7 +65,7 @@ pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(
     |lc| lc + one.get_variable(),
   );
 
-  Ok(one)
+  one
 }
 
 /// alloc a field as a constant

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1498,7 +1498,7 @@ mod tests {
         let x = &z[0];
 
         // we allocate a variable and set it to the provided non-deterministic advice.
-        let y = AllocatedNum::alloc(cs.namespace(|| "y"), || Ok(self.y))?;
+        let y = AllocatedNum::alloc_infallible(cs.namespace(|| "y"), || self.y);
 
         // We now check if y = x^{1/5} by checking if y^5 = x
         let y_sq = y.square(cs.namespace(|| "y_sq"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1406,7 +1406,6 @@ mod tests {
     assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
 
     // run the compressed snark with Spark compiler
-
     // produce the prover and verifier keys for compressed snark
     let (pk, vk) =
       CompressedSNARK::<_, _, _, _, SPrime<G1, E1>, SPrime<G2, E2>>::setup(&pp).unwrap();

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -61,7 +61,7 @@ impl<G: Group> NIFS<G> {
     let r = ro.squeeze(NUM_CHALLENGE_BITS);
 
     // fold the instance using `r` and `comm_T`
-    let U = U1.fold(U2, &comm_T, &r)?;
+    let U = U1.fold(U2, &comm_T, &r);
 
     // fold the witness using `r` and `T`
     let W = W1.fold(W2, &T, &r)?;
@@ -105,7 +105,7 @@ impl<G: Group> NIFS<G> {
     let r = ro.squeeze(NUM_CHALLENGE_BITS);
 
     // fold the instance using `r` and `comm_T`
-    let U = U1.fold(U2, &comm_T, &r)?;
+    let U = U1.fold(U2, &comm_T, &r);
 
     // return the folded instance
     Ok(U)
@@ -131,7 +131,7 @@ mod tests {
     x_val: Option<Scalar>,
   ) -> Result<(), SynthesisError> {
     // Consider a cubic equation: `x^3 + x + 5 = y`, where `x` and `y` are respectively the input and output.
-    let x = AllocatedNum::alloc(cs.namespace(|| "x"), || Ok(x_val.unwrap()))?;
+    let x = AllocatedNum::alloc_infallible(cs.namespace(|| "x"), || x_val.unwrap());
     let _ = x.inputize(cs.namespace(|| "x is input"));
 
     let x_sq = x.square(cs.namespace(|| "x_sq"))?;

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -322,7 +322,7 @@ where
 
       // we can compute an inversion only if acc is non-zero
       if acc == G::Scalar::ZERO {
-        return Err(NovaError::InvalidInputLength);
+        return Err(NovaError::InternalError);
       }
 
       // compute the inverse once for all entries

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -236,8 +236,7 @@ mod tests {
     for i in 0..num_absorbs {
       let num = G::Scalar::random(&mut csprng);
       ro.absorb(num);
-      let num_gadget =
-        AllocatedNum::alloc(cs.namespace(|| format!("data {i}")), || Ok(num)).unwrap();
+      let num_gadget = AllocatedNum::alloc_infallible(cs.namespace(|| format!("data {i}")), || num);
       num_gadget
         .inputize(&mut cs.namespace(|| format!("input {i}")))
         .unwrap();

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -122,9 +122,8 @@ impl<G: Group> R1CSShape<G> {
                     num_vars: usize,
                     num_io: usize,
                     M: &SparseMatrix<G::Scalar>|
-     -> Result<(), NovaError> {
-      let res = M
-        .iter()
+     -> Result<Vec<()>, NovaError> {
+      M.iter()
         .map(|(row, col, _val)| {
           if row >= num_cons || col > num_io + num_vars {
             Err(NovaError::InvalidIndex)
@@ -132,22 +131,12 @@ impl<G: Group> R1CSShape<G> {
             Ok(())
           }
         })
-        .collect::<Result<Vec<()>, NovaError>>();
-
-      if res.is_err() {
-        Err(NovaError::InvalidIndex)
-      } else {
-        Ok(())
-      }
+        .collect::<Result<Vec<()>, NovaError>>()
     };
 
-    let res_A = is_valid(num_cons, num_vars, num_io, &A);
-    let res_B = is_valid(num_cons, num_vars, num_io, &B);
-    let res_C = is_valid(num_cons, num_vars, num_io, &C);
-
-    if res_A.is_err() || res_B.is_err() || res_C.is_err() {
-      return Err(NovaError::InvalidIndex);
-    }
+    is_valid(num_cons, num_vars, num_io, &A)?;
+    is_valid(num_cons, num_vars, num_io, &B)?;
+    is_valid(num_cons, num_vars, num_io, &C)?;
 
     // We require the number of public inputs/outputs to be even
     if num_io % 2 != 0 {

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -535,7 +535,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     U2: &R1CSInstance<G>,
     comm_T: &Commitment<G>,
     r: &G::Scalar,
-  ) -> Result<RelaxedR1CSInstance<G>, NovaError> {
+  ) -> RelaxedR1CSInstance<G> {
     let (X1, u1, comm_W_1, comm_E_1) =
       (&self.X, &self.u, &self.comm_W.clone(), &self.comm_E.clone());
     let (X2, comm_W_2) = (&U2.X, &U2.comm_W);
@@ -550,12 +550,12 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     let comm_E = *comm_E_1 + *comm_T * *r;
     let u = *u1 + *r;
 
-    Ok(RelaxedR1CSInstance {
+    RelaxedR1CSInstance {
       comm_W,
       comm_E,
       X,
       u,
-    })
+    }
   }
 }
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -225,22 +225,25 @@ mod tests {
     type G = pasta_curves::pallas::Point;
     type EE = crate::provider::ipa_pc::EvaluationEngine<G>;
     type S = crate::spartan::snark::RelaxedR1CSSNARK<G, EE>;
-    type Spp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G, EE>;
     test_direct_snark_with::<G, S>();
+
+    type Spp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G, EE>;
     test_direct_snark_with::<G, Spp>();
 
     type G2 = bn256::Point;
     type EE2 = crate::provider::ipa_pc::EvaluationEngine<G2>;
     type S2 = crate::spartan::snark::RelaxedR1CSSNARK<G2, EE2>;
-    type S2pp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2>;
     test_direct_snark_with::<G2, S2>();
+
+    type S2pp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2>;
     test_direct_snark_with::<G2, S2pp>();
 
     type G3 = secp256k1::Point;
     type EE3 = crate::provider::ipa_pc::EvaluationEngine<G3>;
     type S3 = crate::spartan::snark::RelaxedR1CSSNARK<G3, EE3>;
-    type S3pp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G3, EE3>;
     test_direct_snark_with::<G3, S3>();
+
+    type S3pp = crate::spartan::ppsnark::RelaxedR1CSSNARK<G3, EE3>;
     test_direct_snark_with::<G3, S3pp>();
   }
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -9,7 +9,11 @@ use crate::{
   },
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
-  traits::{circuit::StepCircuit, snark::RelaxedR1CSSNARKTrait, Group},
+  traits::{
+    circuit::StepCircuit,
+    snark::{DigestHelperTrait, RelaxedR1CSSNARKTrait},
+    Group,
+  },
   Commitment, CommitmentKey,
 };
 use bellpepper_core::{num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
@@ -73,6 +77,13 @@ where
   S: RelaxedR1CSSNARKTrait<G>,
 {
   vk: S::VerifierKey,
+}
+
+impl<G: Group, S: RelaxedR1CSSNARKTrait<G>> VerifierKey<G, S> {
+  /// Returns the digest of the verifier's key
+  pub fn digest(&self) -> G::Scalar {
+    self.vk.digest()
+  }
 }
 
 /// A direct SNARK proving a step circuit

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -15,6 +15,7 @@ mod sumcheck;
 use crate::{traits::Group, Commitment};
 use ff::Field;
 use polys::multilinear::SparsePolynomial;
+use rayon::{iter::IntoParallelRefIterator, prelude::*};
 
 fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
   assert!(n >= 1);
@@ -58,14 +59,29 @@ impl<G: Group> PolyEvalWitness<G> {
     PolyEvalWitness { p }
   }
 
+  // This method panics unless all vectors in p_vec are of the same length
   fn batch(p_vec: &[&Vec<G::Scalar>], s: &G::Scalar) -> PolyEvalWitness<G> {
+    p_vec
+      .iter()
+      .for_each(|p| assert_eq!(p.len(), p_vec[0].len()));
+
     let powers_of_s = powers::<G>(s, p_vec.len());
-    let mut p = vec![G::Scalar::ZERO; p_vec[0].len()];
-    for i in 0..p_vec.len() {
-      for (j, item) in p.iter_mut().enumerate().take(p_vec[i].len()) {
-        *item += p_vec[i][j] * powers_of_s[i]
-      }
-    }
+
+    let p = p_vec
+      .par_iter()
+      .zip(powers_of_s.par_iter())
+      .map(|(v, &weight)| {
+        // compute the weighted sum for each vector
+        v.iter().map(|&x| x * weight).collect::<Vec<G::Scalar>>()
+      })
+      .reduce(
+        || vec![G::Scalar::ZERO; p_vec[0].len()],
+        |acc, v| {
+          // perform vector addition to combine the weighted vectors
+          acc.into_iter().zip(v).map(|(x, y)| x + y).collect()
+        },
+      );
+
     PolyEvalWitness { p }
   }
 }
@@ -101,15 +117,15 @@ impl<G: Group> PolyEvalInstance<G> {
   ) -> PolyEvalInstance<G> {
     let powers_of_s = powers::<G>(s, c_vec.len());
     let e = e_vec
-      .iter()
-      .zip(powers_of_s.iter())
+      .par_iter()
+      .zip(powers_of_s.par_iter())
       .map(|(e, p)| *e * p)
       .sum();
     let c = c_vec
-      .iter()
-      .zip(powers_of_s.iter())
+      .par_iter()
+      .zip(powers_of_s.par_iter())
       .map(|(c, p)| *c * *p)
-      .fold(Commitment::<G>::default(), |acc, item| acc + item);
+      .reduce(Commitment::<G>::default, |acc, item| acc + item);
 
     PolyEvalInstance {
       c,

--- a/src/spartan/polys/identity.rs
+++ b/src/spartan/polys/identity.rs
@@ -1,0 +1,29 @@
+use core::marker::PhantomData;
+use ff::PrimeField;
+
+pub struct IdentityPolynomial<Scalar: PrimeField> {
+  ell: usize,
+  _p: PhantomData<Scalar>,
+}
+
+impl<Scalar: PrimeField> IdentityPolynomial<Scalar> {
+  pub fn new(ell: usize) -> Self {
+    IdentityPolynomial {
+      ell,
+      _p: PhantomData,
+    }
+  }
+
+  pub fn evaluate(&self, r: &[Scalar]) -> Scalar {
+    assert_eq!(self.ell, r.len());
+    let mut power_of_two = 1_u64;
+    (0..self.ell)
+      .rev()
+      .map(|i| {
+        let result = Scalar::from(power_of_two) * r[i];
+        power_of_two *= 2;
+        result
+      })
+      .fold(Scalar::ZERO, |acc, item| acc + item)
+  }
+}

--- a/src/spartan/polys/mod.rs
+++ b/src/spartan/polys/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains the definitions of polynomial types used in the Spartan SNARK.
 pub mod eq;
 pub mod multilinear;
+pub(crate) mod power;
 pub(crate) mod univariate;

--- a/src/spartan/polys/mod.rs
+++ b/src/spartan/polys/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains the definitions of polynomial types used in the Spartan SNARK.
 pub mod eq;
+pub(crate) mod identity;
 pub mod multilinear;
 pub(crate) mod power;
 pub(crate) mod univariate;

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -1,0 +1,53 @@
+//! `PowPolynomial`: Represents multilinear extension of power polynomials
+
+use crate::spartan::polys::eq::EqPolynomial;
+use ff::PrimeField;
+
+/// Represents the multilinear extension polynomial (MLE) of the equality polynomial $pow(x,t)$, denoted as $\tilde{pow}(x, t)$.
+///
+/// The polynomial is defined by the formula:
+/// $$
+/// \tilde{power}(x, t) = \prod_{i=1}^m(1 + (t^{2^i} - 1) * x_i)
+/// $$
+pub struct PowPolynomial<Scalar: PrimeField> {
+  t_pow: Vec<Scalar>,
+  eq: EqPolynomial<Scalar>,
+}
+
+impl<Scalar: PrimeField> PowPolynomial<Scalar> {
+  /// Creates a new `PowPolynomial` from a Scalars `t`.
+  pub fn new(t: &Scalar, ell: usize) -> Self {
+    // t_pow = [t^{2^0}, t^{2^1}, ..., t^{2^{ell-1}}]
+    let mut t_pow = vec![Scalar::ONE; ell];
+    t_pow[0] = *t;
+    for i in 1..ell {
+      t_pow[i] = t_pow[i - 1].square();
+    }
+
+    PowPolynomial {
+      t_pow: t_pow.clone(),
+      eq: EqPolynomial::new(t_pow),
+    }
+  }
+
+  /// Evaluates the `PowPolynomial` at a given point `rx`.
+  ///
+  /// This function computes the value of the polynomial at the point specified by `rx`.
+  /// It expects `rx` to have the same length as the internal vector `t_pow`.
+  ///
+  /// Panics if `rx` and `t_pow` have different lengths.
+  pub fn evaluate(&self, rx: &[Scalar]) -> Scalar {
+    self.eq.evaluate(rx)
+  }
+
+  pub fn coordinates(&self) -> Vec<Scalar> {
+    self.t_pow.clone()
+  }
+
+  /// Evaluates the `PowPolynomial` at all the `2^|t_pow|` points in its domain.
+  ///
+  /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
+  pub fn evals(&self) -> Vec<Scalar> {
+    self.eq.evals()
+  }
+}

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -11,6 +11,7 @@ use crate::{
     polys::{
       eq::EqPolynomial,
       multilinear::MultilinearPolynomial,
+      power::PowPolynomial,
       univariate::{CompressedUniPoly, UniPoly},
     },
     powers,
@@ -255,7 +256,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
   fn evaluation_oracles(
     &self,
     S: &R1CSShape<G>,
-    r_x: &[G::Scalar],
+    r_x: &G::Scalar,
     z: &[G::Scalar],
   ) -> (
     Vec<G::Scalar>,
@@ -263,13 +264,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     Vec<G::Scalar>,
     Vec<G::Scalar>,
   ) {
-    let r_x_padded = {
-      let mut x = vec![G::Scalar::ZERO; self.N.log_2() - r_x.len()];
-      x.extend(r_x);
-      x
-    };
-
-    let mem_row = EqPolynomial::new(r_x_padded).evals();
+    let mem_row = PowPolynomial::new(r_x, self.N.log_2()).evals();
     let mem_col = {
       let mut val = vec![G::Scalar::ZERO; self.N];
       for (i, v) in z.iter().enumerate() {
@@ -410,16 +405,14 @@ impl<G: Group> ProductSumcheckInstance<G> {
     transcript.absorb(b"o", &comm_output_vec.as_slice());
     transcript.absorb(b"c", &claims.as_slice());
 
-    // generate randomness for the eq polynomial
+    // generate randomness for the eq polynomial emulated via the power polynomial
     let num_rounds = output_vec[0].len().log_2();
-    let rand_eq = (0..num_rounds)
-      .map(|_i| transcript.squeeze(b"e"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+    let rand_eq = transcript.squeeze(b"e")?;
 
     let ((poly_A, poly_B_vec), (poly_C_vec, poly_D_vec)) = rayon::join(
       || {
         rayon::join(
-          || MultilinearPolynomial::new(EqPolynomial::new(rand_eq).evals()),
+          || MultilinearPolynomial::new(PowPolynomial::new(&rand_eq, num_rounds).evals()),
           || {
             left_vec
               .into_par_iter()
@@ -999,9 +992,8 @@ where
 
     // number of rounds of the satisfiability sum-check
     let num_rounds_sat = pk.S_repr.N.log_2();
-    let tau = (0..num_rounds_sat)
-      .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+    let tau = transcript.squeeze(b"t")?;
+    let tau_coords = PowPolynomial::new(&tau, num_rounds_sat).coordinates();
 
     // (1) send commitments to Az, Bz, and Cz along with their evaluations at tau
     let (Az, Bz, Cz, E) = {
@@ -1022,7 +1014,7 @@ where
     let (eval_Az_at_tau, eval_Bz_at_tau, eval_Cz_at_tau) = {
       let evals_at_tau = [&Az, &Bz, &Cz]
         .into_par_iter()
-        .map(|p| MultilinearPolynomial::evaluate_with(p, &tau))
+        .map(|p| MultilinearPolynomial::evaluate_with(p, &tau_coords))
         .collect::<Vec<G::Scalar>>();
       (evals_at_tau[0], evals_at_tau[1], evals_at_tau[2])
     };
@@ -1051,7 +1043,7 @@ where
     transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let w = PolyEvalWitness::batch(&poly_vec, &c);
-    let u = PolyEvalInstance::batch(&comm_vec, &tau, &eval_vec, &c);
+    let u = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
     w_u_vec.push((w, u));
 
     let c_inner = c;
@@ -1063,7 +1055,7 @@ where
 
     // a sum-check instance to prove the first claim
     let mut outer_sc_inst = OuterSumcheckInstance {
-      poly_tau: MultilinearPolynomial::new(EqPolynomial::new(tau).evals()),
+      poly_tau: MultilinearPolynomial::new(PowPolynomial::new(&tau, num_rounds_sat).evals()),
       poly_Az: MultilinearPolynomial::new(Az.clone()),
       poly_Bz: MultilinearPolynomial::new(Bz.clone()),
       poly_uCz_E: {
@@ -1635,9 +1627,8 @@ where
     transcript.absorb(b"c", &[comm_Az, comm_Bz, comm_Cz].as_slice());
 
     let num_rounds_sat = vk.S_comm.N.log_2();
-    let tau = (0..num_rounds_sat)
-      .map(|_i| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+    let tau = transcript.squeeze(b"t")?;
+    let tau_coords = PowPolynomial::new(&tau, num_rounds_sat).coordinates();
 
     transcript.absorb(
       b"e",
@@ -1662,7 +1653,7 @@ where
     let comm_vec = vec![comm_Az, comm_Bz, comm_Cz];
     transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
-    let u = PolyEvalInstance::batch(&comm_vec, &tau, &eval_vec, &c);
+    let u = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
     let claim_inner = u.e;
     let c_inner = c;
     u_vec.push(u);
@@ -1700,9 +1691,8 @@ where
     transcript.absorb(b"c", &self.claims_product_arr.as_slice());
 
     let num_rounds = vk.S_comm.N.log_2();
-    let rand_eq = (0..num_rounds)
-      .map(|_i| transcript.squeeze(b"e"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+    let rand_eq = transcript.squeeze(b"e")?;
+    let rand_eq_coords = PowPolynomial::new(&rand_eq, num_rounds).coordinates();
 
     let num_claims = 10;
     let coeffs = {
@@ -1720,8 +1710,8 @@ where
       .verify(claim, num_rounds_sat, 3, &mut transcript)?;
 
     // verify claim_sat_final
-    let taus_bound_r_sat = EqPolynomial::new(tau.clone()).evaluate(&r_sat);
-    let rand_eq_bound_r_sat = EqPolynomial::new(rand_eq).evaluate(&r_sat);
+    let taus_bound_r_sat = PowPolynomial::new(&tau, num_rounds_sat).evaluate(&r_sat);
+    let rand_eq_bound_r_sat = EqPolynomial::new(rand_eq_coords).evaluate(&r_sat);
     let claim_mem_final_expected: G::Scalar = (0..8)
       .map(|i| {
         coeffs[i]
@@ -1936,7 +1926,7 @@ where
     // finish the final step of the sum-check
     let (claim_init_expected_row, claim_audit_expected_row) = {
       let addr = IdentityPolynomial::new(r_prod.len()).evaluate(&r_prod);
-      let val = EqPolynomial::new(tau).evaluate(&r_prod);
+      let val = EqPolynomial::new(tau_coords.to_vec()).evaluate(&r_prod);
       (
         hash_func(&addr, &val, &G::Scalar::ZERO),
         hash_func(&addr, &val, &self.eval_row_audit_ts),

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -2,6 +2,7 @@
 //! sparse multilinear polynomials involved in Spartan's sum-check protocol, thereby providing a preprocessing SNARK
 //! The verifier in this preprocessing SNARK maintains a commitment to R1CS matrices. This is beneficial when using a
 //! polynomial commitment scheme in which the verifier's costs is succinct.
+//! This code includes experimental optimizations to reduce runtimes and proof sizes.
 use crate::{
   digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
@@ -10,6 +11,7 @@ use crate::{
     math::Math,
     polys::{
       eq::EqPolynomial,
+      identity::IdentityPolynomial,
       multilinear::MultilinearPolynomial,
       power::PowPolynomial,
       univariate::{CompressedUniPoly, UniPoly},
@@ -28,43 +30,18 @@ use crate::{
 };
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
-use core::{cmp::max, marker::PhantomData};
+use core::cmp::max;
 use ff::{Field, PrimeField};
 use once_cell::sync::OnceCell;
-
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-fn vec_to_arr<T, const N: usize>(v: Vec<T>) -> [T; N] {
-  v.try_into()
-    .unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
-}
-
-struct IdentityPolynomial<Scalar: PrimeField> {
-  ell: usize,
-  _p: PhantomData<Scalar>,
-}
-
-impl<Scalar: PrimeField> IdentityPolynomial<Scalar> {
-  pub fn new(ell: usize) -> Self {
-    IdentityPolynomial {
-      ell,
-      _p: PhantomData,
-    }
+fn padded<G: Group>(v: &[G::Scalar], n: usize, e: &G::Scalar) -> Vec<G::Scalar> {
+  let mut v_padded = vec![*e; n];
+  for (i, v_i) in v.iter().enumerate() {
+    v_padded[i] = *v_i;
   }
-
-  pub fn evaluate(&self, r: &[Scalar]) -> Scalar {
-    assert_eq!(self.ell, r.len());
-    let mut power_of_two = 1_u64;
-    (0..self.ell)
-      .rev()
-      .map(|i| {
-        let result = Scalar::from(power_of_two) * r[i];
-        power_of_two *= 2;
-        result
-      })
-      .fold(Scalar::ZERO, |acc, item| acc + item)
-  }
+  v_padded
 }
 
 /// A type that holds `R1CSShape` in a form amenable to memory checking
@@ -88,13 +65,9 @@ pub struct R1CSShapeSparkRepr<G: Group> {
 
   // timestamp polynomials
   #[abomonate_with(Vec<<G::Scalar as PrimeField>::Repr>)]
-  row_read_ts: Vec<G::Scalar>,
+  ts_row: Vec<G::Scalar>,
   #[abomonate_with(Vec<<G::Scalar as PrimeField>::Repr>)]
-  row_audit_ts: Vec<G::Scalar>,
-  #[abomonate_with(Vec<<G::Scalar as PrimeField>::Repr>)]
-  col_read_ts: Vec<G::Scalar>,
-  #[abomonate_with(Vec<<G::Scalar as PrimeField>::Repr>)]
-  col_audit_ts: Vec<G::Scalar>,
+  ts_col: Vec<G::Scalar>,
 }
 
 /// A type that holds a commitment to a sparse polynomial
@@ -112,10 +85,8 @@ pub struct R1CSShapeSparkCommitment<G: Group> {
   comm_val_C: Commitment<G>,
 
   // commitments to the timestamp polynomials
-  comm_row_read_ts: Commitment<G>,
-  comm_row_audit_ts: Commitment<G>,
-  comm_col_read_ts: Commitment<G>,
-  comm_col_audit_ts: Commitment<G>,
+  comm_ts_row: Commitment<G>,
+  comm_ts_col: Commitment<G>,
 }
 
 impl<G: Group> TranscriptReprTrait<G> for R1CSShapeSparkCommitment<G> {
@@ -126,10 +97,8 @@ impl<G: Group> TranscriptReprTrait<G> for R1CSShapeSparkCommitment<G> {
       self.comm_val_A,
       self.comm_val_B,
       self.comm_val_C,
-      self.comm_row_read_ts,
-      self.comm_row_audit_ts,
-      self.comm_col_read_ts,
-      self.comm_col_audit_ts,
+      self.comm_ts_row,
+      self.comm_ts_col,
     ]
     .as_slice()
     .to_transcript_bytes()
@@ -144,7 +113,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       max(total_nz, max(2 * S.num_vars, S.num_cons)).next_power_of_two()
     };
 
-    let (mut row, mut col) = (vec![0usize; N], vec![0usize; N]);
+    let (mut row, mut col) = (vec![0; N], vec![N - 1; N]); // we make col lookup into the last entry of z, so we commit to zeros
 
     for (i, (r, c, _)) in S.A.iter().chain(S.B.iter()).chain(S.C.iter()).enumerate() {
       row[i] = r;
@@ -175,27 +144,20 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     };
 
     // timestamp calculation routine
-    let timestamp_calc =
-      |num_ops: usize, num_cells: usize, addr_trace: &[usize]| -> (Vec<usize>, Vec<usize>) {
-        let mut read_ts = vec![0usize; num_ops];
-        let mut audit_ts = vec![0usize; num_cells];
+    let timestamp_calc = |num_ops: usize, num_cells: usize, addr_trace: &[usize]| -> Vec<usize> {
+      let mut ts = vec![0usize; num_cells];
 
-        assert!(num_ops >= addr_trace.len());
-        for i in 0..addr_trace.len() {
-          let addr = addr_trace[i];
-          assert!(addr < num_cells);
-          let r_ts = audit_ts[addr];
-          read_ts[i] = r_ts;
-
-          let w_ts = r_ts + 1;
-          audit_ts[addr] = w_ts;
-        }
-        (read_ts, audit_ts)
-      };
+      assert!(num_ops >= addr_trace.len());
+      for addr in addr_trace {
+        assert!(*addr < num_cells);
+        ts[*addr] += 1;
+      }
+      ts
+    };
 
     // timestamp polynomials for row
-    let (row_read_ts, row_audit_ts) = timestamp_calc(N, N, &row);
-    let (col_read_ts, col_audit_ts) = timestamp_calc(N, N, &col);
+    let (ts_row, ts_col) =
+      rayon::join(|| timestamp_calc(N, N, &row), || timestamp_calc(N, N, &col));
 
     // a routine to turn a vector of usize into a vector scalars
     let to_vec_scalar = |v: &[usize]| -> Vec<G::Scalar> {
@@ -215,10 +177,8 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       val_C,
 
       // timestamp polynomials
-      row_read_ts: to_vec_scalar(&row_read_ts),
-      row_audit_ts: to_vec_scalar(&row_audit_ts),
-      col_read_ts: to_vec_scalar(&col_read_ts),
-      col_audit_ts: to_vec_scalar(&col_audit_ts),
+      ts_row: to_vec_scalar(&ts_row),
+      ts_col: to_vec_scalar(&ts_col),
     }
   }
 
@@ -229,10 +189,8 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       &self.val_A,
       &self.val_B,
       &self.val_C,
-      &self.row_read_ts,
-      &self.row_audit_ts,
-      &self.col_read_ts,
-      &self.col_audit_ts,
+      &self.ts_row,
+      &self.ts_col,
     ]
     .par_iter()
     .map(|v| G::CE::commit(ck, v))
@@ -245,10 +203,8 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       comm_val_A: comm_vec[2],
       comm_val_B: comm_vec[3],
       comm_val_C: comm_vec[4],
-      comm_row_read_ts: comm_vec[5],
-      comm_row_audit_ts: comm_vec[6],
-      comm_col_read_ts: comm_vec[7],
-      comm_col_audit_ts: comm_vec[8],
+      comm_ts_row: comm_vec[5],
+      comm_ts_col: comm_vec[6],
     }
   }
 
@@ -265,17 +221,11 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     Vec<G::Scalar>,
   ) {
     let mem_row = PowPolynomial::new(r_x, self.N.log_2()).evals();
-    let mem_col = {
-      let mut val = vec![G::Scalar::ZERO; self.N];
-      for (i, v) in z.iter().enumerate() {
-        val[i] = *v;
-      }
-      val
-    };
+    let mem_col = padded::<G>(z, self.N, &G::Scalar::ZERO);
 
-    let (E_row, E_col) = {
-      let mut E_row = vec![mem_row[0]; self.N]; // we place mem_row[0] since resized row is appended with 0s
-      let mut E_col = vec![mem_col[0]; self.N];
+    let (L_row, L_col) = {
+      let mut L_row = vec![mem_row[0]; self.N]; // we place mem_row[0] since resized row is appended with 0s
+      let mut L_col = vec![mem_col[self.N - 1]; self.N]; // we place mem_col[N-1] since resized col is appended with N-1
 
       for (i, (val_r, val_c)) in S
         .A
@@ -285,13 +235,13 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
         .map(|(r, c, _)| (mem_row[r], mem_col[c]))
         .enumerate()
       {
-        E_row[i] = val_r;
-        E_col[i] = val_c;
+        L_row[i] = val_r;
+        L_col[i] = val_c;
       }
-      (E_row, E_col)
+      (L_row, L_col)
     };
 
-    (mem_row, mem_col, E_row, E_col)
+    (mem_row, mem_col, L_row, L_col)
   }
 }
 
@@ -316,146 +266,189 @@ pub trait SumcheckEngine<G: Group>: Send + Sync {
   fn final_claims(&self) -> Vec<Vec<G::Scalar>>;
 }
 
-struct ProductSumcheckInstance<G: Group> {
-  pub(crate) claims: Vec<G::Scalar>, // claimed products
-  pub(crate) comm_output_vec: Vec<Commitment<G>>,
+struct LookupSumcheckInstance<G: Group> {
+  // row
+  w_plus_r_row: MultilinearPolynomial<G::Scalar>,
+  t_plus_r_row: MultilinearPolynomial<G::Scalar>,
+  t_plus_r_inv_row: MultilinearPolynomial<G::Scalar>,
+  w_plus_r_inv_row: MultilinearPolynomial<G::Scalar>,
+  ts_row: MultilinearPolynomial<G::Scalar>,
 
-  input_vec: Vec<Vec<G::Scalar>>,
-  output_vec: Vec<Vec<G::Scalar>>,
+  // col
+  w_plus_r_col: MultilinearPolynomial<G::Scalar>,
+  t_plus_r_col: MultilinearPolynomial<G::Scalar>,
+  t_plus_r_inv_col: MultilinearPolynomial<G::Scalar>,
+  w_plus_r_inv_col: MultilinearPolynomial<G::Scalar>,
+  ts_col: MultilinearPolynomial<G::Scalar>,
 
-  poly_A: MultilinearPolynomial<G::Scalar>,
-  poly_B_vec: Vec<MultilinearPolynomial<G::Scalar>>,
-  poly_C_vec: Vec<MultilinearPolynomial<G::Scalar>>,
-  poly_D_vec: Vec<MultilinearPolynomial<G::Scalar>>,
+  // eq
+  poly_eq: MultilinearPolynomial<G::Scalar>,
 }
 
-impl<G: Group> ProductSumcheckInstance<G> {
+impl<G: Group> LookupSumcheckInstance<G> {
   pub fn new(
     ck: &CommitmentKey<G>,
-    input_vec: Vec<Vec<G::Scalar>>, // list of input vectors
+    r: &G::Scalar,
+    T_row: Vec<G::Scalar>,
+    W_row: Vec<G::Scalar>,
+    ts_row: Vec<G::Scalar>,
+    T_col: Vec<G::Scalar>,
+    W_col: Vec<G::Scalar>,
+    ts_col: Vec<G::Scalar>,
     transcript: &mut G::TE,
-  ) -> Result<Self, NovaError> {
-    let compute_layer = |input: &[G::Scalar]| -> (Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>) {
-      let left = (0..input.len() / 2)
-        .map(|i| input[2 * i])
-        .collect::<Vec<G::Scalar>>();
+  ) -> Result<(Self, [Commitment<G>; 4], [Vec<G::Scalar>; 4]), NovaError> {
+    let batch_invert = |v: &[G::Scalar]| -> Result<Vec<G::Scalar>, NovaError> {
+      let mut products = vec![G::Scalar::ZERO; v.len()];
+      let mut acc = G::Scalar::ONE;
 
-      let right = (0..input.len() / 2)
-        .map(|i| input[2 * i + 1])
-        .collect::<Vec<G::Scalar>>();
+      for i in 0..v.len() {
+        products[i] = acc;
+        acc *= v[i];
+      }
 
-      assert_eq!(left.len(), right.len());
+      // we can compute an inversion only if acc is non-zero
+      if acc == G::Scalar::ZERO {
+        return Err(NovaError::InternalError);
+      }
 
-      let output = (0..left.len())
-        .map(|i| left[i] * right[i])
-        .collect::<Vec<G::Scalar>>();
+      // compute the inverse once for all entries
+      acc = acc.invert().unwrap();
 
-      (left, right, output)
+      let mut inv = vec![G::Scalar::ZERO; v.len()];
+      for i in 0..v.len() {
+        let tmp = acc * v[v.len() - 1 - i];
+        inv[v.len() - 1 - i] = products[v.len() - 1 - i] * acc;
+        acc = tmp;
+      }
+
+      Ok(inv)
     };
 
-    // a closure that returns left, right, output, product
-    let prepare_inputs =
-      |input: &[G::Scalar]| -> (Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>, G::Scalar) {
-        let mut left: Vec<G::Scalar> = Vec::new();
-        let mut right: Vec<G::Scalar> = Vec::new();
-        let mut output: Vec<G::Scalar> = Vec::new();
+    // compute vectors TS[i]/(T[i] + r) and 1/(W[i] + r)
+    let helper = |T: &[G::Scalar],
+                  W: &[G::Scalar],
+                  TS: &[G::Scalar],
+                  r: &G::Scalar|
+     -> (
+      (
+        Result<Vec<G::Scalar>, NovaError>,
+        Result<Vec<G::Scalar>, NovaError>,
+      ),
+      (
+        Result<Vec<G::Scalar>, NovaError>,
+        Result<Vec<G::Scalar>, NovaError>,
+      ),
+    ) {
+      rayon::join(
+        || {
+          rayon::join(
+            || {
+              let inv = batch_invert(&T.par_iter().map(|e| *e + *r).collect::<Vec<G::Scalar>>())?;
 
-        let mut out = input.to_vec();
-        for _i in 0..input.len().log_2() {
-          let (l, r, o) = compute_layer(&out);
-          out = o.clone();
+              // compute inv[i] * TS[i] in parallel
+              Ok(
+                inv
+                  .par_iter()
+                  .zip(TS.par_iter())
+                  .map(|(e1, e2)| *e1 * *e2)
+                  .collect::<Vec<_>>(),
+              )
+            },
+            || batch_invert(&W.par_iter().map(|e| *e + *r).collect::<Vec<G::Scalar>>()),
+          )
+        },
+        || {
+          rayon::join(
+            || Ok(T.par_iter().map(|e| *e + *r).collect::<Vec<G::Scalar>>()),
+            || Ok(W.par_iter().map(|e| *e + *r).collect::<Vec<G::Scalar>>()),
+          )
+        },
+      )
+    };
 
-          left.extend(l);
-          right.extend(r);
-          output.extend(o);
-        }
+    let (
+      ((t_plus_r_inv_row, w_plus_r_inv_row), (t_plus_r_row, w_plus_r_row)),
+      ((t_plus_r_inv_col, w_plus_r_inv_col), (t_plus_r_col, w_plus_r_col)),
+    ) = rayon::join(
+      || helper(&T_row, &W_row, &ts_row, r),
+      || helper(&T_col, &W_col, &ts_col, r),
+    );
 
-        // add a dummy product operation to make the left.len() == right.len() == output.len() == input.len()
-        left.push(output[output.len() - 1]);
-        right.push(G::Scalar::ZERO);
-        output.push(G::Scalar::ZERO);
+    let t_plus_r_inv_row = t_plus_r_inv_row?;
+    let w_plus_r_inv_row = w_plus_r_inv_row?;
+    let t_plus_r_inv_col = t_plus_r_inv_col?;
+    let w_plus_r_inv_col = w_plus_r_inv_col?;
 
-        // output is stored at the last but one position
-        let product = output[output.len() - 2];
-
-        assert_eq!(left.len(), right.len());
-        assert_eq!(left.len(), output.len());
-        (left, right, output, product)
-      };
-
-    let mut left_vec = Vec::new();
-    let mut right_vec = Vec::new();
-    let mut output_vec = Vec::new();
-    let mut claims = Vec::new();
-    for input in input_vec.iter() {
-      let (l, r, o, p) = prepare_inputs(input);
-      left_vec.push(l);
-      right_vec.push(r);
-      output_vec.push(o);
-      claims.push(p);
-    }
-
-    // commit to the outputs
-    let comm_output_vec = (0..output_vec.len())
-      .into_par_iter()
-      .map(|i| G::CE::commit(ck, &output_vec[i]))
-      .collect::<Vec<_>>();
-
-    // absorb the output commitment and the claimed product
-    transcript.absorb(b"o", &comm_output_vec.as_slice());
-    transcript.absorb(b"c", &claims.as_slice());
-
-    // generate randomness for the eq polynomial emulated via the power polynomial
-    let num_rounds = output_vec[0].len().log_2();
-    let rand_eq = transcript.squeeze(b"e")?;
-
-    let ((poly_A, poly_B_vec), (poly_C_vec, poly_D_vec)) = rayon::join(
+    let (
+      (comm_t_plus_r_inv_row, comm_w_plus_r_inv_row),
+      (comm_t_plus_r_inv_col, comm_w_plus_r_inv_col),
+    ) = rayon::join(
       || {
         rayon::join(
-          || MultilinearPolynomial::new(PowPolynomial::new(&rand_eq, num_rounds).evals()),
-          || {
-            left_vec
-              .into_par_iter()
-              .map(MultilinearPolynomial::new)
-              .collect::<Vec<_>>()
-          },
+          || G::CE::commit(ck, &t_plus_r_inv_row),
+          || G::CE::commit(ck, &w_plus_r_inv_row),
         )
       },
       || {
         rayon::join(
-          || {
-            right_vec
-              .into_par_iter()
-              .map(MultilinearPolynomial::new)
-              .collect::<Vec<_>>()
-          },
-          || {
-            output_vec
-              .clone()
-              .into_par_iter()
-              .map(MultilinearPolynomial::new)
-              .collect::<Vec<_>>()
-          },
+          || G::CE::commit(ck, &t_plus_r_inv_col),
+          || G::CE::commit(ck, &w_plus_r_inv_col),
         )
       },
     );
 
-    Ok(Self {
-      claims,
-      comm_output_vec,
-      input_vec,
-      output_vec,
-      poly_A,
-      poly_B_vec,
-      poly_C_vec,
-      poly_D_vec,
-    })
+    // absorb the commitments
+    transcript.absorb(
+      b"l",
+      &[
+        comm_t_plus_r_inv_row,
+        comm_w_plus_r_inv_row,
+        comm_t_plus_r_inv_col,
+        comm_w_plus_r_inv_col,
+      ]
+      .as_slice(),
+    );
+
+    let rho = transcript.squeeze(b"r")?;
+    let poly_eq = MultilinearPolynomial::new(PowPolynomial::new(&rho, T_row.len().log_2()).evals());
+
+    let comm_vec = [
+      comm_t_plus_r_inv_row,
+      comm_w_plus_r_inv_row,
+      comm_t_plus_r_inv_col,
+      comm_w_plus_r_inv_col,
+    ];
+
+    let poly_vec = [
+      t_plus_r_inv_row.clone(),
+      w_plus_r_inv_row.clone(),
+      t_plus_r_inv_col.clone(),
+      w_plus_r_inv_col.clone(),
+    ];
+
+    Ok((
+      Self {
+        w_plus_r_row: MultilinearPolynomial::new(w_plus_r_row?),
+        t_plus_r_row: MultilinearPolynomial::new(t_plus_r_row?),
+        t_plus_r_inv_row: MultilinearPolynomial::new(t_plus_r_inv_row),
+        w_plus_r_inv_row: MultilinearPolynomial::new(w_plus_r_inv_row),
+        ts_row: MultilinearPolynomial::new(ts_row),
+        w_plus_r_col: MultilinearPolynomial::new(w_plus_r_col?),
+        t_plus_r_col: MultilinearPolynomial::new(t_plus_r_col?),
+        t_plus_r_inv_col: MultilinearPolynomial::new(t_plus_r_inv_col),
+        w_plus_r_inv_col: MultilinearPolynomial::new(w_plus_r_inv_col),
+        ts_col: MultilinearPolynomial::new(ts_col),
+        poly_eq,
+      },
+      comm_vec,
+      poly_vec,
+    ))
   }
 }
 
-impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
+impl<G: Group> SumcheckEngine<G> for LookupSumcheckInstance<G> {
   fn initial_claims(&self) -> Vec<G::Scalar> {
-    vec![G::Scalar::ZERO; 8]
+    vec![G::Scalar::ZERO; 6]
   }
 
   fn degree(&self) -> usize {
@@ -463,79 +456,133 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
   }
 
   fn size(&self) -> usize {
-    for poly_B in &self.poly_B_vec {
-      assert_eq!(poly_B.len(), self.poly_A.len());
-    }
-    for poly_C in &self.poly_C_vec {
-      assert_eq!(poly_C.len(), self.poly_A.len());
-    }
-    for poly_D in &self.poly_D_vec {
-      assert_eq!(poly_D.len(), self.poly_A.len());
-    }
-    self.poly_A.len()
+    // sanity checks
+    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_row.len());
+    assert_eq!(self.w_plus_r_row.len(), self.ts_row.len());
+    assert_eq!(self.w_plus_r_row.len(), self.w_plus_r_col.len());
+    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_col.len());
+    assert_eq!(self.w_plus_r_row.len(), self.ts_col.len());
+
+    self.w_plus_r_row.len()
   }
 
   fn evaluation_points(&self) -> Vec<Vec<G::Scalar>> {
-    let poly_A = &self.poly_A;
+    let poly_zero = MultilinearPolynomial::new(vec![G::Scalar::ZERO; self.w_plus_r_row.len()]);
 
-    let comb_func =
+    let comb_func = |poly_A_comp: &G::Scalar,
+                     poly_B_comp: &G::Scalar,
+                     _poly_C_comp: &G::Scalar|
+     -> G::Scalar { *poly_A_comp - *poly_B_comp };
+
+    let comb_func2 =
+      |poly_A_comp: &G::Scalar,
+       poly_B_comp: &G::Scalar,
+       poly_C_comp: &G::Scalar,
+       _poly_D_comp: &G::Scalar|
+       -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - G::Scalar::ONE) };
+
+    let comb_func3 =
       |poly_A_comp: &G::Scalar,
        poly_B_comp: &G::Scalar,
        poly_C_comp: &G::Scalar,
        poly_D_comp: &G::Scalar|
        -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
 
-    self
-      .poly_B_vec
-      .iter()
-      .zip(self.poly_C_vec.iter())
-      .zip(self.poly_D_vec.iter())
-      .map(|((poly_B, poly_C), poly_D)| {
-        // Make an iterator returning the contributions to the evaluations
-        let (eval_point_0, eval_point_2, eval_point_3) =
-          SumcheckProof::<G>::compute_eval_points_cubic(poly_A, poly_B, poly_C, poly_D, &comb_func);
+    // inv related evaluation points
+    let (eval_inv_0_row, eval_inv_2_row, eval_inv_3_row) =
+      SumcheckProof::<G>::compute_eval_points_cubic(
+        &self.t_plus_r_inv_row,
+        &self.w_plus_r_inv_row,
+        &poly_zero,
+        &comb_func,
+      );
 
-        vec![eval_point_0, eval_point_2, eval_point_3]
-      })
-      .collect::<Vec<Vec<G::Scalar>>>()
+    let (eval_inv_0_col, eval_inv_2_col, eval_inv_3_col) =
+      SumcheckProof::<G>::compute_eval_points_cubic(
+        &self.t_plus_r_inv_col,
+        &self.w_plus_r_inv_col,
+        &poly_zero,
+        &comb_func,
+      );
+
+    // row related evaluation points
+    let (eval_T_0_row, eval_T_2_row, eval_T_3_row) =
+      SumcheckProof::<G>::compute_eval_points_cubic_with_additive_term(
+        &self.poly_eq,
+        &self.t_plus_r_inv_row,
+        &self.t_plus_r_row,
+        &self.ts_row,
+        &comb_func3,
+      );
+    let (eval_W_0_row, eval_W_2_row, eval_W_3_row) =
+      SumcheckProof::<G>::compute_eval_points_cubic_with_additive_term(
+        &self.poly_eq,
+        &self.w_plus_r_inv_row,
+        &self.w_plus_r_row,
+        &poly_zero,
+        &comb_func2,
+      );
+
+    // column related evaluation points
+    let (eval_T_0_col, eval_T_2_col, eval_T_3_col) =
+      SumcheckProof::<G>::compute_eval_points_cubic_with_additive_term(
+        &self.poly_eq,
+        &self.t_plus_r_inv_col,
+        &self.t_plus_r_col,
+        &self.ts_col,
+        &comb_func3,
+      );
+    let (eval_W_0_col, eval_W_2_col, eval_W_3_col) =
+      SumcheckProof::<G>::compute_eval_points_cubic_with_additive_term(
+        &self.poly_eq,
+        &self.w_plus_r_inv_col,
+        &self.w_plus_r_col,
+        &poly_zero,
+        &comb_func2,
+      );
+
+    vec![
+      vec![eval_inv_0_row, eval_inv_2_row, eval_inv_3_row],
+      vec![eval_inv_0_col, eval_inv_2_col, eval_inv_3_col],
+      vec![eval_T_0_row, eval_T_2_row, eval_T_3_row],
+      vec![eval_W_0_row, eval_W_2_row, eval_W_3_row],
+      vec![eval_T_0_col, eval_T_2_col, eval_T_3_col],
+      vec![eval_W_0_col, eval_W_2_col, eval_W_3_col],
+    ]
   }
 
   fn bound(&mut self, r: &G::Scalar) {
-    let _ = rayon::join(
-      || self.poly_A.bound_poly_var_top(r),
-      || {
-        for ((poly_B, poly_C), poly_D) in self
-          .poly_B_vec
-          .iter_mut()
-          .zip(self.poly_C_vec.iter_mut())
-          .zip(self.poly_D_vec.iter_mut())
-        {
-          let _ = rayon::join(
-            || poly_B.bound_poly_var_top(r),
-            || {
-              rayon::join(
-                || poly_C.bound_poly_var_top(r),
-                || poly_D.bound_poly_var_top(r),
-              )
-            },
-          );
-        }
-      },
-    );
+    [
+      &mut self.t_plus_r_row,
+      &mut self.t_plus_r_inv_row,
+      &mut self.w_plus_r_row,
+      &mut self.w_plus_r_inv_row,
+      &mut self.ts_row,
+      &mut self.t_plus_r_col,
+      &mut self.t_plus_r_inv_col,
+      &mut self.w_plus_r_col,
+      &mut self.w_plus_r_inv_col,
+      &mut self.ts_col,
+      &mut self.poly_eq,
+    ]
+    .par_iter_mut()
+    .for_each(|poly| poly.bound_poly_var_top(r));
   }
-  fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
-    let poly_A_final = vec![self.poly_A[0]];
-    let poly_B_final = (0..self.poly_B_vec.len())
-      .map(|i| self.poly_B_vec[i][0])
-      .collect();
-    let poly_C_final = (0..self.poly_C_vec.len())
-      .map(|i| self.poly_C_vec[i][0])
-      .collect();
-    let poly_D_final = (0..self.poly_D_vec.len())
-      .map(|i| self.poly_D_vec[i][0])
-      .collect();
 
-    vec![poly_A_final, poly_B_final, poly_C_final, poly_D_final]
+  fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
+    let poly_row_final = vec![
+      self.t_plus_r_inv_row[0],
+      self.w_plus_r_inv_row[0],
+      self.ts_row[0],
+    ];
+
+    let poly_col_final = vec![
+      self.t_plus_r_inv_col[0],
+      self.w_plus_r_inv_col[0],
+      self.ts_col[0],
+    ];
+
+    vec![poly_row_final, poly_col_final]
   }
 }
 
@@ -576,34 +623,34 @@ impl<G: Group> SumcheckEngine<G> for OuterSumcheckInstance<G> {
        poly_D_comp: &G::Scalar|
        -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
 
-    // Make an iterator returning the contributions to the evaluations
     let (eval_point_0, eval_point_2, eval_point_3) =
-      SumcheckProof::<G>::compute_eval_points_cubic(poly_A, poly_B, poly_C, poly_D, &comb_func);
+      SumcheckProof::<G>::compute_eval_points_cubic_with_additive_term(
+        poly_A, poly_B, poly_C, poly_D, &comb_func,
+      );
 
     vec![vec![eval_point_0, eval_point_2, eval_point_3]]
   }
 
   fn bound(&mut self, r: &G::Scalar) {
-    self.poly_tau.bound_poly_var_top(r);
-    self.poly_Az.bound_poly_var_top(r);
-    self.poly_Bz.bound_poly_var_top(r);
-    self.poly_uCz_E.bound_poly_var_top(r);
+    [
+      &mut self.poly_tau,
+      &mut self.poly_Az,
+      &mut self.poly_Bz,
+      &mut self.poly_uCz_E,
+    ]
+    .par_iter_mut()
+    .for_each(|poly| poly.bound_poly_var_top(r));
   }
 
   fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
-    vec![vec![
-      self.poly_tau[0],
-      self.poly_Az[0],
-      self.poly_Bz[0],
-      self.poly_uCz_E[0],
-    ]]
+    vec![vec![self.poly_Az[0], self.poly_Bz[0]]]
   }
 }
 
 struct InnerSumcheckInstance<G: Group> {
   claim: G::Scalar,
-  poly_E_row: MultilinearPolynomial<G::Scalar>,
-  poly_E_col: MultilinearPolynomial<G::Scalar>,
+  poly_L_row: MultilinearPolynomial<G::Scalar>,
+  poly_L_col: MultilinearPolynomial<G::Scalar>,
   poly_val: MultilinearPolynomial<G::Scalar>,
 }
 
@@ -617,69 +664,36 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
   }
 
   fn size(&self) -> usize {
-    assert_eq!(self.poly_E_row.len(), self.poly_val.len());
-    assert_eq!(self.poly_E_row.len(), self.poly_E_col.len());
-    self.poly_E_row.len()
+    assert_eq!(self.poly_L_row.len(), self.poly_val.len());
+    assert_eq!(self.poly_L_row.len(), self.poly_L_col.len());
+    self.poly_L_row.len()
   }
 
   fn evaluation_points(&self) -> Vec<Vec<G::Scalar>> {
-    let (poly_A, poly_B, poly_C) = (&self.poly_E_row, &self.poly_E_col, &self.poly_val);
+    let (poly_A, poly_B, poly_C) = (&self.poly_L_row, &self.poly_L_col, &self.poly_val);
     let comb_func = |poly_A_comp: &G::Scalar,
                      poly_B_comp: &G::Scalar,
                      poly_C_comp: &G::Scalar|
      -> G::Scalar { *poly_A_comp * *poly_B_comp * *poly_C_comp };
-    let len = poly_A.len() / 2;
 
-    // TODO: make this call a function in sumcheck.rs by writing an n-ary variant of crate::spartan::sumcheck::SumcheckProof::<G>::compute_eval_points_cubic
-    // once #[feature(array_methods)] stabilizes (this n-ary variant would need array::each_ref)
-    // Make an iterator returning the contributions to the evaluations
-    let (eval_point_0, eval_point_2, eval_point_3) = (0..len)
-      .into_par_iter()
-      .map(|i| {
-        // eval 0: bound_func is A(low)
-        let eval_point_0 = comb_func(&poly_A[i], &poly_B[i], &poly_C[i]);
-
-        // eval 2: bound_func is -A(low) + 2*A(high)
-        let poly_A_bound_point = poly_A[len + i] + poly_A[len + i] - poly_A[i];
-        let poly_B_bound_point = poly_B[len + i] + poly_B[len + i] - poly_B[i];
-        let poly_C_bound_point = poly_C[len + i] + poly_C[len + i] - poly_C[i];
-        let eval_point_2 = comb_func(
-          &poly_A_bound_point,
-          &poly_B_bound_point,
-          &poly_C_bound_point,
-        );
-
-        // eval 3: bound_func is -2A(low) + 3A(high); computed incrementally with bound_func applied to eval(2)
-        let poly_A_bound_point = poly_A_bound_point + poly_A[len + i] - poly_A[i];
-        let poly_B_bound_point = poly_B_bound_point + poly_B[len + i] - poly_B[i];
-        let poly_C_bound_point = poly_C_bound_point + poly_C[len + i] - poly_C[i];
-        let eval_point_3 = comb_func(
-          &poly_A_bound_point,
-          &poly_B_bound_point,
-          &poly_C_bound_point,
-        );
-        (eval_point_0, eval_point_2, eval_point_3)
-      })
-      .reduce(
-        || (G::Scalar::ZERO, G::Scalar::ZERO, G::Scalar::ZERO),
-        |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
-      );
+    let (eval_point_0, eval_point_2, eval_point_3) =
+      SumcheckProof::<G>::compute_eval_points_cubic(poly_A, poly_B, poly_C, &comb_func);
 
     vec![vec![eval_point_0, eval_point_2, eval_point_3]]
   }
 
   fn bound(&mut self, r: &G::Scalar) {
-    self.poly_E_row.bound_poly_var_top(r);
-    self.poly_E_col.bound_poly_var_top(r);
-    self.poly_val.bound_poly_var_top(r);
+    [
+      &mut self.poly_L_row,
+      &mut self.poly_L_col,
+      &mut self.poly_val,
+    ]
+    .par_iter_mut()
+    .for_each(|poly| poly.bound_poly_var_top(r));
   }
 
   fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
-    vec![vec![
-      self.poly_E_row[0],
-      self.poly_E_col[0],
-      self.poly_val[0],
-    ]]
+    vec![vec![self.poly_L_row[0], self.poly_L_col[0]]]
   }
 }
 
@@ -717,55 +731,52 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G,
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
-  // commitment to oracles
+  // commitment to oracles: the first three are for Az, Bz, Cz,
+  // and the last two are for memory reads
   comm_Az: CompressedCommitment<G>,
   comm_Bz: CompressedCommitment<G>,
   comm_Cz: CompressedCommitment<G>,
+  comm_L_row: CompressedCommitment<G>,
+  comm_L_col: CompressedCommitment<G>,
 
-  // commitment to oracles for the inner sum-check
-  comm_E_row: CompressedCommitment<G>,
-  comm_E_col: CompressedCommitment<G>,
+  // commitments to aid the memory checks
+  comm_t_plus_r_inv_row: CompressedCommitment<G>,
+  comm_w_plus_r_inv_row: CompressedCommitment<G>,
+  comm_t_plus_r_inv_col: CompressedCommitment<G>,
+  comm_w_plus_r_inv_col: CompressedCommitment<G>,
 
-  // initial claims
+  // claims about Az, Bz, and Cz polynomials
   eval_Az_at_tau: G::Scalar,
   eval_Bz_at_tau: G::Scalar,
   eval_Cz_at_tau: G::Scalar,
 
-  comm_output_arr: [CompressedCommitment<G>; 8],
-  claims_product_arr: [G::Scalar; 8],
+  // sum-check
+  sc: SumcheckProof<G>,
 
-  // satisfiability sum-check
-  sc_sat: SumcheckProof<G>,
-
-  // claims from the end of the sum-check
+  // claims from the end of sum-check
   eval_Az: G::Scalar,
   eval_Bz: G::Scalar,
   eval_Cz: G::Scalar,
   eval_E: G::Scalar,
-  eval_E_row: G::Scalar,
-  eval_E_col: G::Scalar,
+  eval_L_row: G::Scalar,
+  eval_L_col: G::Scalar,
   eval_val_A: G::Scalar,
   eval_val_B: G::Scalar,
   eval_val_C: G::Scalar,
-  eval_left_arr: [G::Scalar; 8],
-  eval_right_arr: [G::Scalar; 8],
-  eval_output_arr: [G::Scalar; 8],
-  eval_input_arr: [G::Scalar; 8],
-  eval_output2_arr: [G::Scalar; 8],
 
-  eval_row: G::Scalar,
-  eval_row_read_ts: G::Scalar,
-  eval_E_row_at_r_prod: G::Scalar,
-  eval_row_audit_ts: G::Scalar,
-  eval_col: G::Scalar,
-  eval_col_read_ts: G::Scalar,
-  eval_E_col_at_r_prod: G::Scalar,
-  eval_col_audit_ts: G::Scalar,
   eval_W: G::Scalar,
 
-  // batch openings of all multilinear polynomials
-  sc_proof_batch: SumcheckProof<G>,
-  evals_batch_arr: [G::Scalar; 7],
+  eval_t_plus_r_inv_row: G::Scalar,
+  eval_row: G::Scalar, // address
+  eval_w_plus_r_inv_row: G::Scalar,
+  eval_ts_row: G::Scalar,
+
+  eval_t_plus_r_inv_col: G::Scalar,
+  eval_col: G::Scalar, // address
+  eval_w_plus_r_inv_col: G::Scalar,
+  eval_ts_col: G::Scalar,
+
+  // a PCS evaluation argument
   eval_arg: EE::EvaluationArgument,
 }
 
@@ -773,7 +784,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARK<G, EE>
 where
   <G::Scalar as PrimeField>::Repr: Abomonation,
 {
-  fn prove_inner<T1, T2, T3>(
+  fn prove_helper<T1, T2, T3>(
     mem: &mut T1,
     outer: &mut T2,
     inner: &mut T3,
@@ -800,26 +811,15 @@ where
     assert_eq!(mem.degree(), inner.degree());
 
     // these claims are already added to the transcript, so we do not need to add
-    let claims = {
-      let claims_mem = mem.initial_claims();
-      let claims_outer = outer.initial_claims();
-      let claims_inner = inner.initial_claims();
-      claims_mem
-        .into_iter()
-        .chain(claims_outer)
-        .chain(claims_inner)
-        .collect::<Vec<G::Scalar>>()
-    };
+    let claims = mem
+      .initial_claims()
+      .into_iter()
+      .chain(outer.initial_claims())
+      .chain(inner.initial_claims())
+      .collect::<Vec<G::Scalar>>();
 
-    let num_claims = claims.len();
-    let coeffs = {
-      let s = transcript.squeeze(b"r")?;
-      let mut s_vec = vec![s];
-      for i in 1..num_claims {
-        s_vec.push(s_vec[i - 1] * s);
-      }
-      s_vec
-    };
+    let s = transcript.squeeze(b"r")?;
+    let coeffs = powers::<G>(&s, claims.len());
 
     // compute the joint claim
     let claim = claims
@@ -832,12 +832,12 @@ where
     let mut r: Vec<G::Scalar> = Vec::new();
     let mut cubic_polys: Vec<CompressedUniPoly<G::Scalar>> = Vec::new();
     let num_rounds = mem.size().log_2();
-    for _i in 0..num_rounds {
+    for _ in 0..num_rounds {
       let mut evals: Vec<Vec<G::Scalar>> = Vec::new();
       evals.extend(mem.evaluation_points());
       evals.extend(outer.evaluation_points());
       evals.extend(inner.evaluation_points());
-      assert_eq!(evals.len(), num_claims);
+      assert_eq!(evals.len(), claims.len());
 
       let evals_combined_0 = (0..evals.len()).map(|i| evals[i][0] * coeffs[i]).sum();
       let evals_combined_2 = (0..evals.len()).map(|i| evals[i][1] * coeffs[i]).sum();
@@ -990,26 +990,20 @@ where
 
     transcript.absorb(b"c", &[comm_Az, comm_Bz, comm_Cz].as_slice());
 
-    // number of rounds of the satisfiability sum-check
-    let num_rounds_sat = pk.S_repr.N.log_2();
+    // number of rounds of sum-check
+    let num_rounds_sc = pk.S_repr.N.log_2();
     let tau = transcript.squeeze(b"t")?;
-    let tau_coords = PowPolynomial::new(&tau, num_rounds_sat).coordinates();
+    let tau_coords = PowPolynomial::new(&tau, num_rounds_sc).coordinates();
 
     // (1) send commitments to Az, Bz, and Cz along with their evaluations at tau
-    let (Az, Bz, Cz, E) = {
+    let (Az, Bz, Cz, W, E) = {
       Az.resize(pk.S_repr.N, G::Scalar::ZERO);
       Bz.resize(pk.S_repr.N, G::Scalar::ZERO);
       Cz.resize(pk.S_repr.N, G::Scalar::ZERO);
+      let E = padded::<G>(&W.E, pk.S_repr.N, &G::Scalar::ZERO);
+      let W = padded::<G>(&W.W, pk.S_repr.N, &G::Scalar::ZERO);
 
-      let E = {
-        let mut val = vec![G::Scalar::ZERO; pk.S_repr.N];
-        for (i, w_e) in W.E.iter().enumerate() {
-          val[i] = *w_e;
-        }
-        val
-      };
-
-      (Az, Bz, Cz, E)
+      (Az, Bz, Cz, W, E)
     };
     let (eval_Az_at_tau, eval_Bz_at_tau, eval_Cz_at_tau) = {
       let evals_at_tau = [&Az, &Bz, &Cz]
@@ -1020,19 +1014,19 @@ where
     };
 
     // (2) send commitments to the following two oracles
-    // E_row(i) = eq(tau, row(i)) for all i
-    // E_col(i) = z(col(i)) for all i
-    let (mem_row, mem_col, E_row, E_col) = pk.S_repr.evaluation_oracles(&S, &tau, &z);
-    let (comm_E_row, comm_E_col) =
-      rayon::join(|| G::CE::commit(ck, &E_row), || G::CE::commit(ck, &E_col));
+    // L_row(i) = eq(tau, row(i)) for all i
+    // L_col(i) = z(col(i)) for all i
+    let (mem_row, mem_col, L_row, L_col) = pk.S_repr.evaluation_oracles(&S, &tau, &z);
+    let (comm_L_row, comm_L_col) =
+      rayon::join(|| G::CE::commit(ck, &L_row), || G::CE::commit(ck, &L_col));
 
     // absorb the claimed evaluations into the transcript
     transcript.absorb(
       b"e",
       &[eval_Az_at_tau, eval_Bz_at_tau, eval_Cz_at_tau].as_slice(),
     );
-    // absorb commitments to E_row and E_col in the transcript
-    transcript.absorb(b"e", &vec![comm_E_row, comm_E_col].as_slice());
+    // absorb commitments to L_row and L_col in the transcript
+    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
 
     // add claims about Az, Bz, and Cz to be checked later
     // since all the three polynomials are opened at tau,
@@ -1042,20 +1036,18 @@ where
     let poly_vec = vec![&Az, &Bz, &Cz];
     transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
-    let w = PolyEvalWitness::batch(&poly_vec, &c);
-    let u = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
+    let w: PolyEvalWitness<G> = PolyEvalWitness::batch(&poly_vec, &c);
+    let u: PolyEvalInstance<G> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
     w_u_vec.push((w, u));
-
-    let c_inner = c;
 
     // we now need to prove three claims
     // (1) 0 = \sum_x poly_tau(x) * (poly_Az(x) * poly_Bz(x) - poly_uCz_E(x))
-    // (2) eval_Az_at_tau + r * eval_Bz_at_tau + r^2 * eval_Cz_at_tau = \sum_y E_row(y) * (val_A(y) + r * val_B(y) + r^2 * val_C(y)) * E_col(y)
-    // (3) E_row(i) = eq(tau, row(i)) and E_col(i) = z(col(i))
+    // (2) eval_Az_at_tau + r * eval_Bz_at_tau + r^2 * eval_Cz_at_tau = \sum_y L_row(y) * (val_A(y) + r * val_B(y) + r^2 * val_C(y)) * L_col(y)
+    // (3) L_row(i) = eq(tau, row(i)) and L_col(i) = z(col(i))
 
     // a sum-check instance to prove the first claim
     let mut outer_sc_inst = OuterSumcheckInstance {
-      poly_tau: MultilinearPolynomial::new(PowPolynomial::new(&tau, num_rounds_sat).evals()),
+      poly_tau: MultilinearPolynomial::new(PowPolynomial::new(&tau, num_rounds_sc).evals()),
       poly_Az: MultilinearPolynomial::new(Az.clone()),
       poly_Bz: MultilinearPolynomial::new(Bz.clone()),
       poly_uCz_E: {
@@ -1073,538 +1065,209 @@ where
       .iter()
       .zip(pk.S_repr.val_B.iter())
       .zip(pk.S_repr.val_C.iter())
-      .map(|((v_a, v_b), v_c)| *v_a + c_inner * *v_b + c_inner * c_inner * *v_c)
+      .map(|((v_a, v_b), v_c)| *v_a + c * *v_b + c * c * *v_c)
       .collect::<Vec<G::Scalar>>();
     let mut inner_sc_inst = InnerSumcheckInstance {
-      claim: eval_Az_at_tau + c_inner * eval_Bz_at_tau + c_inner * c_inner * eval_Cz_at_tau,
-      poly_E_row: MultilinearPolynomial::new(E_row.clone()),
-      poly_E_col: MultilinearPolynomial::new(E_col.clone()),
+      claim: eval_Az_at_tau + c * eval_Bz_at_tau + c * c * eval_Cz_at_tau,
+      poly_L_row: MultilinearPolynomial::new(L_row.clone()),
+      poly_L_col: MultilinearPolynomial::new(L_col.clone()),
       poly_val: MultilinearPolynomial::new(val),
     };
 
-    // a third sum-check instance to prove the memory-related claim
-    // we now need to prove that E_row and E_col are well-formed
-    // we use memory checking: H(INIT) * H(WS) =? H(RS) * H(FINAL)
-    let gamma_1 = transcript.squeeze(b"g1")?;
-    let gamma_2 = transcript.squeeze(b"g2")?;
+    // a third sum-check instance to prove the read-only memory claim
+    // we now need to prove that L_row and L_col are well-formed
+    let gamma = transcript.squeeze(b"g")?;
 
-    let gamma_1_sqr = gamma_1 * gamma_1;
-    let hash_func = |addr: &G::Scalar, val: &G::Scalar, ts: &G::Scalar| -> G::Scalar {
-      (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2
+    // hash the tuples of (addr,val) memory contents and read responses into a single field element using `hash_func`
+    let hash_func_vec = |mem: &[G::Scalar],
+                         addr: &[G::Scalar],
+                         lookups: &[G::Scalar]|
+     -> (Vec<G::Scalar>, Vec<G::Scalar>) {
+      let hash_func = |addr: &G::Scalar, val: &G::Scalar| -> G::Scalar { *val * gamma + *addr };
+      assert_eq!(addr.len(), lookups.len());
+      rayon::join(
+        || {
+          (0..mem.len())
+            .map(|i| hash_func(&G::Scalar::from(i as u64), &mem[i]))
+            .collect::<Vec<G::Scalar>>()
+        },
+        || {
+          (0..addr.len())
+            .map(|i| hash_func(&addr[i], &lookups[i]))
+            .collect::<Vec<G::Scalar>>()
+        },
+      )
     };
 
-    let (
-      ((init_row, read_row), (write_row, audit_row)),
-      ((init_col, read_col), (write_col, audit_col)),
-    ) = rayon::join(
-      || {
-        rayon::join(
-          || {
-            rayon::join(
-              || {
-                (0..mem_row.len())
-                  .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_row[i], &G::Scalar::ZERO))
-                  .collect::<Vec<G::Scalar>>()
-              },
-              || {
-                (0..E_row.len())
-                  .map(|i| hash_func(&pk.S_repr.row[i], &E_row[i], &pk.S_repr.row_read_ts[i]))
-                  .collect::<Vec<G::Scalar>>()
-              },
-            )
-          },
-          || {
-            rayon::join(
-              || {
-                (0..E_row.len())
-                  .map(|i| {
-                    hash_func(
-                      &pk.S_repr.row[i],
-                      &E_row[i],
-                      &(pk.S_repr.row_read_ts[i] + G::Scalar::ONE),
-                    )
-                  })
-                  .collect::<Vec<G::Scalar>>()
-              },
-              || {
-                (0..mem_row.len())
-                  .map(|i| {
-                    hash_func(
-                      &G::Scalar::from(i as u64),
-                      &mem_row[i],
-                      &pk.S_repr.row_audit_ts[i],
-                    )
-                  })
-                  .collect::<Vec<G::Scalar>>()
-              },
-            )
-          },
-        )
-      },
-      || {
-        rayon::join(
-          || {
-            rayon::join(
-              || {
-                (0..mem_col.len())
-                  .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_col[i], &G::Scalar::ZERO))
-                  .collect::<Vec<G::Scalar>>()
-              },
-              || {
-                (0..E_col.len())
-                  .map(|i| hash_func(&pk.S_repr.col[i], &E_col[i], &pk.S_repr.col_read_ts[i]))
-                  .collect::<Vec<G::Scalar>>()
-              },
-            )
-          },
-          || {
-            rayon::join(
-              || {
-                (0..E_col.len())
-                  .map(|i| {
-                    hash_func(
-                      &pk.S_repr.col[i],
-                      &E_col[i],
-                      &(pk.S_repr.col_read_ts[i] + G::Scalar::ONE),
-                    )
-                  })
-                  .collect::<Vec<G::Scalar>>()
-              },
-              || {
-                (0..mem_col.len())
-                  .map(|i| {
-                    hash_func(
-                      &G::Scalar::from(i as u64),
-                      &mem_col[i],
-                      &pk.S_repr.col_audit_ts[i],
-                    )
-                  })
-                  .collect::<Vec<G::Scalar>>()
-              },
-            )
-          },
-        )
-      },
+    let ((T_row, W_row), (T_col, W_col)) = rayon::join(
+      || hash_func_vec(&mem_row, &pk.S_repr.row, &L_row),
+      || hash_func_vec(&mem_col, &pk.S_repr.col, &L_col),
     );
 
-    let mut mem_sc_inst = ProductSumcheckInstance::new(
+    let r = transcript.squeeze(b"r")?;
+    let (mut mem_sc_inst, comm_lookup, polys_lookup) = LookupSumcheckInstance::new(
       ck,
-      vec![
-        init_row, read_row, write_row, audit_row, init_col, read_col, write_col, audit_col,
-      ],
+      &r,
+      T_row,
+      W_row,
+      pk.S_repr.ts_row.clone(),
+      T_col,
+      W_col,
+      pk.S_repr.ts_col.clone(),
       &mut transcript,
     )?;
 
-    let (sc_sat, r_sat, claims_mem, claims_outer, claims_inner) = Self::prove_inner(
+    let (sc, rand_sc, claims_mem, claims_outer, claims_inner) = Self::prove_helper(
       &mut mem_sc_inst,
       &mut outer_sc_inst,
       &mut inner_sc_inst,
       &mut transcript,
     )?;
 
-    // claims[0] is about the Eq polynomial, which the verifier computes directly
-    // claims[1] =? weighed sum of left(rand)
-    // claims[2] =? weighted sum of right(rand)
-    // claims[3] =? weighted sum of output(rand), which is easy to verify by querying output
-    // we also need to prove that output(output.len()-2) = claimed_product
-    let eval_left_vec = claims_mem[1].clone();
-    let eval_right_vec = claims_mem[2].clone();
-    let eval_output_vec = claims_mem[3].clone();
+    // claims from the end of the sum-check
+    let eval_Az = claims_outer[0][0];
+    let eval_Bz = claims_outer[0][1];
 
-    // claims from the end of sum-check
-    let (eval_Az, eval_Bz): (G::Scalar, G::Scalar) = (claims_outer[0][1], claims_outer[0][2]);
-    let eval_Cz = MultilinearPolynomial::evaluate_with(&Cz, &r_sat);
-    let eval_E = MultilinearPolynomial::evaluate_with(&E, &r_sat);
-    let eval_E_row = claims_inner[0][0];
-    let eval_E_col = claims_inner[0][1];
-    let eval_val_A = MultilinearPolynomial::evaluate_with(&pk.S_repr.val_A, &r_sat);
-    let eval_val_B = MultilinearPolynomial::evaluate_with(&pk.S_repr.val_B, &r_sat);
-    let eval_val_C = MultilinearPolynomial::evaluate_with(&pk.S_repr.val_C, &r_sat);
+    let eval_L_row = claims_inner[0][0];
+    let eval_L_col = claims_inner[0][1];
+
+    let eval_t_plus_r_inv_row = claims_mem[0][0];
+    let eval_w_plus_r_inv_row = claims_mem[0][1];
+    let eval_ts_row = claims_mem[0][2];
+
+    let eval_t_plus_r_inv_col = claims_mem[1][0];
+    let eval_w_plus_r_inv_col = claims_mem[1][1];
+    let eval_ts_col = claims_mem[1][2];
+
+    // compute the remaining claims that did not come for free from the sum-check prover
+    let (eval_W, eval_Cz, eval_E, eval_val_A, eval_val_B, eval_val_C, eval_row, eval_col) = {
+      let e = [
+        &W,
+        &Cz,
+        &E,
+        &pk.S_repr.val_A,
+        &pk.S_repr.val_B,
+        &pk.S_repr.val_C,
+        &pk.S_repr.row,
+        &pk.S_repr.col,
+      ]
+      .into_par_iter()
+      .map(|p| MultilinearPolynomial::evaluate_with(p, &rand_sc))
+      .collect::<Vec<G::Scalar>>();
+      (e[0], e[1], e[2], e[3], e[4], e[5], e[6], e[7])
+    };
+
+    // all the evaluations are at rand_sc, we can fold them into one claim
     let eval_vec = vec![
-      eval_Az, eval_Bz, eval_Cz, eval_E, eval_E_row, eval_E_col, eval_val_A, eval_val_B, eval_val_C,
+      eval_W,
+      eval_Az,
+      eval_Bz,
+      eval_Cz,
+      eval_E,
+      eval_L_row,
+      eval_L_col,
+      eval_val_A,
+      eval_val_B,
+      eval_val_C,
+      eval_t_plus_r_inv_row,
+      eval_row,
+      eval_w_plus_r_inv_row,
+      eval_ts_row,
+      eval_t_plus_r_inv_col,
+      eval_col,
+      eval_w_plus_r_inv_col,
+      eval_ts_col,
     ]
     .into_iter()
-    .chain(eval_left_vec.clone())
-    .chain(eval_right_vec.clone())
-    .chain(eval_output_vec.clone())
     .collect::<Vec<G::Scalar>>();
 
-    // absorb all the claimed evaluations
-    transcript.absorb(b"e", &eval_vec.as_slice());
-
-    // we now combine eval_left = left(rand) and eval_right = right(rand)
-    // into claims about input and output
-    let c = transcript.squeeze(b"c")?;
-
-    // eval = (G::Scalar::ONE - c) * eval_left + c * eval_right
-    // eval is claimed evaluation of input||output(r, c), which can be proven by proving input(r[1..], c) and output(r[1..], c)
-    let rand_ext = {
-      let mut r = r_sat.clone();
-      r.extend(&[c]);
-      r
-    };
-    let eval_input_vec = mem_sc_inst
-      .input_vec
-      .iter()
-      .map(|i| MultilinearPolynomial::evaluate_with(i, &rand_ext[1..]))
-      .collect::<Vec<G::Scalar>>();
-
-    let eval_output2_vec = mem_sc_inst
-      .output_vec
-      .iter()
-      .map(|o| MultilinearPolynomial::evaluate_with(o, &rand_ext[1..]))
-      .collect::<Vec<G::Scalar>>();
-
-    // add claimed evaluations to the transcript
-    let evals = eval_input_vec
-      .clone()
-      .into_iter()
-      .chain(eval_output2_vec.clone())
-      .collect::<Vec<G::Scalar>>();
-    transcript.absorb(b"e", &evals.as_slice());
-
-    // squeeze a challenge to combine multiple claims into one
-    let powers_of_rho = {
-      let s = transcript.squeeze(b"r")?;
-      let mut s_vec = vec![s];
-      for i in 1..mem_sc_inst.initial_claims().len() {
-        s_vec.push(s_vec[i - 1] * s);
-      }
-      s_vec
-    };
-
-    // take weighted sum of input, output, and their commitments
-    let product = mem_sc_inst
-      .claims
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    let eval_output = eval_output_vec
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    let comm_output = mem_sc_inst
-      .comm_output_vec
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(c, r_i)| *c * *r_i)
-      .fold(Commitment::<G>::default(), |acc, item| acc + item);
-
-    let weighted_sum = |W: &[Vec<G::Scalar>], s: &[G::Scalar]| -> Vec<G::Scalar> {
-      assert_eq!(W.len(), s.len());
-      let mut p = vec![G::Scalar::ZERO; W[0].len()];
-      for i in 0..W.len() {
-        for (j, item) in W[i].iter().enumerate().take(W[i].len()) {
-          p[j] += *item * s[i]
-        }
-      }
-      p
-    };
-
-    let poly_output = weighted_sum(&mem_sc_inst.output_vec, &powers_of_rho);
-
-    let eval_output2 = eval_output2_vec
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    // eval_output = output(r_sat)
-    w_u_vec.push((
-      PolyEvalWitness {
-        p: poly_output.clone(),
-      },
-      PolyEvalInstance {
-        c: comm_output,
-        x: r_sat.clone(),
-        e: eval_output,
-      },
-    ));
-
-    // claimed_product = output(1, ..., 1, 0)
-    let x = {
-      let mut x = vec![G::Scalar::ONE; r_sat.len()];
-      x[r_sat.len() - 1] = G::Scalar::ZERO;
-      x
-    };
-    w_u_vec.push((
-      PolyEvalWitness {
-        p: poly_output.clone(),
-      },
-      PolyEvalInstance {
-        c: comm_output,
-        x,
-        e: product,
-      },
-    ));
-
-    // eval_output2 = output(rand_ext[1..])
-    w_u_vec.push((
-      PolyEvalWitness { p: poly_output },
-      PolyEvalInstance {
-        c: comm_output,
-        x: rand_ext[1..].to_vec(),
-        e: eval_output2,
-      },
-    ));
-
-    let r_prod = rand_ext[1..].to_vec();
-    // row-related and col-related claims of polynomial evaluations to aid the final check of the sum-check
-    let evals = [
-      &pk.S_repr.row,
-      &pk.S_repr.row_read_ts,
-      &E_row,
-      &pk.S_repr.row_audit_ts,
-      &pk.S_repr.col,
-      &pk.S_repr.col_read_ts,
-      &E_col,
-      &pk.S_repr.col_audit_ts,
-    ]
-    .into_par_iter()
-    .map(|p| MultilinearPolynomial::evaluate_with(p, &r_prod))
-    .collect::<Vec<G::Scalar>>();
-
-    let eval_row = evals[0];
-    let eval_row_read_ts = evals[1];
-    let eval_E_row_at_r_prod = evals[2];
-    let eval_row_audit_ts = evals[3];
-    let eval_col = evals[4];
-    let eval_col_read_ts = evals[5];
-    let eval_E_col_at_r_prod = evals[6];
-    let eval_col_audit_ts = evals[7];
-
-    // we need to prove that eval_z = z(r_prod) = (1-r_prod[0]) * W.w(r_prod[1..]) + r_prod[0] * U.x(r_prod[1..]).
-    // r_prod was padded, so we now remove the padding
-    let r_prod_unpad = {
-      let l = pk.S_repr.N.log_2() - (2 * S.num_vars).log_2();
-      r_prod[l..].to_vec()
-    };
-
-    let eval_W = MultilinearPolynomial::evaluate_with(&W.W, &r_prod_unpad[1..]);
-
-    // we can batch all the claims
-    transcript.absorb(
-      b"e",
-      &[
-        eval_row,
-        eval_row_read_ts,
-        eval_E_row_at_r_prod,
-        eval_row_audit_ts,
-        eval_col,
-        eval_col_read_ts,
-        eval_E_col_at_r_prod,
-        eval_col_audit_ts,
-        eval_W, // this will not be batched below as it is evaluated at r_prod[1..]
-      ]
-      .as_slice(),
-    );
-
-    let c = transcript.squeeze(b"c")?;
-    let eval_vec = [
-      eval_row,
-      eval_row_read_ts,
-      eval_E_row_at_r_prod,
-      eval_row_audit_ts,
-      eval_col,
-      eval_col_read_ts,
-      eval_E_col_at_r_prod,
-      eval_col_audit_ts,
-    ];
     let comm_vec = [
-      pk.S_comm.comm_row,
-      pk.S_comm.comm_row_read_ts,
-      comm_E_row,
-      pk.S_comm.comm_row_audit_ts,
-      pk.S_comm.comm_col,
-      pk.S_comm.comm_col_read_ts,
-      comm_E_col,
-      pk.S_comm.comm_col_audit_ts,
-    ];
-    let poly_vec = [
-      &pk.S_repr.row,
-      &pk.S_repr.row_read_ts,
-      &E_row,
-      &pk.S_repr.row_audit_ts,
-      &pk.S_repr.col,
-      &pk.S_repr.col_read_ts,
-      &E_col,
-      &pk.S_repr.col_audit_ts,
-    ];
-    let w = PolyEvalWitness::batch(&poly_vec, &c);
-    let u = PolyEvalInstance::batch(&comm_vec, &r_prod, &eval_vec, &c);
-
-    // add the claim to prove for later
-    w_u_vec.push((w, u));
-
-    w_u_vec.push((
-      PolyEvalWitness { p: W.W },
-      PolyEvalInstance {
-        c: U.comm_W,
-        x: r_prod_unpad[1..].to_vec(),
-        e: eval_W,
-      },
-    ));
-
-    // all nine evaluations are at r_sat, we can fold them into one; they were added to the transcript earlier
-    let eval_vec = [
-      eval_Az, eval_Bz, eval_Cz, eval_E, eval_E_row, eval_E_col, eval_val_A, eval_val_B, eval_val_C,
-    ];
-    let comm_vec = [
+      U.comm_W,
       comm_Az,
       comm_Bz,
       comm_Cz,
       U.comm_E,
-      comm_E_row,
-      comm_E_col,
+      comm_L_row,
+      comm_L_col,
       pk.S_comm.comm_val_A,
       pk.S_comm.comm_val_B,
       pk.S_comm.comm_val_C,
+      comm_lookup[0],
+      pk.S_comm.comm_row,
+      comm_lookup[1],
+      pk.S_comm.comm_ts_row,
+      comm_lookup[2],
+      pk.S_comm.comm_col,
+      comm_lookup[3],
+      pk.S_comm.comm_ts_col,
     ];
     let poly_vec = [
+      &W,
       &Az,
       &Bz,
       &Cz,
       &E,
-      &E_row,
-      &E_col,
+      &L_row,
+      &L_col,
       &pk.S_repr.val_A,
       &pk.S_repr.val_B,
       &pk.S_repr.val_C,
+      polys_lookup[0].as_ref(),
+      &pk.S_repr.row,
+      polys_lookup[1].as_ref(),
+      &pk.S_repr.ts_row,
+      polys_lookup[2].as_ref(),
+      &pk.S_repr.col,
+      polys_lookup[3].as_ref(),
+      &pk.S_repr.ts_col,
     ];
-    transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
+    transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
-    let w = PolyEvalWitness::batch(&poly_vec, &c);
-    let u = PolyEvalInstance::batch(&comm_vec, &r_sat, &eval_vec, &c);
-    w_u_vec.push((w, u));
+    let w: PolyEvalWitness<G> = PolyEvalWitness::batch(&poly_vec, &c);
+    let u: PolyEvalInstance<G> = PolyEvalInstance::batch(&comm_vec, &rand_sc, &eval_vec, &c);
 
-    // We will now reduce a vector of claims of evaluations at different points into claims about them at the same point.
-    // For example, eval_W =? W(r_y[1..]) and eval_W =? E(r_x) into
-    // two claims: eval_W_prime =? W(rz) and eval_E_prime =? E(rz)
-    // We can them combine the two into one: eval_W_prime + gamma * eval_E_prime =? (W + gamma*E)(rz),
-    // where gamma is a public challenge
-    // Since commitments to W and E are homomorphic, the verifier can compute a commitment
-    // to the batched polynomial.
-    assert!(w_u_vec.len() >= 2);
-
-    let (w_vec, u_vec): (Vec<PolyEvalWitness<G>>, Vec<PolyEvalInstance<G>>) =
-      w_u_vec.into_iter().unzip();
-    let w_vec_padded = PolyEvalWitness::pad(&w_vec); // pad the polynomials to be of the same size
-    let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
-
-    // generate a challenge
-    let rho = transcript.squeeze(b"r")?;
-    let num_claims = w_vec_padded.len();
-    let powers_of_rho = powers::<G>(&rho, num_claims);
-    let claim_batch_joint = u_vec_padded
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(u, p)| u.e * p)
-      .sum();
-
-    let mut polys_left: Vec<MultilinearPolynomial<G::Scalar>> = w_vec_padded
-      .iter()
-      .map(|w| MultilinearPolynomial::new(w.p.clone()))
-      .collect();
-    let mut polys_right: Vec<MultilinearPolynomial<G::Scalar>> = u_vec_padded
-      .iter()
-      .map(|u| MultilinearPolynomial::new(EqPolynomial::new(u.x.clone()).evals()))
-      .collect();
-
-    let num_rounds_z = u_vec_padded[0].x.len();
-    let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
-      *poly_A_comp * *poly_B_comp
-    };
-    let (sc_proof_batch, r_z, claims_batch) = SumcheckProof::prove_quad_batch(
-      &claim_batch_joint,
-      num_rounds_z,
-      &mut polys_left,
-      &mut polys_right,
-      &powers_of_rho,
-      comb_func,
-      &mut transcript,
-    )?;
-
-    let (claims_batch_left, _): (Vec<G::Scalar>, Vec<G::Scalar>) = claims_batch;
-
-    transcript.absorb(b"l", &claims_batch_left.as_slice());
-
-    // we now combine evaluation claims at the same point rz into one
-    let gamma = transcript.squeeze(b"g")?;
-    let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
-    let comm_joint = u_vec_padded
-      .iter()
-      .zip(powers_of_gamma.iter())
-      .map(|(u, g_i)| u.c * *g_i)
-      .fold(Commitment::<G>::default(), |acc, item| acc + item);
-    let poly_joint = PolyEvalWitness::weighted_sum(&w_vec_padded, &powers_of_gamma);
-    let eval_joint = claims_batch_left
-      .iter()
-      .zip(powers_of_gamma.iter())
-      .map(|(e, g_i)| *e * *g_i)
-      .sum();
-
-    let eval_arg = EE::prove(
-      ck,
-      &pk.pk_ee,
-      &mut transcript,
-      &comm_joint,
-      &poly_joint.p,
-      &r_z,
-      &eval_joint,
-    )?;
+    let eval_arg = EE::prove(ck, &pk.pk_ee, &mut transcript, &u.c, &w.p, &rand_sc, &u.e)?;
 
     Ok(RelaxedR1CSSNARK {
       comm_Az: comm_Az.compress(),
       comm_Bz: comm_Bz.compress(),
       comm_Cz: comm_Cz.compress(),
-      comm_E_row: comm_E_row.compress(),
-      comm_E_col: comm_E_col.compress(),
+      comm_L_row: comm_L_row.compress(),
+      comm_L_col: comm_L_col.compress(),
+
+      comm_t_plus_r_inv_row: comm_lookup[0].compress(),
+      comm_w_plus_r_inv_row: comm_lookup[1].compress(),
+      comm_t_plus_r_inv_col: comm_lookup[2].compress(),
+      comm_w_plus_r_inv_col: comm_lookup[3].compress(),
+
       eval_Az_at_tau,
       eval_Bz_at_tau,
       eval_Cz_at_tau,
-      comm_output_arr: vec_to_arr(
-        mem_sc_inst
-          .comm_output_vec
-          .iter()
-          .map(|c| c.compress())
-          .collect::<Vec<CompressedCommitment<G>>>(),
-      ),
-      claims_product_arr: vec_to_arr(mem_sc_inst.claims.clone()),
 
-      sc_sat,
+      sc,
 
       eval_Az,
       eval_Bz,
       eval_Cz,
       eval_E,
-      eval_E_row,
-      eval_E_col,
+      eval_L_row,
+      eval_L_col,
       eval_val_A,
       eval_val_B,
       eval_val_C,
 
-      eval_left_arr: vec_to_arr(eval_left_vec),
-      eval_right_arr: vec_to_arr(eval_right_vec),
-      eval_output_arr: vec_to_arr(eval_output_vec),
-      eval_input_arr: vec_to_arr(eval_input_vec),
-      eval_output2_arr: vec_to_arr(eval_output2_vec),
-
-      eval_row,
-      eval_row_read_ts,
-      eval_E_row_at_r_prod,
-      eval_row_audit_ts,
-      eval_col,
-      eval_col_read_ts,
-      eval_E_col_at_r_prod,
-      eval_col_audit_ts,
       eval_W,
 
-      sc_proof_batch,
-      evals_batch_arr: vec_to_arr(claims_batch_left),
+      eval_t_plus_r_inv_row,
+      eval_row,
+      eval_w_plus_r_inv_row,
+      eval_ts_row,
+
+      eval_col,
+      eval_t_plus_r_inv_col,
+      eval_w_plus_r_inv_col,
+      eval_ts_col,
+
       eval_arg,
     })
   }
@@ -1621,14 +1284,18 @@ where
     let comm_Az = Commitment::<G>::decompress(&self.comm_Az)?;
     let comm_Bz = Commitment::<G>::decompress(&self.comm_Bz)?;
     let comm_Cz = Commitment::<G>::decompress(&self.comm_Cz)?;
-    let comm_E_row = Commitment::<G>::decompress(&self.comm_E_row)?;
-    let comm_E_col = Commitment::<G>::decompress(&self.comm_E_col)?;
+    let comm_L_row = Commitment::<G>::decompress(&self.comm_L_row)?;
+    let comm_L_col = Commitment::<G>::decompress(&self.comm_L_col)?;
+    let comm_t_plus_r_inv_row = Commitment::<G>::decompress(&self.comm_t_plus_r_inv_row)?;
+    let comm_w_plus_r_inv_row = Commitment::<G>::decompress(&self.comm_w_plus_r_inv_row)?;
+    let comm_t_plus_r_inv_col = Commitment::<G>::decompress(&self.comm_t_plus_r_inv_col)?;
+    let comm_w_plus_r_inv_col = Commitment::<G>::decompress(&self.comm_w_plus_r_inv_col)?;
 
     transcript.absorb(b"c", &[comm_Az, comm_Bz, comm_Cz].as_slice());
 
-    let num_rounds_sat = vk.S_comm.N.log_2();
+    let num_rounds_sc = vk.S_comm.N.log_2();
     let tau = transcript.squeeze(b"t")?;
-    let tau_coords = PowPolynomial::new(&tau, num_rounds_sat).coordinates();
+    let tau_coords = PowPolynomial::new(&tau, num_rounds_sc).coordinates();
 
     transcript.absorb(
       b"e",
@@ -1640,7 +1307,7 @@ where
       .as_slice(),
     );
 
-    transcript.absorb(b"e", &vec![comm_E_row, comm_E_col].as_slice());
+    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
 
     // add claims about Az, Bz, and Cz to be checked later
     // since all the three polynomials are opened at tau,
@@ -1655,431 +1322,186 @@ where
     let c = transcript.squeeze(b"c")?;
     let u = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
     let claim_inner = u.e;
-    let c_inner = c;
     u_vec.push(u);
 
-    let gamma_1 = transcript.squeeze(b"g1")?;
-    let gamma_2 = transcript.squeeze(b"g2")?;
+    let gamma = transcript.squeeze(b"g")?;
 
-    // hash function
-    let gamma_1_sqr = gamma_1 * gamma_1;
-    let hash_func = |addr: &G::Scalar, val: &G::Scalar, ts: &G::Scalar| -> G::Scalar {
-      (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2
-    };
+    let r = transcript.squeeze(b"r")?;
 
-    // check the required multiset relationship
-    // row
-    if self.claims_product_arr[0] * self.claims_product_arr[2]
-      != self.claims_product_arr[1] * self.claims_product_arr[3]
-    {
-      return Err(NovaError::InvalidMultisetProof);
-    }
-    // col
-    if self.claims_product_arr[4] * self.claims_product_arr[6]
-      != self.claims_product_arr[5] * self.claims_product_arr[7]
-    {
-      return Err(NovaError::InvalidMultisetProof);
-    }
-
-    let comm_output_vec = self
-      .comm_output_arr
-      .iter()
-      .map(|c| Commitment::<G>::decompress(c))
-      .collect::<Result<Vec<Commitment<G>>, NovaError>>()?;
-
-    transcript.absorb(b"o", &comm_output_vec.as_slice());
-    transcript.absorb(b"c", &self.claims_product_arr.as_slice());
-
-    let num_rounds = vk.S_comm.N.log_2();
-    let rand_eq = transcript.squeeze(b"e")?;
-    let rand_eq_coords = PowPolynomial::new(&rand_eq, num_rounds).coordinates();
-
-    let num_claims = 10;
-    let coeffs = {
-      let s = transcript.squeeze(b"r")?;
-      let mut s_vec = vec![s];
-      for i in 1..num_claims {
-        s_vec.push(s_vec[i - 1] * s);
-      }
-      s_vec
-    };
-
-    let claim = coeffs[9] * claim_inner; // rest are zeros
-    let (claim_sat_final, r_sat) = self
-      .sc_sat
-      .verify(claim, num_rounds_sat, 3, &mut transcript)?;
-
-    // verify claim_sat_final
-    let taus_bound_r_sat = PowPolynomial::new(&tau, num_rounds_sat).evaluate(&r_sat);
-    let rand_eq_bound_r_sat = EqPolynomial::new(rand_eq_coords).evaluate(&r_sat);
-    let claim_mem_final_expected: G::Scalar = (0..8)
-      .map(|i| {
-        coeffs[i]
-          * rand_eq_bound_r_sat
-          * (self.eval_left_arr[i] * self.eval_right_arr[i] - self.eval_output_arr[i])
-      })
-      .sum();
-    let claim_outer_final_expected = coeffs[8]
-      * taus_bound_r_sat
-      * (self.eval_Az * self.eval_Bz - U.u * self.eval_Cz - self.eval_E);
-    let claim_inner_final_expected = coeffs[9]
-      * self.eval_E_row
-      * self.eval_E_col
-      * (self.eval_val_A + c_inner * self.eval_val_B + c_inner * c_inner * self.eval_val_C);
-
-    if claim_mem_final_expected + claim_outer_final_expected + claim_inner_final_expected
-      != claim_sat_final
-    {
-      return Err(NovaError::InvalidSumcheckProof);
-    }
-
-    // claims from the end of the sum-check
-    let eval_vec = [
-      self.eval_Az,
-      self.eval_Bz,
-      self.eval_Cz,
-      self.eval_E,
-      self.eval_E_row,
-      self.eval_E_col,
-      self.eval_val_A,
-      self.eval_val_B,
-      self.eval_val_C,
-    ]
-    .into_iter()
-    .chain(self.eval_left_arr)
-    .chain(self.eval_right_arr)
-    .chain(self.eval_output_arr)
-    .collect::<Vec<G::Scalar>>();
-
-    transcript.absorb(b"e", &eval_vec.as_slice());
-    // we now combine eval_left = left(rand) and eval_right = right(rand)
-    // into claims about input and output
-    let c = transcript.squeeze(b"c")?;
-
-    // eval = (G::Scalar::ONE - c) * eval_left + c * eval_right
-    // eval is claimed evaluation of input||output(r, c), which can be proven by proving input(r[1..], c) and output(r[1..], c)
-    let rand_ext = {
-      let mut r = r_sat.clone();
-      r.extend(&[c]);
-      r
-    };
-
-    // add claimed evaluations to the transcript
-    let evals = self
-      .eval_input_arr
-      .into_iter()
-      .chain(self.eval_output2_arr)
-      .collect::<Vec<G::Scalar>>();
-    transcript.absorb(b"e", &evals.as_slice());
-
-    // squeeze a challenge to combine multiple claims into one
-    let powers_of_rho = {
-      let s = transcript.squeeze(b"r")?;
-      let mut s_vec = vec![s];
-      for i in 1..num_claims {
-        s_vec.push(s_vec[i - 1] * s);
-      }
-      s_vec
-    };
-
-    // take weighted sum of input, output, and their commitments
-    let product = self
-      .claims_product_arr
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    let eval_output = self
-      .eval_output_arr
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    let comm_output = comm_output_vec
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(c, r_i)| *c * *r_i)
-      .fold(Commitment::<G>::default(), |acc, item| acc + item);
-
-    let eval_output2 = self
-      .eval_output2_arr
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(e, p)| *e * p)
-      .sum();
-
-    // eval_output = output(r_sat)
-    u_vec.push(PolyEvalInstance {
-      c: comm_output,
-      x: r_sat.clone(),
-      e: eval_output,
-    });
-
-    // claimed_product = output(1, ..., 1, 0)
-    let x = {
-      let mut x = vec![G::Scalar::ONE; r_sat.len()];
-      x[r_sat.len() - 1] = G::Scalar::ZERO;
-      x
-    };
-    u_vec.push(PolyEvalInstance {
-      c: comm_output,
-      x,
-      e: product,
-    });
-
-    // eval_output2 = output(rand_ext[1..])
-    u_vec.push(PolyEvalInstance {
-      c: comm_output,
-      x: rand_ext[1..].to_vec(),
-      e: eval_output2,
-    });
-
-    let r_prod = rand_ext[1..].to_vec();
-    // row-related and col-related claims of polynomial evaluations to aid the final check of the sum-check
-    // we can batch all the claims
     transcript.absorb(
-      b"e",
-      &[
-        self.eval_row,
-        self.eval_row_read_ts,
-        self.eval_E_row_at_r_prod,
-        self.eval_row_audit_ts,
-        self.eval_col,
-        self.eval_col_read_ts,
-        self.eval_E_col_at_r_prod,
-        self.eval_col_audit_ts,
-        self.eval_W,
+      b"l",
+      &vec![
+        comm_t_plus_r_inv_row,
+        comm_w_plus_r_inv_row,
+        comm_t_plus_r_inv_col,
+        comm_w_plus_r_inv_col,
       ]
       .as_slice(),
     );
-    let c = transcript.squeeze(b"c")?;
-    let eval_vec = [
-      self.eval_row,
-      self.eval_row_read_ts,
-      self.eval_E_row_at_r_prod,
-      self.eval_row_audit_ts,
-      self.eval_col,
-      self.eval_col_read_ts,
-      self.eval_E_col_at_r_prod,
-      self.eval_col_audit_ts,
-    ];
-    let comm_vec = [
-      vk.S_comm.comm_row,
-      vk.S_comm.comm_row_read_ts,
-      comm_E_row,
-      vk.S_comm.comm_row_audit_ts,
-      vk.S_comm.comm_col,
-      vk.S_comm.comm_col_read_ts,
-      comm_E_col,
-      vk.S_comm.comm_col_audit_ts,
-    ];
-    let u = PolyEvalInstance::batch(&comm_vec, &r_prod, &eval_vec, &c);
 
-    // add the claim to prove for later
-    u_vec.push(u);
+    let rho = transcript.squeeze(b"r")?;
 
-    // compute eval_Z
-    let (eval_Z, r_prod_unpad) = {
-      // r_prod was padded, so we now remove the padding
-      let (factor, r_prod_unpad) = {
-        let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
+    let num_claims = 8;
+    let s = transcript.squeeze(b"r")?;
+    let coeffs = powers::<G>(&s, num_claims);
+    let claim = coeffs[7] * claim_inner; // rest are zeros
 
-        let mut factor = G::Scalar::ONE;
-        for r_p in r_prod.iter().take(l) {
-          factor *= G::Scalar::ONE - r_p
-        }
+    // verify sc
+    let (claim_sc_final, rand_sc) = self.sc.verify(claim, num_rounds_sc, 3, &mut transcript)?;
 
-        let r_prod_unpad = {
-          let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
-          r_prod[l..].to_vec()
+    // verify claim_sc_final
+    let claim_sc_final_expected = {
+      let rand_eq_bound_rand_sc = {
+        let poly_eq_coords = PowPolynomial::new(&rho, num_rounds_sc).coordinates();
+        EqPolynomial::new(poly_eq_coords).evaluate(&rand_sc)
+      };
+      let taus_bound_rand_sc = PowPolynomial::new(&tau, num_rounds_sc).evaluate(&rand_sc);
+
+      let eval_t_plus_r_row = {
+        let eval_addr_row = IdentityPolynomial::new(num_rounds_sc).evaluate(&rand_sc);
+        let eval_val_row = taus_bound_rand_sc;
+        let eval_t = eval_addr_row + gamma * eval_val_row;
+        eval_t + r
+      };
+
+      let eval_w_plus_r_row = {
+        let eval_addr_row = self.eval_row;
+        let eval_val_row = self.eval_L_row;
+        let eval_w = eval_addr_row + gamma * eval_val_row;
+        eval_w + r
+      };
+
+      let eval_t_plus_r_col = {
+        let eval_addr_col = IdentityPolynomial::new(num_rounds_sc).evaluate(&rand_sc);
+
+        // memory contents is z, so we compute eval_Z from eval_W and eval_X
+        let eval_val_col = {
+          // rand_sc was padded, so we now remove the padding
+          let (factor, rand_sc_unpad) = {
+            let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
+
+            let mut factor = G::Scalar::ONE;
+            for r_p in rand_sc.iter().take(l) {
+              factor *= G::Scalar::ONE - r_p
+            }
+
+            let rand_sc_unpad = {
+              let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
+              rand_sc[l..].to_vec()
+            };
+
+            (factor, rand_sc_unpad)
+          };
+
+          let eval_X = {
+            // constant term
+            let mut poly_X = vec![(0, U.u)];
+            //remaining inputs
+            poly_X.extend(
+              (0..U.X.len())
+                .map(|i| (i + 1, U.X[i]))
+                .collect::<Vec<(usize, G::Scalar)>>(),
+            );
+            SparsePolynomial::new(vk.num_vars.log_2(), poly_X).evaluate(&rand_sc_unpad[1..])
+          };
+
+          self.eval_W + factor * rand_sc_unpad[0] * eval_X
         };
-
-        (factor, r_prod_unpad)
+        let eval_t = eval_addr_col + gamma * eval_val_col;
+        eval_t + r
       };
 
-      let eval_X = {
-        // constant term
-        let mut poly_X = vec![(0, U.u)];
-        //remaining inputs
-        poly_X.extend(
-          (0..U.X.len())
-            .map(|i| (i + 1, U.X[i]))
-            .collect::<Vec<(usize, G::Scalar)>>(),
-        );
-        SparsePolynomial::new(usize::try_from(vk.num_vars.ilog2()).unwrap(), poly_X)
-          .evaluate(&r_prod_unpad[1..])
+      let eval_w_plus_r_col = {
+        let eval_addr_col = self.eval_col;
+        let eval_val_col = self.eval_L_col;
+        let eval_w = eval_addr_col + gamma * eval_val_col;
+        eval_w + r
       };
-      let eval_Z =
-        factor * ((G::Scalar::ONE - r_prod_unpad[0]) * self.eval_W + r_prod_unpad[0] * eval_X);
 
-      (eval_Z, r_prod_unpad)
+      let claim_mem_final_expected: G::Scalar = coeffs[0]
+        * (self.eval_t_plus_r_inv_row - self.eval_w_plus_r_inv_row)
+        + coeffs[1] * (self.eval_t_plus_r_inv_col - self.eval_w_plus_r_inv_col)
+        + coeffs[2]
+          * (rand_eq_bound_rand_sc
+            * (self.eval_t_plus_r_inv_row * eval_t_plus_r_row - self.eval_ts_row))
+        + coeffs[3]
+          * (rand_eq_bound_rand_sc
+            * (self.eval_w_plus_r_inv_row * eval_w_plus_r_row - G::Scalar::ONE))
+        + coeffs[4]
+          * (rand_eq_bound_rand_sc
+            * (self.eval_t_plus_r_inv_col * eval_t_plus_r_col - self.eval_ts_col))
+        + coeffs[5]
+          * (rand_eq_bound_rand_sc
+            * (self.eval_w_plus_r_inv_col * eval_w_plus_r_col - G::Scalar::ONE));
+
+      let claim_outer_final_expected = coeffs[6]
+        * taus_bound_rand_sc
+        * (self.eval_Az * self.eval_Bz - U.u * self.eval_Cz - self.eval_E);
+      let claim_inner_final_expected = coeffs[7]
+        * self.eval_L_row
+        * self.eval_L_col
+        * (self.eval_val_A + c * self.eval_val_B + c * c * self.eval_val_C);
+
+      claim_mem_final_expected + claim_outer_final_expected + claim_inner_final_expected
     };
 
-    u_vec.push(PolyEvalInstance {
-      c: U.comm_W,
-      x: r_prod_unpad[1..].to_vec(),
-      e: self.eval_W,
-    });
-
-    // finish the final step of the sum-check
-    let (claim_init_expected_row, claim_audit_expected_row) = {
-      let addr = IdentityPolynomial::new(r_prod.len()).evaluate(&r_prod);
-      let val = EqPolynomial::new(tau_coords.to_vec()).evaluate(&r_prod);
-      (
-        hash_func(&addr, &val, &G::Scalar::ZERO),
-        hash_func(&addr, &val, &self.eval_row_audit_ts),
-      )
-    };
-
-    let (claim_read_expected_row, claim_write_expected_row) = {
-      (
-        hash_func(
-          &self.eval_row,
-          &self.eval_E_row_at_r_prod,
-          &self.eval_row_read_ts,
-        ),
-        hash_func(
-          &self.eval_row,
-          &self.eval_E_row_at_r_prod,
-          &(self.eval_row_read_ts + G::Scalar::ONE),
-        ),
-      )
-    };
-
-    // multiset check for the row
-    if claim_init_expected_row != self.eval_input_arr[0]
-      || claim_read_expected_row != self.eval_input_arr[1]
-      || claim_write_expected_row != self.eval_input_arr[2]
-      || claim_audit_expected_row != self.eval_input_arr[3]
-    {
+    if claim_sc_final_expected != claim_sc_final {
       return Err(NovaError::InvalidSumcheckProof);
     }
 
-    let (claim_init_expected_col, claim_audit_expected_col) = {
-      let addr = IdentityPolynomial::new(r_prod.len()).evaluate(&r_prod);
-      let val = eval_Z;
-      (
-        hash_func(&addr, &val, &G::Scalar::ZERO),
-        hash_func(&addr, &val, &self.eval_col_audit_ts),
-      )
-    };
-
-    let (claim_read_expected_col, claim_write_expected_col) = {
-      (
-        hash_func(
-          &self.eval_col,
-          &self.eval_E_col_at_r_prod,
-          &self.eval_col_read_ts,
-        ),
-        hash_func(
-          &self.eval_col,
-          &self.eval_E_col_at_r_prod,
-          &(self.eval_col_read_ts + G::Scalar::ONE),
-        ),
-      )
-    };
-
-    // multiset check for the col
-    if claim_init_expected_col != self.eval_input_arr[4]
-      || claim_read_expected_col != self.eval_input_arr[5]
-      || claim_write_expected_col != self.eval_input_arr[6]
-      || claim_audit_expected_col != self.eval_input_arr[7]
-    {
-      return Err(NovaError::InvalidSumcheckProof);
-    }
-
-    // since all the nine polynomials are opened at r_sat,
-    // we can combine them into a single polynomial opened at r_sat
-    let eval_vec = [
+    let eval_vec = vec![
+      self.eval_W,
       self.eval_Az,
       self.eval_Bz,
       self.eval_Cz,
       self.eval_E,
-      self.eval_E_row,
-      self.eval_E_col,
+      self.eval_L_row,
+      self.eval_L_col,
       self.eval_val_A,
       self.eval_val_B,
       self.eval_val_C,
-    ];
+      self.eval_t_plus_r_inv_row,
+      self.eval_row,
+      self.eval_w_plus_r_inv_row,
+      self.eval_ts_row,
+      self.eval_t_plus_r_inv_col,
+      self.eval_col,
+      self.eval_w_plus_r_inv_col,
+      self.eval_ts_col,
+    ]
+    .into_iter()
+    .collect::<Vec<G::Scalar>>();
     let comm_vec = [
+      U.comm_W,
       comm_Az,
       comm_Bz,
       comm_Cz,
       U.comm_E,
-      comm_E_row,
-      comm_E_col,
+      comm_L_row,
+      comm_L_col,
       vk.S_comm.comm_val_A,
       vk.S_comm.comm_val_B,
       vk.S_comm.comm_val_C,
+      comm_t_plus_r_inv_row,
+      vk.S_comm.comm_row,
+      comm_w_plus_r_inv_row,
+      vk.S_comm.comm_ts_row,
+      comm_t_plus_r_inv_col,
+      vk.S_comm.comm_col,
+      comm_w_plus_r_inv_col,
+      vk.S_comm.comm_ts_col,
     ];
-    transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
+    transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
-    let u = PolyEvalInstance::batch(&comm_vec, &r_sat, &eval_vec, &c);
-    u_vec.push(u);
-
-    let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
-
-    // generate a challenge
-    let rho = transcript.squeeze(b"r")?;
-    let num_claims = u_vec.len();
-    let powers_of_rho = powers::<G>(&rho, num_claims);
-    let claim_batch_joint = u_vec_padded
-      .iter()
-      .zip(powers_of_rho.iter())
-      .map(|(u, p)| u.e * p)
-      .sum();
-
-    let num_rounds_z = u_vec_padded[0].x.len();
-    let (claim_batch_final, r_z) =
-      self
-        .sc_proof_batch
-        .verify(claim_batch_joint, num_rounds_z, 2, &mut transcript)?;
-
-    let claim_batch_final_expected = {
-      let poly_rz = EqPolynomial::new(r_z.clone());
-      let evals = u_vec_padded
-        .iter()
-        .map(|u| poly_rz.evaluate(&u.x))
-        .collect::<Vec<G::Scalar>>();
-
-      evals
-        .iter()
-        .zip(self.evals_batch_arr.iter())
-        .zip(powers_of_rho.iter())
-        .map(|((e_i, p_i), rho_i)| *e_i * *p_i * rho_i)
-        .sum()
-    };
-
-    if claim_batch_final != claim_batch_final_expected {
-      return Err(NovaError::InvalidSumcheckProof);
-    }
-
-    transcript.absorb(b"l", &self.evals_batch_arr.as_slice());
-
-    // we now combine evaluation claims at the same point rz into one
-    let gamma = transcript.squeeze(b"g")?;
-    let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
-    let comm_joint = u_vec_padded
-      .iter()
-      .zip(powers_of_gamma.iter())
-      .map(|(u, g_i)| u.c * *g_i)
-      .fold(Commitment::<G>::default(), |acc, item| acc + item);
-    let eval_joint = self
-      .evals_batch_arr
-      .iter()
-      .zip(powers_of_gamma.iter())
-      .map(|(e, g_i)| *e * *g_i)
-      .sum();
+    let u: PolyEvalInstance<G> = PolyEvalInstance::batch(&comm_vec, &rand_sc, &eval_vec, &c);
 
     // verify
     EE::verify(
       &vk.vk_ee,
       &mut transcript,
-      &comm_joint,
-      &r_z,
-      &eval_joint,
+      &u.c,
+      &rand_sc,
+      &u.e,
       &self.eval_arg,
     )?;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -20,7 +20,7 @@ use crate::{
   traits::{
     commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
     evaluation::EvaluationEngineTrait,
-    snark::RelaxedR1CSSNARKTrait,
+    snark::{DigestHelperTrait, RelaxedR1CSSNARKTrait},
     Group, TranscriptEngineTrait, TranscriptReprTrait,
   },
   Commitment, CommitmentKey, CompressedCommitment,
@@ -876,9 +876,10 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
       digest: Default::default(),
     }
   }
-
+}
+impl<G: Group, EE: EvaluationEngineTrait<G>> DigestHelperTrait<G> for VerifierKey<G, EE> {
   /// Returns the digest of the verifier's key
-  pub fn digest(&self) -> G::Scalar {
+  fn digest(&self) -> G::Scalar {
     self
       .digest
       .get_or_try_init(|| {

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -301,7 +301,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
 }
 
 /// Defines a trait for implementing sum-check in a generic manner
-pub trait SumcheckEngine<G: Group> {
+pub trait SumcheckEngine<G: Group>: Send + Sync {
   /// returns the initial claims
   fn initial_claims(&self) -> Vec<G::Scalar>;
 
@@ -416,20 +416,36 @@ impl<G: Group> ProductSumcheckInstance<G> {
       .map(|_i| transcript.squeeze(b"e"))
       .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
 
-    let poly_A = MultilinearPolynomial::new(EqPolynomial::new(rand_eq).evals());
-    let poly_B_vec = left_vec
-      .into_par_iter()
-      .map(MultilinearPolynomial::new)
-      .collect::<Vec<_>>();
-    let poly_C_vec = right_vec
-      .into_par_iter()
-      .map(MultilinearPolynomial::new)
-      .collect::<Vec<_>>();
-    let poly_D_vec = output_vec
-      .clone()
-      .into_par_iter()
-      .map(MultilinearPolynomial::new)
-      .collect::<Vec<_>>();
+    let ((poly_A, poly_B_vec), (poly_C_vec, poly_D_vec)) = rayon::join(
+      || {
+        rayon::join(
+          || MultilinearPolynomial::new(EqPolynomial::new(rand_eq).evals()),
+          || {
+            left_vec
+              .into_par_iter()
+              .map(MultilinearPolynomial::new)
+              .collect::<Vec<_>>()
+          },
+        )
+      },
+      || {
+        rayon::join(
+          || {
+            right_vec
+              .into_par_iter()
+              .map(MultilinearPolynomial::new)
+              .collect::<Vec<_>>()
+          },
+          || {
+            output_vec
+              .clone()
+              .into_par_iter()
+              .map(MultilinearPolynomial::new)
+              .collect::<Vec<_>>()
+          },
+        )
+      },
+    );
 
     Ok(Self {
       claims,
@@ -492,17 +508,27 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
   }
 
   fn bound(&mut self, r: &G::Scalar) {
-    self.poly_A.bound_poly_var_top(r);
-    for ((poly_B, poly_C), poly_D) in self
-      .poly_B_vec
-      .iter_mut()
-      .zip(self.poly_C_vec.iter_mut())
-      .zip(self.poly_D_vec.iter_mut())
-    {
-      poly_B.bound_poly_var_top(r);
-      poly_C.bound_poly_var_top(r);
-      poly_D.bound_poly_var_top(r);
-    }
+    let _ = rayon::join(
+      || self.poly_A.bound_poly_var_top(r),
+      || {
+        for ((poly_B, poly_C), poly_D) in self
+          .poly_B_vec
+          .iter_mut()
+          .zip(self.poly_C_vec.iter_mut())
+          .zip(self.poly_D_vec.iter_mut())
+        {
+          let _ = rayon::join(
+            || poly_B.bound_poly_var_top(r),
+            || {
+              rayon::join(
+                || poly_C.bound_poly_var_top(r),
+                || poly_D.bound_poly_var_top(r),
+              )
+            },
+          );
+        }
+      },
+    );
   }
   fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
     let poly_A_final = vec![self.poly_A[0]];
@@ -839,9 +865,10 @@ where
       let r_i = transcript.squeeze(b"c")?;
       r.push(r_i);
 
-      mem.bound(&r_i);
-      outer.bound(&r_i);
-      inner.bound(&r_i);
+      let _ = rayon::join(
+        || mem.bound(&r_i),
+        || rayon::join(|| outer.bound(&r_i), || inner.bound(&r_i)),
+      );
 
       e = poly.evaluate(&r_i);
       cubic_polys.push(poly.compress());
@@ -1074,55 +1101,99 @@ where
       (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2
     };
 
-    let init_row = (0..mem_row.len())
-      .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_row[i], &G::Scalar::ZERO))
-      .collect::<Vec<G::Scalar>>();
-    let read_row = (0..E_row.len())
-      .map(|i| hash_func(&pk.S_repr.row[i], &E_row[i], &pk.S_repr.row_read_ts[i]))
-      .collect::<Vec<G::Scalar>>();
-    let write_row = (0..E_row.len())
-      .map(|i| {
-        hash_func(
-          &pk.S_repr.row[i],
-          &E_row[i],
-          &(pk.S_repr.row_read_ts[i] + G::Scalar::ONE),
+    let (
+      ((init_row, read_row), (write_row, audit_row)),
+      ((init_col, read_col), (write_col, audit_col)),
+    ) = rayon::join(
+      || {
+        rayon::join(
+          || {
+            rayon::join(
+              || {
+                (0..mem_row.len())
+                  .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_row[i], &G::Scalar::ZERO))
+                  .collect::<Vec<G::Scalar>>()
+              },
+              || {
+                (0..E_row.len())
+                  .map(|i| hash_func(&pk.S_repr.row[i], &E_row[i], &pk.S_repr.row_read_ts[i]))
+                  .collect::<Vec<G::Scalar>>()
+              },
+            )
+          },
+          || {
+            rayon::join(
+              || {
+                (0..E_row.len())
+                  .map(|i| {
+                    hash_func(
+                      &pk.S_repr.row[i],
+                      &E_row[i],
+                      &(pk.S_repr.row_read_ts[i] + G::Scalar::ONE),
+                    )
+                  })
+                  .collect::<Vec<G::Scalar>>()
+              },
+              || {
+                (0..mem_row.len())
+                  .map(|i| {
+                    hash_func(
+                      &G::Scalar::from(i as u64),
+                      &mem_row[i],
+                      &pk.S_repr.row_audit_ts[i],
+                    )
+                  })
+                  .collect::<Vec<G::Scalar>>()
+              },
+            )
+          },
         )
-      })
-      .collect::<Vec<G::Scalar>>();
-    let audit_row = (0..mem_row.len())
-      .map(|i| {
-        hash_func(
-          &G::Scalar::from(i as u64),
-          &mem_row[i],
-          &pk.S_repr.row_audit_ts[i],
+      },
+      || {
+        rayon::join(
+          || {
+            rayon::join(
+              || {
+                (0..mem_col.len())
+                  .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_col[i], &G::Scalar::ZERO))
+                  .collect::<Vec<G::Scalar>>()
+              },
+              || {
+                (0..E_col.len())
+                  .map(|i| hash_func(&pk.S_repr.col[i], &E_col[i], &pk.S_repr.col_read_ts[i]))
+                  .collect::<Vec<G::Scalar>>()
+              },
+            )
+          },
+          || {
+            rayon::join(
+              || {
+                (0..E_col.len())
+                  .map(|i| {
+                    hash_func(
+                      &pk.S_repr.col[i],
+                      &E_col[i],
+                      &(pk.S_repr.col_read_ts[i] + G::Scalar::ONE),
+                    )
+                  })
+                  .collect::<Vec<G::Scalar>>()
+              },
+              || {
+                (0..mem_col.len())
+                  .map(|i| {
+                    hash_func(
+                      &G::Scalar::from(i as u64),
+                      &mem_col[i],
+                      &pk.S_repr.col_audit_ts[i],
+                    )
+                  })
+                  .collect::<Vec<G::Scalar>>()
+              },
+            )
+          },
         )
-      })
-      .collect::<Vec<G::Scalar>>();
-
-    let init_col = (0..mem_col.len())
-      .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_col[i], &G::Scalar::ZERO))
-      .collect::<Vec<G::Scalar>>();
-    let read_col = (0..E_col.len())
-      .map(|i| hash_func(&pk.S_repr.col[i], &E_col[i], &pk.S_repr.col_read_ts[i]))
-      .collect::<Vec<G::Scalar>>();
-    let write_col = (0..E_col.len())
-      .map(|i| {
-        hash_func(
-          &pk.S_repr.col[i],
-          &E_col[i],
-          &(pk.S_repr.col_read_ts[i] + G::Scalar::ONE),
-        )
-      })
-      .collect::<Vec<G::Scalar>>();
-    let audit_col = (0..mem_col.len())
-      .map(|i| {
-        hash_func(
-          &G::Scalar::from(i as u64),
-          &mem_col[i],
-          &pk.S_repr.col_audit_ts[i],
-        )
-      })
-      .collect::<Vec<G::Scalar>>();
+      },
+    );
 
     let mut mem_sc_inst = ProductSumcheckInstance::new(
       ck,

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -15,7 +15,9 @@ use crate::{
     PolyEvalInstance, PolyEvalWitness,
   },
   traits::{
-    evaluation::EvaluationEngineTrait, snark::RelaxedR1CSSNARKTrait, Group, TranscriptEngineTrait,
+    evaluation::EvaluationEngineTrait,
+    snark::{DigestHelperTrait, RelaxedR1CSSNARKTrait},
+    Group, TranscriptEngineTrait,
   },
   Commitment, CommitmentKey,
 };
@@ -60,9 +62,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
       digest: OnceCell::new(),
     }
   }
+}
 
+impl<G: Group, EE: EvaluationEngineTrait<G>> DigestHelperTrait<G> for VerifierKey<G, EE> {
   /// Returns the digest of the verifier's key.
-  pub fn digest(&self) -> G::Scalar {
+  fn digest(&self) -> G::Scalar {
     self
       .digest
       .get_or_try_init(|| {

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -473,7 +473,7 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
       )?;
 
     // Compute variable indicating if this is the base case
-    let zero = alloc_zero(cs.namespace(|| "zero"))?;
+    let zero = alloc_zero(cs.namespace(|| "zero"));
     let is_base_case = alloc_num_equals(cs.namespace(|| "Check if base case"), &i.clone(), &zero)?;
 
     // Synthesize the circuit for the non-base case and get the new running

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -30,7 +30,7 @@ fn constrain_augmented_circuit_index<F: PrimeField, CS: ConstraintSystem<F>>(
   circuit_index: &AllocatedNum<F>,
 ) -> Result<(), SynthesisError> {
   // select target when index match or empty
-  let zero = alloc_zero(cs.namespace(|| "zero"))?;
+  let zero = alloc_zero(cs.namespace(|| "zero"));
   let rom_values = rom
     .iter()
     .enumerate()
@@ -111,7 +111,7 @@ fn next_rom_index_and_pc<F: PrimeField, CS: ConstraintSystem<F>>(
   rom_index: &AllocatedNum<F>,
   allocated_rom: &[AllocatedNum<F>],
 ) -> Result<(AllocatedNum<F>, AllocatedNum<F>), SynthesisError> {
-  let one = alloc_one(cs.namespace(|| "alloc one"))?;
+  let one = alloc_one(cs.namespace(|| "alloc one"));
 
   let rom_index_next = add_allocated_num(
     // rom_index = rom_index + 1

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -26,7 +26,12 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   type ProverKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
 
   /// A type that represents the verifier's key
-  type VerifierKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
+  type VerifierKey: Send
+    + Sync
+    + Serialize
+    + for<'de> Deserialize<'de>
+    + DigestHelperTrait<G>
+    + Abomonation;
 
   /// This associated function (not a method) provides a hint that offers
   /// a minimum sizing cue for the commitment key used by this SNARK
@@ -54,4 +59,10 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
 
   /// Verifies a SNARK for a relaxed R1CS
   fn verify(&self, vk: &Self::VerifierKey, U: &RelaxedR1CSInstance<G>) -> Result<(), NovaError>;
+}
+
+/// A helper trait that defines the behavior of a verifier key of `zkSNARK`
+pub trait DigestHelperTrait<G: Group> {
+  /// Returns the digest of the verifier's key
+  fn digest(&self) -> G::Scalar;
 }


### PR DESCRIPTION
Closes #88. Ports the following from upstream:
- https://github.com/microsoft/Nova/pull/240 
- https://github.com/microsoft/Nova/pull/243
- https://github.com/microsoft/Nova/pull/245
- https://github.com/microsoft/Nova/pull/246
- https://github.com/microsoft/Nova/pull/247
- https://github.com/microsoft/Nova/pull/248
- https://github.com/microsoft/Nova/pull/250

<details>
<summary> CPU Bench results for https://github.com/microsoft/Nova/pull/240 </summary>

```
group                                                        main                                   nova_240
-----                                                        ----                                   --------
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.00       7.5±0.05s            1.00       7.5±0.11s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.00   184.9±11.69ms            1.02   189.2±18.72ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.00      20.2±0.63s            1.01      20.5±0.46s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.01   531.7±28.37ms            1.00   527.1±17.99ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.01      11.5±0.20s            1.00      11.4±0.22s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.00   296.1±17.31ms            1.00   296.3±14.38ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.00      36.4±0.80s            1.02      37.1±1.02s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.00   838.0±56.73ms            1.00   834.6±40.63ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.01      20.3±0.40s            1.00      20.1±0.46s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.03   549.6±33.61ms            1.00   531.7±12.12ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.00      11.4±0.17s            1.01      11.5±0.20s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.00   295.8±17.55ms            1.02   302.2±16.53ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.00    764.4±9.82ms            1.01    770.7±9.79ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.00     31.6±0.91ms            1.01     31.8±1.19ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.00      24.8±0.53s            1.00      24.9±0.71s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.04   843.0±41.25ms            1.00   814.3±28.53ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.00       3.4±0.12s            1.01       3.4±0.16s
CompressedSNARK-StepCircuitSize-121253/Verify                1.00    126.2±5.13ms            1.01    128.1±5.52ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00  1110.8±11.90ms            1.01   1116.4±9.77ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.03     49.7±2.86ms            1.00     48.4±1.58ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.00       6.2±0.21s            1.01       6.3±0.17s
CompressedSNARK-StepCircuitSize-252325/Verify                1.03   240.6±12.66ms            1.00   232.5±16.13ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.02      12.6±0.38s            1.00      12.3±0.27s
CompressedSNARK-StepCircuitSize-514469/Verify                1.00   494.9±27.29ms            1.00   493.2±13.84ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.00  1881.6±32.24ms            1.01  1898.6±70.31ms
CompressedSNARK-StepCircuitSize-55717/Verify                 1.02     71.5±4.31ms            1.00     70.0±1.59ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00   758.7±13.16ms            1.01   765.1±10.16ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.00     31.0±1.14ms            1.02     31.5±1.11ms
RecursiveSNARK-StepCircuitSize-0/Prove                       1.00   100.7±10.63ms            1.10   110.6±16.63ms
RecursiveSNARK-StepCircuitSize-0/Verify                      1.00     28.1±0.36ms            1.00     28.1±0.31ms
RecursiveSNARK-StepCircuitSize-1038757/Prove                 1.00  1806.1±57.34ms            1.00  1798.4±55.54ms
RecursiveSNARK-StepCircuitSize-1038757/Verify                1.00  1696.0±29.38ms            1.00  1689.9±39.09ms
RecursiveSNARK-StepCircuitSize-121253/Prove                  1.05    232.3±9.40ms            1.00   220.6±14.98ms
RecursiveSNARK-StepCircuitSize-121253/Verify                 1.00   168.2±11.08ms            1.00   167.5±11.10ms
RecursiveSNARK-StepCircuitSize-22949/Prove                   1.02   117.7±16.34ms            1.00    115.3±9.65ms
RecursiveSNARK-StepCircuitSize-22949/Verify                  1.01     56.7±1.10ms            1.00     55.9±1.01ms
RecursiveSNARK-StepCircuitSize-252325/Prove                  1.00   430.1±28.49ms            1.02   437.3±21.50ms
RecursiveSNARK-StepCircuitSize-252325/Verify                 1.00   343.7±20.26ms            1.00   343.3±17.58ms
RecursiveSNARK-StepCircuitSize-514469/Prove                  1.00   804.0±35.80ms            1.02   823.8±36.80ms
RecursiveSNARK-StepCircuitSize-514469/Verify                 1.00   755.1±31.61ms            1.04   788.8±34.80ms
RecursiveSNARK-StepCircuitSize-55717/Prove                   1.00    154.7±9.85ms            1.00   154.3±11.41ms
RecursiveSNARK-StepCircuitSize-55717/Verify                  1.03    98.7±10.98ms            1.00     96.1±3.34ms
RecursiveSNARK-StepCircuitSize-6565/Prove                    1.11   102.9±14.25ms            1.00    92.7±16.52ms
RecursiveSNARK-StepCircuitSize-6565/Verify                   1.01     36.7±0.37ms            1.00     36.3±0.40ms
```
</details>

<details>
<summary>CPU benchmarks for the whole PR (interesting results in the `CompressedSNARK-Commitments` section)</summary>

```
group                                                        dev                                    forward_port
-----                                                        ---                                    ------------
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.19       7.5±0.12s            1.00       6.3±0.04s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.04   186.3±16.13ms            1.00    179.1±6.35ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.19      20.4±0.55s            1.00      17.1±0.27s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.04   538.0±23.81ms            1.00   519.5±18.50ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.18      11.5±0.17s            1.00       9.7±0.18s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.09   319.4±21.64ms            1.00   292.1±13.27ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.16      36.2±0.40s            1.00      31.2±1.19s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.02   843.5±29.54ms            1.00   824.2±54.74ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.24      20.3±0.35s            1.00      16.4±0.22s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.00   530.5±21.56ms            1.00   531.6±24.18ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.23      11.5±0.29s            1.00       9.4±0.18s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.01   295.2±13.36ms            1.00    292.9±7.29ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.00   765.1±12.87ms            1.04   796.9±44.06ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.00     31.1±0.88ms            1.01     31.4±0.79ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.00      24.5±0.83s            1.01      24.7±0.61s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.01   833.2±36.51ms            1.00   828.1±29.51ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.01       3.4±0.11s            1.00       3.3±0.10s
CompressedSNARK-StepCircuitSize-121253/Verify                1.01    126.9±5.00ms            1.00    125.9±5.75ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00  1112.2±17.01ms            1.01  1119.6±15.04ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.02     49.8±2.63ms            1.00     48.8±1.16ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.00       6.2±0.18s            1.01       6.3±0.17s
CompressedSNARK-StepCircuitSize-252325/Verify                1.00   230.9±14.65ms            1.03   237.0±13.74ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.00      12.2±0.28s            1.00      12.2±0.32s
CompressedSNARK-StepCircuitSize-514469/Verify                1.02    497.9±9.47ms            1.00   489.0±14.57ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.01  1880.4±54.77ms            1.00  1867.5±49.81ms
CompressedSNARK-StepCircuitSize-55717/Verify                 1.01     73.2±3.11ms            1.00     72.2±3.55ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00   763.4±16.19ms            1.01   767.6±12.63ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.00     31.5±1.13ms            1.02     32.1±1.37ms
RecursiveSNARK-StepCircuitSize-0/Prove                       1.06   106.3±11.87ms            1.00   100.4±12.84ms
RecursiveSNARK-StepCircuitSize-0/Verify                      1.08     30.4±2.29ms            1.00     28.0±0.35ms
RecursiveSNARK-StepCircuitSize-1038757/Prove                 1.00  1784.6±33.04ms            1.02  1827.4±60.27ms
RecursiveSNARK-StepCircuitSize-1038757/Verify                1.01  1712.0±74.83ms            1.00  1696.2±30.28ms
RecursiveSNARK-StepCircuitSize-121253/Prove                  1.00   222.9±12.25ms            1.03   230.2±17.22ms
RecursiveSNARK-StepCircuitSize-121253/Verify                 1.00    167.2±9.20ms            1.01    168.2±6.36ms
RecursiveSNARK-StepCircuitSize-22949/Prove                   1.06   125.4±13.69ms            1.00   118.3±11.78ms
RecursiveSNARK-StepCircuitSize-22949/Verify                  1.00     56.1±1.34ms            1.00     56.2±1.00ms
RecursiveSNARK-StepCircuitSize-252325/Prove                  1.03   428.7±29.65ms            1.00   417.1±17.33ms
RecursiveSNARK-StepCircuitSize-252325/Verify                 1.01   344.9±15.04ms            1.00   341.1±18.49ms
RecursiveSNARK-StepCircuitSize-514469/Prove                  1.00   838.9±37.65ms            1.00   839.7±46.58ms
RecursiveSNARK-StepCircuitSize-514469/Verify                 1.04   786.0±38.82ms            1.00   754.2±32.68ms
RecursiveSNARK-StepCircuitSize-55717/Prove                   1.06   159.0±15.97ms            1.00    150.4±9.97ms
RecursiveSNARK-StepCircuitSize-55717/Verify                  1.00     94.6±3.47ms            1.01     95.7±4.87ms
RecursiveSNARK-StepCircuitSize-6565/Prove                    1.00    93.7±16.76ms            1.07     99.8±8.03ms
RecursiveSNARK-StepCircuitSize-6565/Verify                   1.01     36.7±0.87ms            1.00     36.3±0.37ms
```
</details>
