### PR TITLE
ci: refine triggers for Rust tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,6 @@ name: Build and Test Nova
 
 on:
   merge_group:
-  push:
-    branches: [ dev, zeromorph ]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [ dev, zeromorph ]
@@ -37,6 +35,7 @@ jobs:
         cargo nextest run --profile ci --workspace --cargo-profile dev-ci
 
   check-lurk-compiles:
+    if: github.event_name == 'pull_request'
     runs-on: buildjet-8vcpu-ubuntu-2204
     env:
       RUSTFLAGS: -D warnings


### PR DESCRIPTION
- Modified the Rust GitHub action workflow by removing the `push` event type.
- Introduced a conditional execution check to the `check-lurk-compiles` job, which now only triggers for `pull_request` events.
- Closes #103.