### PR TITLE
chore: switch to abomonation_derive_ng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
 subtle = "2.5"
 pasta_curves = { git = "https://github.com/lurk-lab/pasta_curves", branch="dev", features = ["repr-c", "serde"] }
-neptune = { git = "https://github.com/lurk-lab/neptune", branch="dev", default-features = false }
+neptune = { git = "https://github.com/lurk-lab/neptune", branch="dev", default-features = false, features = ["abomonation"] }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
@@ -35,7 +35,7 @@ thiserror = "1.0"
 halo2curves = { version = "0.4.0", features = ["derive_serde"] }
 group = "0.13.0"
 abomonation = "0.7.3"
-abomonation_derive = { git = "https://github.com/lurk-lab/abomonation_derive.git" }
+abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
 tap = "1.0.1"
 tracing = "0.1.37"
 tracing-texray = "0.2.0"


### PR DESCRIPTION
This is fully expected to break on CI, but the full setup was tested locally.

> [!WARNING]  
> Sequencing for this PR:
> ~~1. companion Lurk PR is open ([#869](https://github.com/lurk-lab/lurk-rs/pull/869))~~
> 2. this PR is reviewed ✅ despite CI status being ❎ 
> 3. https://github.com/lurk-lab/neptune/tree/dev is reset to https://github.com/lurk-lab/neptune/tree/dev_ng
> 4. this PR's CI is re-run and succeeds
> 5. this PR is merged

> [!NOTE]
> If you want to test this at home:
> 1. checkout https://github.com/lurk-lab/neptune/tree/dev_ng (note the specific branch) to $FOO/neptune
> 2. change the neptune dependency in *this* repo to `neptune = { path="$FOO/neptune", default-features = false, features = ["abomonation"] }`
> 3. run tests as usual