### PR TITLE
feat: Enhance KZG commitment SRS generation efficiency 

### DIFF
--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -3,6 +3,7 @@
 
 use std::marker::PhantomData;
 
+use ff::PrimeFieldBits;
 use group::{prime::PrimeCurveAffine, Curve};
 use pairing::Engine;
 use rand::rngs::StdRng;
@@ -30,6 +31,7 @@ where
   E::G1: Group<PreprocessedGroupElement = E::G1Affine>,
   E::G1Affine: Serialize + for<'de> Deserialize<'de>,
   E::G2Affine: Serialize + for<'de> Deserialize<'de>,
+  E::Fr: PrimeFieldBits, // TODO due to use of gen_srs_for_testing, make optional
 {
   type CommitmentKey = UVUniversalKZGParam<E>;
   type Commitment = Commitment<E::G1>;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -16,6 +16,7 @@ pub mod secp_secq;
 pub mod kzg_commitment;
 pub mod non_hiding_kzg;
 pub mod non_hiding_zeromorph;
+mod util;
 
 use ff::PrimeField;
 use pasta_curves::{self, arithmetic::CurveAffine, group::Group as AnotherGroup};

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -11,7 +11,7 @@ use std::{borrow::Borrow, marker::PhantomData, ops::Mul};
 
 use crate::{
   errors::{NovaError, PCSError},
-  provider::util,
+  provider::util::fb_msm,
   traits::{commitment::Len, Group, TranscriptReprTrait},
 };
 
@@ -150,17 +150,17 @@ where
       })
       .collect::<Vec<E::Fr>>();
 
-    let window_size = util::get_mul_window_size(max_degree);
+    let window_size = fb_msm::get_mul_window_size(max_degree);
     let scalar_bits = E::Fr::NUM_BITS as usize;
 
     let (powers_of_g_projective, powers_of_h_projective) = rayon::join(
       || {
-        let g_table = util::get_window_table(scalar_bits, window_size, g);
-        util::multi_scalar_mul::<E::G1>(scalar_bits, window_size, &g_table, &nz_powers_of_beta)
+        let g_table = fb_msm::get_window_table(scalar_bits, window_size, g);
+        fb_msm::multi_scalar_mul::<E::G1>(scalar_bits, window_size, &g_table, &nz_powers_of_beta)
       },
       || {
-        let h_table = util::get_window_table(scalar_bits, window_size, h);
-        util::multi_scalar_mul::<E::G2>(scalar_bits, window_size, &h_table, &nz_powers_of_beta)
+        let h_table = fb_msm::get_window_table(scalar_bits, window_size, h);
+        fb_msm::multi_scalar_mul::<E::G2>(scalar_bits, window_size, &h_table, &nz_powers_of_beta)
       },
     );
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -9,7 +9,7 @@ use crate::{
   Commitment,
 };
 use abomonation_derive::Abomonation;
-use ff::{BatchInvert, Field, PrimeField};
+use ff::{BatchInvert, Field, PrimeField, PrimeFieldBits};
 use group::{Curve, Group as _};
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
 use rayon::prelude::{
@@ -412,6 +412,7 @@ where
   E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr, CE = KZGCommitmentEngine<E>>,
   E::G1Affine: Serialize + DeserializeOwned,
   E::G2Affine: Serialize + DeserializeOwned,
+  E::Fr: PrimeFieldBits, // TODO due to use of gen_srs_for_testing, make optional
 {
   type ProverKey = ZMProverKey<E>;
   type VerifierKey = ZMVerifierKey<E>;
@@ -461,7 +462,7 @@ where
 mod test {
   use std::iter;
 
-  use ff::FromUniformBytes;
+  use ff::{FromUniformBytes, PrimeFieldBits};
   use halo2curves::bn256::Bn256;
   use pairing::MultiMillerLoop;
   use rand::{thread_rng, Rng};
@@ -483,6 +484,7 @@ mod test {
   fn commit_open_verify_with<E: MultiMillerLoop>()
   where
     E::G1: Group<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+    E::Fr: PrimeFieldBits,
   {
     let max_vars = 16;
     let mut rng = thread_rng();

--- a/src/provider/util.rs
+++ b/src/provider/util.rs
@@ -1,0 +1,106 @@
+use ff::{PrimeField, PrimeFieldBits};
+use group::{
+  prime::{PrimeCurve, PrimeCurveAffine},
+  Curve,
+};
+
+use rayon::prelude::*;
+
+pub(crate) fn get_mul_window_size(num_scalars: usize) -> usize {
+  if num_scalars < 32 {
+    3
+  } else {
+    (num_scalars as f64).ln().ceil() as usize
+  }
+}
+
+pub(crate) fn get_window_table<T>(
+  scalar_size: usize,
+  window: usize,
+  g: T,
+) -> Vec<Vec<T::AffineRepr>>
+where
+  T: Curve,
+  T::AffineRepr: Send,
+{
+  let in_window = 1 << window;
+  let outerc = (scalar_size + window - 1) / window;
+  let last_in_window = 1 << (scalar_size - (outerc - 1) * window);
+
+  let mut multiples_of_g = vec![vec![T::identity(); in_window]; outerc];
+
+  let mut g_outer = g;
+  let mut g_outers = Vec::with_capacity(outerc);
+  for _ in 0..outerc {
+    g_outers.push(g_outer);
+    for _ in 0..window {
+      g_outer = g_outer.double();
+    }
+  }
+  multiples_of_g
+    .par_iter_mut()
+    .enumerate()
+    .take(outerc)
+    .zip(g_outers)
+    .for_each(|((outer, multiples_of_g), g_outer)| {
+      let cur_in_window = if outer == outerc - 1 {
+        last_in_window
+      } else {
+        in_window
+      };
+
+      let mut g_inner = T::identity();
+      for inner in multiples_of_g.iter_mut().take(cur_in_window) {
+        *inner = g_inner;
+        g_inner.add_assign(&g_outer);
+      }
+    });
+  multiples_of_g
+    .par_iter()
+    .map(|s| s.iter().map(|s| s.to_affine()).collect())
+    .collect()
+}
+
+pub(crate) fn windowed_mul<T>(
+  outerc: usize,
+  window: usize,
+  multiples_of_g: &[Vec<T::Affine>],
+  scalar: &T::Scalar,
+) -> T
+where
+  T: PrimeCurve,
+  T::Scalar: PrimeFieldBits,
+{
+  let modulus_size = <T::Scalar as PrimeField>::NUM_BITS as usize;
+  let scalar_val: Vec<bool> = scalar.to_le_bits().into_iter().collect();
+
+  let mut res = multiples_of_g[0][0].to_curve();
+  for outer in 0..outerc {
+    let mut inner = 0usize;
+    for i in 0..window {
+      if outer * window + i < modulus_size && scalar_val[outer * window + i] {
+        inner |= 1 << i;
+      }
+    }
+    res.add_assign(&multiples_of_g[outer][inner]);
+  }
+  res
+}
+
+pub(crate) fn multi_scalar_mul<T>(
+  scalar_size: usize,
+  window: usize,
+  table: &[Vec<T::AffineRepr>],
+  v: &[T::Scalar],
+) -> Vec<T>
+where
+  T: PrimeCurve,
+  T::Scalar: PrimeFieldBits,
+{
+  let outerc = (scalar_size + window - 1) / window;
+  assert!(outerc <= table.len());
+
+  v.par_iter()
+    .map(|e| windowed_mul::<T>(outerc, window, table, e))
+    .collect::<Vec<_>>()
+}

--- a/src/provider/util/fb_msm.rs
+++ b/src/provider/util/fb_msm.rs
@@ -1,3 +1,9 @@
+/// # Fixed-base Scalar Multiplication
+///
+/// This module provides an implementation of fixed-base scalar multiplication on elliptic curves.
+///
+/// The multiplication is optimized through a windowed method, where scalars are broken into fixed-size
+/// windows, pre-computation tables are generated, and results are efficiently combined.
 use ff::{PrimeField, PrimeFieldBits};
 use group::{
   prime::{PrimeCurve, PrimeCurveAffine},
@@ -6,6 +12,9 @@ use group::{
 
 use rayon::prelude::*;
 
+/// Determines the window size for scalar multiplication based on the number of scalars.
+///
+/// This is used to balance between pre-computation and number of point additions.
 pub(crate) fn get_mul_window_size(num_scalars: usize) -> usize {
   if num_scalars < 32 {
     3
@@ -14,6 +23,12 @@ pub(crate) fn get_mul_window_size(num_scalars: usize) -> usize {
   }
 }
 
+/// Generates a table of multiples of a base point `g` for use in windowed scalar multiplication.
+///
+/// This pre-computes multiples of a base point for each window and organizes them
+/// into a table for quick lookup during the scalar multiplication process. The table is a vector
+/// of vectors, each inner vector corresponding to a window and containing the multiples of `g`
+/// for that window.
 pub(crate) fn get_window_table<T>(
   scalar_size: usize,
   window: usize,
@@ -61,6 +76,11 @@ where
     .collect()
 }
 
+/// Performs the actual windowed scalar multiplication using a pre-computed table of points.
+///
+/// Given a scalar and a table of pre-computed multiples of a base point, this function
+/// efficiently computes the scalar multiplication by breaking the scalar into windows and
+/// adding the corresponding multiples from the table.
 pub(crate) fn windowed_mul<T>(
   outerc: usize,
   window: usize,
@@ -87,6 +107,7 @@ where
   res
 }
 
+/// Computes multiple scalar multiplications simultaneously using the windowed method.
 pub(crate) fn multi_scalar_mul<T>(
   scalar_size: usize,
   window: usize,

--- a/src/provider/util/fb_msm.rs
+++ b/src/provider/util/fb_msm.rs
@@ -40,7 +40,6 @@ where
   let outerc = (scalar_size + window - 1) / window;
 
   // Number of multiples of the window's "outer point" needed for each window (fewer for the last window)
-  let in_window = 1 << window;
   let last_in_window = 1 << (scalar_size - (outerc - 1) * window);
 
   let mut multiples_of_g = vec![vec![T::identity(); in_window]; outerc];

--- a/src/provider/util/fb_msm.rs
+++ b/src/provider/util/fb_msm.rs
@@ -57,7 +57,6 @@ where
   multiples_of_g
     .par_iter_mut()
     .enumerate()
-    .take(outerc)
     .zip(g_outers)
     .for_each(|((outer, multiples_of_g), g_outer)| {
       let cur_in_window = if outer == outerc - 1 {

--- a/src/provider/util/fb_msm.rs
+++ b/src/provider/util/fb_msm.rs
@@ -5,10 +5,7 @@
 /// The multiplication is optimized through a windowed method, where scalars are broken into fixed-size
 /// windows, pre-computation tables are generated, and results are efficiently combined.
 use ff::{PrimeField, PrimeFieldBits};
-use group::{
-  prime::{PrimeCurve, PrimeCurveAffine},
-  Curve,
-};
+use group::{prime::PrimeCurve, Curve};
 
 use rayon::prelude::*;
 
@@ -39,11 +36,17 @@ where
   T::AffineRepr: Send,
 {
   let in_window = 1 << window;
+  // Number of outer iterations needed to cover the entire scalar
   let outerc = (scalar_size + window - 1) / window;
+
+  // Number of multiples of the window's "outer point" needed for each window (fewer for the last window)
+  let in_window = 1 << window;
   let last_in_window = 1 << (scalar_size - (outerc - 1) * window);
 
   let mut multiples_of_g = vec![vec![T::identity(); in_window]; outerc];
 
+  // Compute the multiples of g for each window
+  // g_outers = [ 2^{k*window}*g for k in 0..outerc]
   let mut g_outer = g;
   let mut g_outers = Vec::with_capacity(outerc);
   for _ in 0..outerc {
@@ -64,6 +67,8 @@ where
         in_window
       };
 
+      // multiples_of_g = [id, g_outer, 2*g_outer, 3*g_outer, ...],
+      // where g_outer = 2^{outer*window}*g
       let mut g_inner = T::identity();
       for inner in multiples_of_g.iter_mut().take(cur_in_window) {
         *inner = g_inner;
@@ -94,7 +99,7 @@ where
   let modulus_size = <T::Scalar as PrimeField>::NUM_BITS as usize;
   let scalar_val: Vec<bool> = scalar.to_le_bits().into_iter().collect();
 
-  let mut res = multiples_of_g[0][0].to_curve();
+  let mut res = T::identity();
   for outer in 0..outerc {
     let mut inner = 0usize;
     for i in 0..window {

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -1,0 +1,2 @@
+/// Utilities for provider module
+pub(crate) mod fb_msm;

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -724,7 +724,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "f8de057dc64151079516d660f929b5f92e514a54d1c5ab70b1f1520c0043e902",
+    "079cc555d63b9ed702370c914e0451395999d939189a703d4b9cdac104439000",
   );
 
   let rom = vec![


### PR DESCRIPTION
- Introduced a new module `util` within the `provider` module, implementing fixed-base MSM,
- properly expressed the KZG SRS generation as an MSM,
- New trait constraint has been imposed for `E::Fr: PrimeFieldBits` within the `non_hiding_zeromorph.rs` file, and usages have been adjusted in the `test` module.
- Adding the `PrimeFieldBits` import from the `ff` crate and importing `provider::util` from the local crate.

<details>
<summary> Result of running the tests before / after </summary>

```
nova-snark bellpepper::tests::test_alloc_bit: Before = 0.052s, After = 0.068s
nova-snark circuit::tests::test_recursive_circuit_grumpkin: Before = 37.498s, After = 4.36s
nova-snark circuit::tests::test_recursive_circuit_pasta: Before = 1.579s, After = 2.124s
nova-snark circuit::tests::test_recursive_circuit_secp: Before = 3.191s, After = 4.23s
nova-snark digest::tests::test_digest_field_not_ingested_in_computation: Before = 0.01s, After = 0.006s
nova-snark digest::tests::test_digest_impervious_to_serialization: Before = 0.009s, After = 0.014s
nova-snark gadgets::ecc::tests::test_ecc_circuit_add_equal: Before = 0.403s, After = 0.249s
nova-snark gadgets::ecc::tests::test_ecc_circuit_add_negation: Before = 0.452s, After = 0.288s
nova-snark gadgets::ecc::tests::test_ecc_circuit_ops: Before = 12.917s, After = 2.385s
nova-snark gadgets::ecc::tests::test_ecc_ops: Before = 0.051s, After = 0.074s
nova-snark gadgets::nonnative::bignat::tests::test_big_nat_can_decompose: Before = 1.861s, After = 2.04s
nova-snark gadgets::nonnative::bignat::tests::test_polynomial_multiplier_circuit: Before = 0.036s, After = 0.016s
nova-snark nifs::tests::test_tiny_r1cs: Before = 1.987s, After = 3.068s
nova-snark nifs::tests::test_tiny_r1cs_bellpepper: Before = 1.32s, After = 1.896s
nova-snark provider::bn256_grumpkin::tests::test_from_label: Before = 0.787s, After = 1.043s
nova-snark provider::keccak::tests::test_keccak_example: Before = 0.01s, After = 0.014s
nova-snark provider::keccak::tests::test_keccak_transcript: Before = 0.019s, After = 0.015s
nova-snark provider::keccak::tests::test_keccak_transcript_incremental_vs_explicit: Before = 0.015s, After = 0.013s
nova-snark provider::non_hiding_kzg::tests::batch_check_test: Before = 2.166s, After = 3.293s
nova-snark provider::non_hiding_kzg::tests::end_to_end_test: Before = 4.392s, After = 8.542s
nova-snark provider::non_hiding_zeromorph::test::test_commit_open_verify: Before = 142.069s, After = 8.098s
nova-snark provider::non_hiding_zeromorph::test::test_quo: Before = 0.071s, After = 0.17s
nova-snark provider::pasta::tests::test_from_label: Before = 0.375s, After = 0.324s
nova-snark provider::poseidon::tests::test_poseidon_ro: Before = 2.769s, After = 3.581s
nova-snark provider::secp_secq::tests::test_from_label: Before = 1.012s, After = 1.706s
nova-snark r1cs::sparse::tests::test_matrix_creation: Before = 0.011s, After = 0.009s
nova-snark r1cs::sparse::tests::test_matrix_iter: Before = 0.011s, After = 0.022s
nova-snark r1cs::sparse::tests::test_matrix_vector_multiplication: Before = 0.021s, After = 0.009s
nova-snark r1cs::tests::test_pad_tiny_r1cs: Before = 0.101s, After = 0.07s
nova-snark spartan::direct::tests::test_direct_snark: Before = 3.344s, After = 4.063s
nova-snark spartan::polys::eq::tests::test_eq_polynomial: Before = 0.011s, After = 0.031s
nova-snark spartan::polys::multilinear::tests::test_evaluation: Before = 0.046s, After = 0.039s
nova-snark spartan::polys::multilinear::tests::test_mlp_add: Before = 0.009s, After = 0.01s
nova-snark spartan::polys::multilinear::tests::test_mlp_scalar_mul: Before = 0.013s, After = 0.007s
nova-snark spartan::polys::multilinear::tests::test_multilinear_polynomial: Before = 0.016s, After = 0.015s
nova-snark spartan::polys::multilinear::tests::test_partial_and_evaluate: Before = 2.572s, After = 2.349s
nova-snark spartan::polys::multilinear::tests::test_partial_evaluate_mle: Before = 0.052s, After = 0.099s
nova-snark spartan::polys::multilinear::tests::test_sparse_polynomial: Before = 0.018s, After = 0.021s
nova-snark spartan::polys::univariate::tests::test_from_evals_cubic: Before = 0.021s, After = 0.017s
nova-snark spartan::polys::univariate::tests::test_from_evals_quad: Before = 0.021s, After = 0.009s
nova-snark supernova::test::test_nivc_nondet: Before = 50.548s, After = 23.904s
nova-snark supernova::test::test_recursive_circuit: Before = 1.593s, After = 1.896s
nova-snark supernova::test::test_supernova_pp_digest: Before = 45.206s, After = 17.546s
nova-snark supernova::test::test_trivial_nivc: Before = 6.266s, After = 9.074s
nova-snark tests::test_ivc_base: Before = 46.715s, After = 17.773s
nova-snark tests::test_ivc_nondet_with_compression: Before = 56.633s, After = 34.32s
nova-snark tests::test_ivc_nontrivial: Before = 50.523s, After = 24.135s
nova-snark tests::test_ivc_nontrivial_with_compression: Before = 57.576s, After = 35.983s
nova-snark tests::test_ivc_nontrivial_with_spark_compression: Before = 189.162s, After = 85.136s
nova-snark tests::test_ivc_trivial: Before = 48.429s, After = 18.568s
nova-snark tests::test_pp_digest: Before = 276.442s, After = 63.296s
```
</details>

> [!NOTE]
> Lurk isn't expected to compile when rebased on the ZM branch