### PR TITLE
Ensure exactly one selection in get_from_vec_alloc_relaxed_r1cs.

### DIFF
--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -484,3 +484,30 @@ pub fn select_num_or_one<F: PrimeField, CS: ConstraintSystem<F>>(
 
   Ok(c)
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::r1cs::util::FWrap;
+  use bellpepper_core::test_cs::TestConstraintSystem;
+  use pasta_curves::pallas::Scalar as Fr;
+  use proptest::prelude::*;
+
+  proptest! {
+    #[test]
+    fn test_enforce_alloc_num_equal_const((a, b) in any::<(FWrap<Fr>, FWrap<Fr>)>()) {
+      prop_assume!(a != b);
+
+        let test_a_b = |a, b| {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+            let a_num = AllocatedNum::alloc_infallible(cs.namespace(|| "a_num"), || a);
+            let r = alloc_num_equals_const(&mut cs, &a_num, b);
+            assert_eq!(r.unwrap().get_value().unwrap(), a==b);
+        };
+        // negative testing
+        test_a_b(a.0, b.0);
+        // positive testing
+        test_a_b(a.0, a.0);
+    }
+  }
+}

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -167,15 +167,15 @@ pub fn alloc_num_equals<F: PrimeField, CS: ConstraintSystem<F>>(
 
   let r = AllocatedBit::alloc(cs.namespace(|| "r"), r_value)?;
 
-  // Allocate t s.t. t=1 if z1 == z2 else 1/(z1 - z2)
+  // Allocate t s.t. t=1 if a == b else 1/(a - b)
 
   let t = AllocatedNum::alloc(cs.namespace(|| "t"), || {
-    Ok(if *a.get_value().get()? == *b.get_value().get()? {
+    let a_val = *a.get_value().get()?;
+    let b_val = *b.get_value().get()?;
+    Ok(if a_val == b_val {
       F::ONE
     } else {
-      (*a.get_value().get()? - *b.get_value().get()?)
-        .invert()
-        .unwrap()
+      (a_val - b_val).invert().unwrap()
     })
   })?;
 
@@ -204,20 +204,18 @@ pub fn alloc_num_equals_const<F: PrimeField, CS: ConstraintSystem<F>>(
 ) -> Result<AllocatedBit, SynthesisError> {
   // Allocate and constrain `r`: result boolean bit.
   // It equals `true` if `a` equals `b`, `false` otherwise
-  let r_value = match (a.get_value(), b) {
-    (Some(a), b) => Some(a == b),
-    _ => None,
-  };
+  let r_value = a.get_value().map(|a_val| a_val == b);
 
   let r = AllocatedBit::alloc(cs.namespace(|| "r"), r_value)?;
 
-  // Allocate t s.t. t=1 if z1 == z2 else 1/(z1 - z2)
+  // Allocate t s.t. t=1 if a == b else 1/(a - b)
 
   let t = AllocatedNum::alloc(cs.namespace(|| "t"), || {
-    Ok(if *a.get_value().get()? == b {
+    let a_val = *a.get_value().get()?;
+    Ok(if a_val == b {
       F::ONE
     } else {
-      (*a.get_value().get()? - b).invert().unwrap()
+      (a_val - b).invert().unwrap()
     })
   })?;
 

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,7 +1,7 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 mod sparse;
 #[cfg(test)]
-mod util;
+pub(crate) mod util;
 
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS},

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -369,7 +369,7 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
     )?;
 
     // Run NIFS Verifier
-    let (last_augmented_circuit_index_checked, U_to_fold) = get_from_vec_alloc_relaxed_r1cs(
+    let (_last_augmented_circuit_selector, U_to_fold) = get_from_vec_alloc_relaxed_r1cs(
       cs.namespace(|| "U to fold"),
       U,
       last_augmented_circuit_index,
@@ -397,7 +397,7 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
         let equal_bit = Boolean::from(alloc_num_equals(
           cs.namespace(|| "check equal bit"),
           &i_alloc,
-          &last_augmented_circuit_index_checked,
+          &last_augmented_circuit_index,
         )?);
         conditionally_select_alloc_relaxed_r1cs(
           cs.namespace(|| "select on index namespace"),
@@ -408,7 +408,7 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
       })
       .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<G>>, _>>()?;
 
-    Ok((last_augmented_circuit_index_checked, U_next, check_pass))
+    Ok((last_augmented_circuit_index.clone(), U_next, check_pass))
   }
 }
 

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -393,7 +393,7 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
           cs.namespace(|| "select on index namespace"),
           &U_fold,
           U,
-          &equal_bit,
+          equal_bit,
         )
       })
       .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<G>>, _>>()?;

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -417,24 +417,6 @@ impl<'a, G: Group, SC: EnforcingStepCircuit<G::Base>> SuperNovaAugmentedCircuit<
     self,
     cs: &mut CS,
   ) -> Result<(Option<AllocatedNum<G::Base>>, Vec<AllocatedNum<G::Base>>), SynthesisError> {
-    // NOTE `last_augmented_circuit_index` is aux without any constraint.
-    // Reason is prover can only produce valid running instance by folding u into proper U_i[last_augmented_circuit_index]
-    // However, there is crucial pre-asumption: `last_augmented_circuit_index` must within range [0, num_augmented_circuits)
-    // otherwise there will be a soundness error, such that maliculous prover can choose out of range last_augmented_circuit_index.
-    // The soundness error depends on how we process out-of-range condition.
-    //
-    // there are 2 possible solution
-    // 1. range check `last_augmented_circuit_index`
-    // 2. if last_augmented_circuit_index out of range, then by default select index 0
-    //
-    // For current version we choose 2, due to its simplicify and fit well in last_augmented_circuit_index use case.
-    // Recap, the only way to pass running instance check is folding u into respective U_i[last_augmented_circuit_index]
-    // So, a circuit implementing to set out-of-range last_augmented_circuit_index to index 0 is fine.
-    // The illegal running instances will be propogate to later phase and finally captured with "high" probability on the basis of Nova IVC security.
-    //
-    // Although above "informal" analysis implies there is no `malleability` on statement (malleability refer `NARK.8 Malleability of Nova’s IVC` https://eprint.iacr.org/2023/969.pdf )
-    // We need to carefully check whether it lead to other vulnerability.
-
     let arity = self.step_circuit.arity();
     let num_augmented_circuits = if self.params.is_primary_circuit {
       // primary circuit only fold single running instance with secondary output strict r1cs instance

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -663,7 +663,7 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
-  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9840, 12039);
+  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9835, 12028);
 }
 
 fn test_pp_digest_with<G1, G2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
@@ -709,7 +709,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "e47062f431c354060f73529db4161288cb4cdc78efc62c129acac24bc1231f02",
+    "232c6c75db09f58a6a5a67311422a937239f67233902f3804ed3484ae9cd2b03",
   );
 
   let rom = vec![
@@ -724,7 +724,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "352c27c61cf6efe07cdfbc5c40252f31b16c20c5eb3cd1838e8deb861d4e2301",
+    "5f1f389cffbb535fc6e7114a25ab4d0eed5457e98eb95c8a4720e48b83fc8701",
   );
 
   let rom = vec![
@@ -739,7 +739,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "5e27800dacc03218659d09f361b9c50cbc9164b9af0a623e137ec6bf0a8e4a01",
+    "9ee20885d37d921673140bd9bfd6af06408b6d380a1e06f720990ea66d0f1e01",
   );
 }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -663,7 +663,7 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
-  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9836, 12035);
+  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9840, 12039);
 }
 
 fn test_pp_digest_with<G1, G2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
@@ -709,7 +709,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "989e3756cf76e0af1f0e76ced6fc356404d7beedcee5ad244dad25ed08809e00",
+    "e47062f431c354060f73529db4161288cb4cdc78efc62c129acac24bc1231f02",
   );
 
   let rom = vec![
@@ -724,7 +724,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "0b8c080ffa823b95d1dd75b6a5b49852c53ff60fbead6652af6d2a0bd177b800",
+    "352c27c61cf6efe07cdfbc5c40252f31b16c20c5eb3cd1838e8deb861d4e2301",
   );
 
   let rom = vec![
@@ -739,7 +739,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "3ae4759aa0338bcc6ac11b456c17803467a1f44364992e3f1a0c6344b0135703",
+    "5e27800dacc03218659d09f361b9c50cbc9164b9af0a623e137ec6bf0a8e4a01",
   );
 }
 

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -1,4 +1,7 @@
-use bellpepper_core::{boolean::Boolean, num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{
+  boolean::Boolean, num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError,
+};
+use ff::Field;
 
 use crate::{
   gadgets::{
@@ -8,59 +11,122 @@ use crate::{
   traits::Group,
 };
 
-// return the element matched index
-// WARNING: there is no check for index out of bound. By default will return first one
-// FIXME use api `try_result` https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.try_reduce to fine tune function logic once stable
-// TODO optimize this part to have raw linear-combination on variables to achieve less constraints
+/// Return the element of `a` at `target_index`.
+///
+/// If `target_index` is out of bounds, the circuit will be unsatisified.
+//
+// NOTE: When `a` is greater than 5 (estimated), it will be cheaper to use a multicase gadget.
+//
+// We should plan to rely on a well-designed gadget offering a common interface but that adapts its implementation based
+// on the size of inputs (known at synthesis time). The threshold size depends on the size of the elements of `a`. The
+// larger the elements, the fewer are needed before multicase becomes cost-effective.
 pub fn get_from_vec_alloc_relaxed_r1cs<G: Group, CS: ConstraintSystem<<G as Group>::Base>>(
   mut cs: CS,
   a: &[AllocatedRelaxedR1CSInstance<G>],
   target_index: &AllocatedNum<G::Base>,
 ) -> Result<(AllocatedNum<G::Base>, AllocatedRelaxedR1CSInstance<G>), SynthesisError> {
   let mut a = a.iter().enumerate();
+
+  let zero_index = alloc_const(cs.namespace(|| "i_const 0 allocated"), G::Base::from(0u64))?;
+  let first_selected = alloc_num_equals(
+    cs.namespace(|| "check 0 equal bit".to_string()),
+    &zero_index,
+    target_index,
+  )?;
+
   let first = (
-    alloc_const(cs.namespace(|| "i_const 0 allocated"), G::Base::from(0u64))?,
+    zero_index,
     a.next()
       .ok_or_else(|| SynthesisError::IncompatibleLengthVector("empty vec length".to_string()))?
       .1
       .clone(),
   );
-  let selected = a.try_fold(first, |matched, (i, candidate)| {
-    let i_const = alloc_const(
-      cs.namespace(|| format!("i_const {:?} allocated", i)),
-      G::Base::from(i as u64),
-    )?;
-    let equal_bit = Boolean::from(alloc_num_equals(
-      cs.namespace(|| format!("check {:?} equal bit", i_const.get_value().unwrap())),
-      &i_const,
-      target_index,
-    )?);
-    let next_matched_index = conditionally_select(
-      cs.namespace(|| {
-        format!(
-          "select on index namespace {:?}",
-          i_const.get_value().unwrap()
-        )
-      }),
-      &i_const,
-      &matched.0,
-      &equal_bit,
-    )?;
-    let next_matched_allocated = conditionally_select_alloc_relaxed_r1cs(
-      cs.namespace(|| {
-        format!(
-          "select on index namespace {:?}",
-          i_const.get_value().unwrap()
-        )
-      }),
-      candidate,
-      &matched.1,
-      &equal_bit,
-    )?;
-    Ok::<(AllocatedNum<G::Base>, AllocatedRelaxedR1CSInstance<G>), SynthesisError>((
-      next_matched_index,
-      next_matched_allocated,
-    ))
-  })?;
+
+  let initial_sum = Boolean::from(first_selected).lc(CS::one(), G::Base::ONE);
+
+  let (selected, selected_sum) = a.try_fold(
+    (first, initial_sum),
+    |(matched, mut selected_sum), (i, candidate)| {
+      let i_const = alloc_const(
+        cs.namespace(|| format!("i_const {:?} allocated", i)),
+        G::Base::from(i as u64),
+      )?;
+      let equal_bit = Boolean::from(alloc_num_equals(
+        cs.namespace(|| format!("check {:?} equal bit", i_const.get_value().unwrap())),
+        &i_const,
+        target_index,
+      )?);
+      selected_sum = selected_sum + &equal_bit.lc(CS::one(), G::Base::ONE);
+      let next_matched_index = conditionally_select(
+        cs.namespace(|| format!("next_matched_index-{:?}", i_const.get_value().unwrap())),
+        &i_const,
+        &matched.0,
+        &equal_bit,
+      )?;
+      let next_matched_allocated = conditionally_select_alloc_relaxed_r1cs(
+        cs.namespace(|| format!("next_matched_allocated-{:?}", i_const.get_value().unwrap())),
+        candidate,
+        &matched.1,
+        &equal_bit,
+      )?;
+
+      Ok::<
+        (
+          (AllocatedNum<G::Base>, AllocatedRelaxedR1CSInstance<G>),
+          LinearCombination<G::Base>,
+        ),
+        SynthesisError,
+      >(((next_matched_index, next_matched_allocated), selected_sum))
+    },
+  )?;
+
+  cs.enforce(
+    || "exactly-one-selection",
+    |_| selected_sum,
+    |lc| lc + CS::one(),
+    |lc| lc + CS::one(),
+  );
+
   Ok(selected)
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use bellpepper_core::test_cs::TestConstraintSystem;
+  use pasta_curves::pallas::{Base, Point};
+
+  #[test]
+  fn test_get_from_vec_alloc_relaxed_r1cs_bounds() {
+    let n = 3;
+    for selected in 0..(2 * n) {
+      let mut cs = TestConstraintSystem::<Base>::new();
+
+      let vec = (0..n)
+        .map(|i| {
+          AllocatedRelaxedR1CSInstance::<Point>::default(
+            &mut cs.namespace(|| format!("elt-{i}")),
+            4,
+            64,
+          )
+          .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+      let allocated_target =
+        alloc_const(&mut cs.namespace(|| "target"), Base::from(selected as u64)).unwrap();
+
+      let (checked_target, _selected_instance) =
+        get_from_vec_alloc_relaxed_r1cs(&mut cs.namespace(|| "test-fn"), &vec, &allocated_target)
+          .unwrap();
+
+      if selected < n {
+        assert_eq!(allocated_target.get_value(), checked_target.get_value());
+        assert!(cs.is_satisfied())
+      } else {
+        // If selected is out of range, the circuit must be unsatisfied.
+        assert!(!cs.is_satisfied())
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes #94. I think the alternate approach (checking consistency of the chosen and received target index) is probably a little better. I may take a shot at this along with investigating a refactoring to avoid duplication of the bit-checking, etc. in a separate PR. Meanwhile, this should fix the immediate issue straightforwardly.