### PR TITLE
[WIP] Restructure the memory pipeline

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -78,7 +78,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
 
     // produce a recursive SNARK
     let num_steps = 3;
-    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> = RecursiveSNARK::new(
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,
@@ -88,7 +88,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
     .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary, &mut sink);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion
@@ -164,7 +164,7 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
 
     // produce a recursive SNARK
     let num_steps = 3;
-    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> = RecursiveSNARK::new(
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,
@@ -174,7 +174,7 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary, &mut sink);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -69,7 +69,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     // the first step is cheaper than other steps owing to the presence of
     // a lot of zeros in the satisfying assignment
     let num_warmup_steps = 10;
-    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> = RecursiveSNARK::new(
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,
@@ -79,7 +79,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     .unwrap();
 
     for i in 0..num_warmup_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary, &mut sink);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion
@@ -100,6 +100,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
             black_box(&pp),
             black_box(&c_primary),
             black_box(&c_secondary),
+            black_box(&mut sink)
           )
           .is_ok());
       })

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -169,7 +169,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     group.bench_function("Prove", |b| {
       b.iter(|| {
-        let mut recursive_snark = RecursiveSNARK::new(
+        let (mut recursive_snark, mut sink) = RecursiveSNARK::new(
           black_box(&pp),
           black_box(&circuit_primary),
           black_box(&circuit_secondary),
@@ -184,6 +184,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
             black_box(&pp),
             black_box(&circuit_primary),
             black_box(&circuit_secondary),
+            black_box(&mut sink),
           )
           .is_ok());
       })

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -221,19 +221,18 @@ fn main() {
     type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> =
-      RecursiveSNARK::<G1, G2, C1, C2>::new(
-        &pp,
-        &minroot_circuits[0],
-        &circuit_secondary,
-        &z0_primary,
-        &z0_secondary,
-      )
-      .unwrap();
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<G1, G2, C1, C2>::new(
+      &pp,
+      &minroot_circuits[0],
+      &circuit_secondary,
+      &z0_primary,
+      &z0_secondary,
+    )
+    .unwrap();
 
     for (i, circuit_primary) in minroot_circuits.iter().take(num_steps).enumerate() {
       let start = Instant::now();
-      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
+      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary, &mut sink);
       assert!(res.is_ok());
       println!(
         "RecursiveSNARK::prove_step {}: {:?}, took {:?} ",

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -52,6 +52,7 @@ mod tests {
     // Now get the assignment
     let mut cs = SatisfyingAssignment::<G>::new();
     synthesize_alloc_bit(&mut cs);
+
     let (inst, witness) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that this is satisfiable

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -44,11 +44,10 @@ impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
     ck: &CommitmentKey<G>,
   ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError> {
     let W = R1CSWitness::<G>::new(shape, self.aux_assignment().to_vec())?;
-    let X = &self.input_assignment()[1..];
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<G>::new(shape, comm_W, X.to_owned())?;
+    let instance = R1CSInstance::<G>::new(shape, comm_W, self.input_assignment().to_vec())?;
 
     Ok((instance, W))
   }

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -43,12 +43,12 @@ impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
     shape: &R1CSShape<G>,
     ck: &CommitmentKey<G>,
   ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError> {
-    let W = R1CSWitness::<G>::new(shape, self.aux_assignment())?;
+    let W = R1CSWitness::<G>::new(shape, self.aux_assignment().to_vec())?;
     let X = &self.input_assignment()[1..];
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<G>::new(shape, &comm_W, X)?;
+    let instance = R1CSInstance::<G>::new(shape, comm_W, X.to_owned())?;
 
     Ok((instance, W))
   }

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -120,13 +120,13 @@ where
   fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
     let allocated_aux = {
       let i = self.aux_assignment.len();
-      self.aux_assignment.reserve_exact(aux_n + i);
+      self.aux_assignment.resize(aux_n + i, Scalar::ZERO);
       &mut self.aux_assignment[i..]
     };
 
     let allocated_inputs = {
       let i = self.input_assignment.len();
-      self.input_assignment.reserve_exact(inputs_n + i);
+      self.input_assignment.resize(inputs_n + i, Scalar::ZERO);
       &mut self.input_assignment[i..]
     };
 
@@ -147,9 +147,9 @@ impl<'a, Scalar: PrimeField> WitnessViewCS<'a, Scalar> {
     input_assignment: &'a mut Vec<Scalar>,
     aux_assignment: &'a mut Vec<Scalar>,
   ) -> Self {
-    assert!(input_assignment.is_empty());
-    assert!(aux_assignment.is_empty());
+    input_assignment.clear();
     input_assignment.push(Scalar::ONE);
+    aux_assignment.clear();
 
     Self {
       input_assignment,

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,8 +1,145 @@
 //! Support for generating R1CS witness using bellpepper.
-
 use crate::traits::Group;
+use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use ff::PrimeField;
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 pub type SatisfyingAssignment<G> = WitnessCS<<G as Group>::Scalar>;
+
+#[derive(Debug, PartialEq, Eq)]
+/// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
+pub struct WitnessViewCS<'a, Scalar>
+where
+  Scalar: PrimeField,
+{
+  // Assignments of variables
+  pub(crate) input_assignment: &'a mut Vec<Scalar>,
+  pub(crate) aux_assignment: &'a mut Vec<Scalar>,
+}
+
+impl<'a, Scalar> ConstraintSystem<Scalar> for WitnessViewCS<'a, Scalar>
+where
+  Scalar: PrimeField,
+{
+  type Root = Self;
+
+  fn new() -> Self {
+    unimplemented!()
+  }
+
+  fn alloc<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+  where
+    F: FnOnce() -> Result<Scalar, SynthesisError>,
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+  {
+    self.aux_assignment.push(f()?);
+
+    Ok(Variable(Index::Aux(self.aux_assignment.len() - 1)))
+  }
+
+  fn alloc_input<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+  where
+    F: FnOnce() -> Result<Scalar, SynthesisError>,
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+  {
+    self.input_assignment.push(f()?);
+
+    Ok(Variable(Index::Input(self.input_assignment.len() - 1)))
+  }
+
+  fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _a: LA, _b: LB, _c: LC)
+  where
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+    LA: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+    LB: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+    LC: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+  {
+    // Do nothing: we don't care about linear-combination evaluations in this context.
+  }
+
+  fn push_namespace<NR, N>(&mut self, _: N)
+  where
+    NR: Into<String>,
+    N: FnOnce() -> NR,
+  {
+    // Do nothing; we don't care about namespaces in this context.
+  }
+
+  fn pop_namespace(&mut self) {
+    // Do nothing; we don't care about namespaces in this context.
+  }
+
+  fn get_root(&mut self) -> &mut Self::Root {
+    self
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Extensible
+  fn is_extensible() -> bool {
+    true
+  }
+
+  /// This should not be used because the whole point of [`WitnessViewCS`] is to
+  /// hold the witness in a external buffer, in which case we shouldn't have
+  /// two [`WitnessViewCS`]s.
+  fn extend(&mut self, _other: &Self) {
+    panic!("WitnessViewCS::extend");
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Witness generator
+  fn is_witness_generator(&self) -> bool {
+    true
+  }
+
+  fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
+    self.input_assignment.extend_from_slice(new_inputs);
+  }
+
+  fn extend_aux(&mut self, new_aux: &[Scalar]) {
+    self.aux_assignment.extend_from_slice(new_aux);
+  }
+
+  fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
+    let allocated_aux = {
+      let i = self.aux_assignment.len();
+      self.aux_assignment.reserve_exact(aux_n + i);
+      &mut self.aux_assignment[i..]
+    };
+
+    let allocated_inputs = {
+      let i = self.input_assignment.len();
+      self.input_assignment.reserve_exact(inputs_n + i);
+      &mut self.input_assignment[i..]
+    };
+
+    (allocated_aux, allocated_inputs)
+  }
+
+  fn inputs_slice(&self) -> &[Scalar] {
+    self.input_assignment
+  }
+
+  fn aux_slice(&self) -> &[Scalar] {
+    self.aux_assignment
+  }
+}
+
+impl<'a, Scalar: PrimeField> WitnessViewCS<'a, Scalar> {
+  pub fn new_view(
+    input_assignment: &'a mut Vec<Scalar>,
+    aux_assignment: &'a mut Vec<Scalar>,
+  ) -> Self {
+    assert_eq!(input_assignment[0], Scalar::ONE);
+
+    Self {
+      input_assignment,
+      aux_assignment,
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,20 @@ where
   }
 }
 
+/// A resource sink for [`RecursiveSNARK`]
+pub struct ResourceSink<G1, G2>
+where
+  G1: Group<Base = <G2 as Group>::Scalar>,
+  G2: Group<Base = <G1 as Group>::Scalar>,
+{
+  l_w_primary: R1CSWitness<G1>,
+  l_u_primary: R1CSInstance<G1>,
+  /// buffer for `commit_T`
+  T_primary: Vec<G1::Scalar>,
+  /// buffer for `commit_T`
+  T_secondary: Vec<G2::Scalar>,
+}
+
 /// A SNARK that proves the correct execution of an incremental computation
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
@@ -282,15 +296,8 @@ where
   r_W_secondary: RelaxedR1CSWitness<G2>,
   r_U_secondary: RelaxedR1CSInstance<G2>,
 
-  l_w_primary: R1CSWitness<G1>,
-  l_u_primary: R1CSInstance<G1>,
   l_w_secondary: R1CSWitness<G2>,
   l_u_secondary: R1CSInstance<G2>,
-
-  /// buffer for `commit_T`
-  T_primary: Vec<G1::Scalar>,
-  /// buffer for `commit_T`
-  T_secondary: Vec<G2::Scalar>,
 
   i: usize,
   zi_primary: Vec<G1::Scalar>,
@@ -312,7 +319,7 @@ where
     c_secondary: &C2,
     z0_primary: &[G1::Scalar],
     z0_secondary: &[G2::Scalar],
-  ) -> Result<Self, NovaError> {
+  ) -> Result<(Self, ResourceSink<G1, G2>), NovaError> {
     if z0_primary.len() != pp.F_arity_primary || z0_secondary.len() != pp.F_arity_secondary {
       return Err(NovaError::InvalidInitialInputLength);
     }
@@ -422,13 +429,8 @@ where
       r_W_secondary,
       r_U_secondary,
 
-      l_w_primary,
-      l_u_primary,
       l_w_secondary,
       l_u_secondary,
-
-      T_primary: default_T(r1cs_primary),
-      T_secondary: default_T(r1cs_secondary),
 
       i: 0,
       zi_primary,
@@ -439,7 +441,14 @@ where
     // resize the witness buffers to be as snug as possible
     recursive_snark.shrink_to_fit();
 
-    Ok(recursive_snark)
+    let sink = ResourceSink {
+      l_w_primary,
+      l_u_primary,
+      T_primary: default_T(r1cs_primary),
+      T_secondary: default_T(r1cs_secondary),
+    };
+
+    Ok((recursive_snark, sink))
   }
 
   /// Shrink the witness buffers to the exact size they need to be
@@ -458,6 +467,7 @@ where
     pp: &PublicParams<G1, G2, C1, C2>,
     c_primary: &C1,
     c_secondary: &C2,
+    sink: &mut ResourceSink<G1, G2>,
   ) -> Result<(), NovaError> {
     // first step was already done in the constructor
     if self.i == 0 {
@@ -482,14 +492,14 @@ where
       &mut self.r_W_secondary,
       &self.l_u_secondary,
       &self.l_w_secondary,
-      &mut self.T_secondary,
+      &mut sink.T_secondary,
     )
     .expect("Unable to fold secondary");
 
     // increment `l_u_primary` and `l_w_primary`
     let mut cs_primary = WitnessViewCS::<G1::Scalar>::new_view(
-      &mut self.l_u_primary.one_and_X,
-      &mut self.l_w_primary.W,
+      &mut sink.l_u_primary.one_and_X,
+      &mut sink.l_w_primary.W,
     );
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest()),
@@ -517,7 +527,7 @@ where
     //   .r1cs_instance_and_witness(&pp.circuit_shape_primary.r1cs_shape, &pp.ck_primary)
     //   .map_err(|_e| NovaError::UnSat)
     //   .expect("Nova error unsat");
-    self.l_u_primary.comm_W = self.l_w_primary.commit(&pp.ck_primary);
+    sink.l_u_primary.comm_W = sink.l_w_primary.commit(&pp.ck_primary);
 
     // fold the primary circuit's instance
     let nifs_primary = NIFS::prove_mut(
@@ -527,9 +537,9 @@ where
       &pp.circuit_shape_primary.r1cs_shape,
       &mut self.r_U_primary,
       &mut self.r_W_primary,
-      &self.l_u_primary,
-      &self.l_w_primary,
-      &mut self.T_primary,
+      &sink.l_u_primary,
+      &sink.l_w_primary,
+      &mut sink.T_primary,
     )
     .expect("Unable to fold primary");
 
@@ -544,7 +554,7 @@ where
       self.z0_secondary.to_vec(),
       Some(self.zi_secondary.clone()),
       Some(r_U_primary_i),
-      Some(self.l_u_primary.clone()),
+      Some(sink.l_u_primary.clone()),
       Some(Commitment::<G1>::decompress(&nifs_primary.comm_T)?),
     );
 
@@ -1163,7 +1173,7 @@ mod tests {
     let num_steps = 1;
 
     // produce a recursive SNARK
-    let mut recursive_snark = RecursiveSNARK::new(
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::new(
       &pp,
       &test_circuit1,
       &test_circuit2,
@@ -1172,7 +1182,7 @@ mod tests {
     )
     .unwrap();
 
-    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2);
+    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2, &mut sink);
 
     assert!(res.is_ok());
 
@@ -1220,7 +1230,7 @@ mod tests {
     let num_steps = 3;
 
     // produce a recursive SNARK
-    let mut recursive_snark = RecursiveSNARK::<
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<
       G1,
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
@@ -1235,7 +1245,7 @@ mod tests {
     .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary);
+      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary, &mut sink);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion
@@ -1308,7 +1318,7 @@ mod tests {
     let num_steps = 3;
 
     // produce a recursive SNARK
-    let mut recursive_snark = RecursiveSNARK::<
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<
       G1,
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
@@ -1323,7 +1333,7 @@ mod tests {
     .unwrap();
 
     for _i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary);
+      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary, &mut sink);
       assert!(res.is_ok());
     }
 
@@ -1405,7 +1415,7 @@ mod tests {
     let num_steps = 3;
 
     // produce a recursive SNARK
-    let mut recursive_snark = RecursiveSNARK::<
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<
       G1,
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
@@ -1420,7 +1430,7 @@ mod tests {
     .unwrap();
 
     for _i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary);
+      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary, &mut sink);
       assert!(res.is_ok());
     }
 
@@ -1580,12 +1590,7 @@ mod tests {
     let z0_secondary = vec![<G2 as Group>::Scalar::ZERO];
 
     // produce a recursive SNARK
-    let mut recursive_snark: RecursiveSNARK<
-      G1,
-      G2,
-      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
-    > = RecursiveSNARK::<
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<
       G1,
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
@@ -1600,7 +1605,7 @@ mod tests {
     .unwrap();
 
     for circuit_primary in roots.iter().take(num_steps) {
-      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
+      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary, &mut sink);
       assert!(res.is_ok());
     }
 
@@ -1656,7 +1661,7 @@ mod tests {
     let num_steps = 1;
 
     // produce a recursive SNARK
-    let mut recursive_snark = RecursiveSNARK::<
+    let (mut recursive_snark, mut sink) = RecursiveSNARK::<
       G1,
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
@@ -1671,7 +1676,7 @@ mod tests {
     .unwrap();
 
     // produce a recursive SNARK
-    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2);
+    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2, &mut sink);
 
     assert!(res.is_ok());
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -75,6 +75,55 @@ impl<G: Group> NIFS<G> {
     ))
   }
 
+  /// Takes as input a Relaxed R1CS instance-witness tuple `(U1, W1)` and
+  /// an R1CS instance-witness tuple `(U2, W2)` with the same structure `shape`
+  /// and defined with respect to the same `ck`, and updates `(U1, W1)` by folding
+  /// `(U2, W2)` into it with the guarantee that the updated witness `W` satisfies
+  /// the updated instance `U` if and only if `W1` satisfies `U1` and `W2` satisfies `U2`.
+  #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all, level = "trace", name = "NIFS::prove_mut")]
+  pub fn prove_mut(
+    ck: &CommitmentKey<G>,
+    ro_consts: &ROConstants<G>,
+    pp_digest: &G::Scalar,
+    S: &R1CSShape<G>,
+    U1: &mut RelaxedR1CSInstance<G>,
+    W1: &mut RelaxedR1CSWitness<G>,
+    U2: &R1CSInstance<G>,
+    W2: &R1CSWitness<G>,
+    T: &mut Vec<G::Scalar>,
+  ) -> Result<NIFS<G>, NovaError> {
+    // initialize a new RO
+    let mut ro = G::RO::new(ro_consts.clone(), NUM_FE_FOR_RO);
+
+    // append the digest of pp to the transcript
+    ro.absorb(scalar_as_base::<G>(*pp_digest));
+
+    // append U1 and U2 to transcript
+    U1.absorb_in_ro(&mut ro);
+    U2.absorb_in_ro(&mut ro);
+
+    // compute a commitment to the cross-term
+    let comm_T = S.commit_T_into(ck, U1, W1, U2, W2, T)?;
+
+    // append `comm_T` to the transcript and obtain a challenge
+    comm_T.absorb_in_ro(&mut ro);
+
+    // compute a challenge from the RO
+    let r = ro.squeeze(NUM_CHALLENGE_BITS);
+
+    // fold the instance using `r` and `comm_T`
+    U1.fold_mut(U2, &comm_T, &r);
+
+    // fold the witness using `r` and `T`
+    W1.fold_mut(W2, T, &r)?;
+
+    // return the commitment
+    Ok(Self {
+      comm_T: comm_T.compress(),
+    })
+  }
+
   /// Takes as input a relaxed R1CS instance `U1` and R1CS instance `U2`
   /// with the same shape and defined with respect to the same parameters,
   /// and outputs a folded instance `U` with the same shape,
@@ -356,13 +405,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, &vars);
+          let res = R1CSWitness::new(&S, vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, &X);
+          let res = R1CSInstance::new(&S, comm_W, X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -209,11 +209,9 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::bellpepper::solver::WitnessViewCS;
   use crate::provider::{bn256_grumpkin::bn256, secp_secq};
-  use crate::{
-    bellpepper::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
-    gadgets::utils::le_bits_to_num, traits::Group,
-  };
+  use crate::{constants::NUM_CHALLENGE_BITS, gadgets::utils::le_bits_to_num, traits::Group};
   use ff::Field;
   use rand::rngs::OsRng;
 
@@ -232,7 +230,10 @@ mod tests {
     let mut ro: PoseidonRO<G::Scalar, G::Base> = PoseidonRO::new(constants.clone(), num_absorbs);
     let mut ro_gadget: PoseidonROCircuit<G::Scalar> =
       PoseidonROCircuit::new(constants, num_absorbs);
-    let mut cs = SatisfyingAssignment::<G>::new();
+
+    // Create the witness
+    let (mut input_assignment, mut aux_assignment) = (Vec::new(), Vec::new());
+    let mut cs = WitnessViewCS::<G::Scalar>::new_view(&mut input_assignment, &mut aux_assignment);
     for i in 0..num_absorbs {
       let num = G::Scalar::random(&mut csprng);
       ro.absorb(num);

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -55,7 +55,14 @@ pub struct R1CSWitness<G: Group> {
 #[serde(bound = "")]
 pub struct R1CSInstance<G: Group> {
   pub(crate) comm_W: Commitment<G>,
-  pub(crate) X: Vec<G::Scalar>,
+  /// This is intended to be a buffer for `WitnessViewCS`, which has an extra allocated one variable.
+  /// It ends up working out, and we use the extra slot for `G::Scalar::ONE` anyways
+  ///
+  /// We refer to `one_and_X[1..]` as just `X`
+  ///
+  /// ## TODO:
+  /// **MUST ASSERT THAT `one_and_X[0] == G::Scalar::ONE`**
+  pub(crate) one_and_X: Vec<G::Scalar>,
 }
 
 /// A type that holds a witness for a given Relaxed R1CS instance
@@ -71,8 +78,11 @@ pub struct RelaxedR1CSWitness<G: Group> {
 pub struct RelaxedR1CSInstance<G: Group> {
   pub(crate) comm_W: Commitment<G>,
   pub(crate) comm_E: Commitment<G>,
-  pub(crate) X: Vec<G::Scalar>,
-  pub(crate) u: G::Scalar,
+  /// This is intended to be a buffer for `WitnessViewCS`, which has an extra allocated one variable.
+  /// It ends up working out, and we use the extra slot for `u`
+  ///
+  /// We refer to `u_and_X[1..]` as just `X`
+  pub(crate) u_and_X: Vec<G::Scalar>,
 }
 
 /// A type for functions that hints commitment key sizing by returning the floor of the number of required generators.
@@ -190,19 +200,18 @@ impl<G: Group> R1CSShape<G> {
   pub(crate) fn multiply_witness(
     &self,
     W: &[G::Scalar],
-    u: &G::Scalar,
-    X: &[G::Scalar],
+    u_and_X: &[G::Scalar],
   ) -> Result<(Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>), NovaError> {
-    if X.len() != self.num_io || W.len() != self.num_vars {
+    if u_and_X.len() != self.num_io + 1 || W.len() != self.num_vars {
       return Err(NovaError::InvalidWitnessLength);
     }
 
     let (Az, (Bz, Cz)) = rayon::join(
-      || self.A.multiply_witness(W, u, X),
+      || self.A.multiply_witness(W, u_and_X),
       || {
         rayon::join(
-          || self.B.multiply_witness(W, u, X),
-          || self.C.multiply_witness(W, u, X),
+          || self.B.multiply_witness(W, u_and_X),
+          || self.C.multiply_witness(W, u_and_X),
         )
       },
     );
@@ -219,17 +228,17 @@ impl<G: Group> R1CSShape<G> {
   ) -> Result<(), NovaError> {
     assert_eq!(W.W.len(), self.num_vars);
     assert_eq!(W.E.len(), self.num_cons);
-    assert_eq!(U.X.len(), self.num_io);
+    assert_eq!(U.u_and_X.len(), self.num_io + 1);
 
     // verify if Az * Bz = u*Cz + E
     let res_eq = {
-      let (Az, Bz, Cz) = self.multiply_witness(&W.W, &U.u, &U.X)?;
+      let (Az, Bz, Cz) = self.multiply_witness(&W.W, &U.u_and_X)?;
       assert_eq!(Az.len(), self.num_cons);
       assert_eq!(Bz.len(), self.num_cons);
       assert_eq!(Cz.len(), self.num_cons);
 
       (0..self.num_cons).try_for_each(|i| {
-        if Az[i] * Bz[i] != U.u * Cz[i] + W.E[i] {
+        if Az[i] * Bz[i] != U.u_and_X[0] * Cz[i] + W.E[i] {
           // constraint failed
           Err(NovaError::UnSatIndex(i))
         } else {
@@ -260,11 +269,12 @@ impl<G: Group> R1CSShape<G> {
     W: &R1CSWitness<G>,
   ) -> Result<(), NovaError> {
     assert_eq!(W.W.len(), self.num_vars);
-    assert_eq!(U.X.len(), self.num_io);
+    assert_eq!(U.one_and_X.len(), self.num_io + 1);
+    assert_eq!(U.one_and_X[0], G::Scalar::ONE);
 
     // verify if Az * Bz = u*Cz
     let res_eq = {
-      let (Az, Bz, Cz) = self.multiply_witness(&W.W, &G::Scalar::ONE, &U.X)?;
+      let (Az, Bz, Cz) = self.multiply_witness(&W.W, &U.one_and_X)?;
       assert_eq!(Az.len(), self.num_cons);
       assert_eq!(Bz.len(), self.num_cons);
       assert_eq!(Cz.len(), self.num_cons);
@@ -298,10 +308,10 @@ impl<G: Group> R1CSShape<G> {
     W2: &R1CSWitness<G>,
   ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
     let (AZ_1, BZ_1, CZ_1) = tracing::trace_span!("AZ_1, BZ_1, CZ_1")
-      .in_scope(|| self.multiply_witness(&W1.W, &U1.u, &U1.X))?;
+      .in_scope(|| self.multiply_witness(&W1.W, &U1.u_and_X))?;
 
     let (AZ_2, BZ_2, CZ_2) = tracing::trace_span!("AZ_2, BZ_2, CZ_2")
-      .in_scope(|| self.multiply_witness(&W2.W, &G::Scalar::ONE, &U2.X))?;
+      .in_scope(|| self.multiply_witness(&W2.W, &U2.one_and_X))?;
 
     let (AZ_1_circ_BZ_2, AZ_2_circ_BZ_1, u_1_cdot_CZ_2, u_2_cdot_CZ_1) =
       tracing::trace_span!("cross terms").in_scope(|| {
@@ -315,7 +325,7 @@ impl<G: Group> R1CSShape<G> {
           .collect::<Vec<G::Scalar>>();
         let u_1_cdot_CZ_2 = (0..CZ_2.len())
           .into_par_iter()
-          .map(|i| U1.u * CZ_2[i])
+          .map(|i| U1.u_and_X[0] * CZ_2[i])
           .collect::<Vec<G::Scalar>>();
         let u_2_cdot_CZ_1 = (0..CZ_1.len())
           .into_par_iter()
@@ -353,10 +363,10 @@ impl<G: Group> R1CSShape<G> {
     T: &mut Vec<G::Scalar>,
   ) -> Result<Commitment<G>, NovaError> {
     let (AZ_1, BZ_1, CZ_1) = tracing::trace_span!("AZ_1, BZ_1, CZ_1")
-      .in_scope(|| self.multiply_witness(&W1.W, &U1.u, &U1.X))?;
+      .in_scope(|| self.multiply_witness(&W1.W, &U1.u_and_X))?;
 
     let (AZ_2, BZ_2, CZ_2) = tracing::trace_span!("AZ_2, BZ_2, CZ_2")
-      .in_scope(|| self.multiply_witness(&W2.W, &G::Scalar::ONE, &U2.X))?;
+      .in_scope(|| self.multiply_witness(&W2.W, &U2.one_and_X))?;
 
     // this doesn't allocate memory but has bad temporal cache locality -- should test to see which is faster
     tracing::trace_span!("T").in_scope(|| {
@@ -365,7 +375,7 @@ impl<G: Group> R1CSShape<G> {
         .map(|i| {
           let AZ_1_circ_BZ_2 = AZ_1[i] * BZ_2[i];
           let AZ_2_circ_BZ_1 = AZ_2[i] * BZ_1[i];
-          let u_1_cdot_CZ_2 = U1.u * CZ_2[i];
+          let u_1_cdot_CZ_2 = U1.u_and_X[0] * CZ_2[i];
           AZ_1_circ_BZ_2 + AZ_2_circ_BZ_1 - u_1_cdot_CZ_2 - CZ_1[i]
         })
         .collect_into_vec(T)
@@ -442,7 +452,7 @@ impl<G: Group> R1CSWitness<G> {
   /// Produces a default `RelaxedR1CSWitness` given an `R1CSShape`
   pub fn default(S: &R1CSShape<G>) -> R1CSWitness<G> {
     R1CSWitness {
-      W: vec![G::Scalar::ZERO; S.num_vars],
+      W: Vec::with_capacity(S.num_vars),
     }
   }
 
@@ -467,7 +477,7 @@ impl<G: Group> R1CSInstance<G> {
     let comm_W = Commitment::<G>::default();
     R1CSInstance {
       comm_W,
-      X: vec![G::Scalar::ZERO; S.num_io],
+      one_and_X: Vec::with_capacity(S.num_io + 1),
     }
   }
 
@@ -475,12 +485,12 @@ impl<G: Group> R1CSInstance<G> {
   pub fn new(
     S: &R1CSShape<G>,
     comm_W: Commitment<G>,
-    X: Vec<G::Scalar>,
+    one_and_X: Vec<G::Scalar>,
   ) -> Result<R1CSInstance<G>, NovaError> {
-    if S.num_io != X.len() {
+    if S.num_io + 1 != one_and_X.len() || one_and_X[0] != G::Scalar::ONE {
       Err(NovaError::InvalidInputLength)
     } else {
-      Ok(R1CSInstance { comm_W, X })
+      Ok(R1CSInstance { comm_W, one_and_X })
     }
   }
 }
@@ -488,7 +498,8 @@ impl<G: Group> R1CSInstance<G> {
 impl<G: Group> AbsorbInROTrait<G> for R1CSInstance<G> {
   fn absorb_in_ro(&self, ro: &mut G::RO) {
     self.comm_W.absorb_in_ro(ro);
-    for x in &self.X {
+    // make sure to skip the one allocation
+    for x in &self.one_and_X[1..] {
       ro.absorb(scalar_as_base::<G>(*x));
     }
   }
@@ -498,8 +509,8 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   /// Produces a default `RelaxedR1CSWitness` given an `R1CSShape`
   pub fn default(S: &R1CSShape<G>) -> RelaxedR1CSWitness<G> {
     RelaxedR1CSWitness {
-      W: vec![G::Scalar::ZERO; S.num_vars],
-      E: vec![G::Scalar::ZERO; S.num_cons],
+      W: Vec::with_capacity(S.num_vars),
+      E: Vec::with_capacity(S.num_cons),
     }
   }
 
@@ -507,7 +518,7 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   pub fn from_r1cs_witness(S: &R1CSShape<G>, witness: R1CSWitness<G>) -> RelaxedR1CSWitness<G> {
     RelaxedR1CSWitness {
       W: witness.W,
-      E: vec![G::Scalar::ZERO; S.num_cons],
+      E: Vec::with_capacity(S.num_cons),
     }
   }
 
@@ -587,8 +598,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     RelaxedR1CSInstance {
       comm_W,
       comm_E,
-      u: G::Scalar::ZERO,
-      X: vec![G::Scalar::ZERO; S.num_io],
+      u_and_X: Vec::with_capacity(S.num_io + 1),
     }
   }
 
@@ -598,26 +608,28 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     S: &R1CSShape<G>,
     instance: R1CSInstance<G>,
   ) -> RelaxedR1CSInstance<G> {
-    assert_eq!(S.num_io, instance.X.len());
+    assert_eq!(S.num_io + 1, instance.one_and_X.len());
+    assert_eq!(G::Scalar::ONE, instance.one_and_X[0]);
 
     RelaxedR1CSInstance {
       comm_W: instance.comm_W,
       comm_E: Commitment::<G>::default(),
-      u: G::Scalar::ONE,
-      X: instance.X,
+      u_and_X: instance.one_and_X,
     }
   }
 
   /// Initializes a new `RelaxedR1CSInstance` from an `R1CSInstance`
   pub fn from_r1cs_instance_unchecked(
     comm_W: Commitment<G>,
-    X: Vec<G::Scalar>,
+    X: &[G::Scalar],
   ) -> RelaxedR1CSInstance<G> {
+    let mut u_and_X = vec![G::Scalar::ONE];
+    u_and_X.extend_from_slice(X);
+
     RelaxedR1CSInstance {
       comm_W,
       comm_E: Commitment::<G>::default(),
-      u: G::Scalar::ONE,
-      X,
+      u_and_X,
     }
   }
 
@@ -628,39 +640,40 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     comm_T: &Commitment<G>,
     r: &G::Scalar,
   ) -> RelaxedR1CSInstance<G> {
-    let (X1, u1, comm_W_1, comm_E_1) =
-      (&self.X, &self.u, &self.comm_W.clone(), &self.comm_E.clone());
-    let (X2, comm_W_2) = (&U2.X, &U2.comm_W);
+    let (u1_and_X1, comm_W_1, comm_E_1) =
+      (&self.u_and_X, &self.comm_W.clone(), &self.comm_E.clone());
+    let (one_and_X2, comm_W_2) = (&U2.one_and_X, &U2.comm_W);
 
     // weighted sum of X, comm_W, comm_E, and u
-    let X = X1
+    let u_and_X = u1_and_X1
       .par_iter()
-      .zip(X2)
+      .zip(one_and_X2)
       .map(|(a, b)| *a + *r * *b)
       .collect::<Vec<G::Scalar>>();
     let comm_W = *comm_W_1 + *comm_W_2 * *r;
     let comm_E = *comm_E_1 + *comm_T * *r;
-    let u = *u1 + *r;
 
     RelaxedR1CSInstance {
       comm_W,
       comm_E,
-      X,
-      u,
+      u_and_X,
     }
   }
 
   /// Mutably folds an incoming `RelaxedR1CSInstance` into the current one
   pub fn fold_mut(&mut self, U2: &R1CSInstance<G>, comm_T: &Commitment<G>, r: &G::Scalar) {
-    let (X2, comm_W_2) = (&U2.X, &U2.comm_W);
+    let (one_and_X2, comm_W_2) = (&U2.one_and_X, &U2.comm_W);
 
     // weighted sum of X, comm_W, comm_E, and u
-    self.X.par_iter_mut().zip(X2).for_each(|(a, b)| {
-      *a += *r * *b;
-    });
+    self
+      .u_and_X
+      .par_iter_mut()
+      .zip(one_and_X2)
+      .for_each(|(a, b)| {
+        *a += *r * *b;
+      });
     self.comm_W += *comm_W_2 * *r;
     self.comm_E += *comm_T * *r;
-    self.u += r;
   }
 }
 
@@ -669,8 +682,7 @@ impl<G: Group> TranscriptReprTrait<G> for RelaxedR1CSInstance<G> {
     [
       self.comm_W.to_transcript_bytes(),
       self.comm_E.to_transcript_bytes(),
-      self.u.to_transcript_bytes(),
-      self.X.as_slice().to_transcript_bytes(),
+      self.u_and_X.as_slice().to_transcript_bytes(),
     ]
     .concat()
   }
@@ -680,10 +692,10 @@ impl<G: Group> AbsorbInROTrait<G> for RelaxedR1CSInstance<G> {
   fn absorb_in_ro(&self, ro: &mut G::RO) {
     self.comm_W.absorb_in_ro(ro);
     self.comm_E.absorb_in_ro(ro);
-    ro.absorb(scalar_as_base::<G>(self.u));
+    ro.absorb(scalar_as_base::<G>(self.u_and_X[0]));
 
     // absorb each element of self.X in bignum format
-    for x in &self.X {
+    for x in &self.u_and_X[1..] {
       let limbs: Vec<G::Scalar> = nat_to_limbs(&f_to_nat(x), BN_LIMB_WIDTH, BN_N_LIMBS).unwrap();
       for limb in limbs {
         ro.absorb(scalar_as_base::<G>(limb));

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -4,6 +4,8 @@
 //! Specifically, we implement sparse matrix / dense vector multiplication
 //! to compute the `A z`, `B z`, and `C z` in Nova.
 
+use std::cmp::Ordering;
+
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use ff::PrimeField;
@@ -116,6 +118,43 @@ impl<F: PrimeField> SparseMatrix<F> {
           .sum()
       })
       .collect()
+  }
+
+  /// Multiply by a witness representing a dense vector; uses rayon/gpu.
+  pub fn multiply_witness(&self, W: &[F], u: &F, X: &[F]) -> Vec<F> {
+    assert_eq!(self.cols, W.len() + X.len() + 1, "invalid shape");
+
+    self.multiply_witness_unchecked(W, u, X)
+  }
+
+  /// Multiply by a witness representing a dense vector; uses rayon/gpu.
+  /// This does not check that the shape of the matrix/vector are compatible.
+  #[tracing::instrument(
+    skip_all,
+    level = "trace",
+    name = "SparseMatrix::multiply_vec_unchecked"
+  )]
+  pub fn multiply_witness_unchecked(&self, W: &[F], u: &F, X: &[F]) -> Vec<F> {
+    let num_vars = W.len();
+    // preallocate the result vector
+    let mut result = Vec::with_capacity(self.indptr.len() - 1);
+    self
+      .indptr
+      .par_windows(2)
+      .map(|ptrs| {
+        self
+          .get_row_unchecked(ptrs.try_into().unwrap())
+          .fold(F::ZERO, |acc, (val, col_idx)| {
+            let val = match col_idx.cmp(&num_vars) {
+              Ordering::Less => *val * W[*col_idx],
+              Ordering::Equal => *val * X[*col_idx - num_vars],
+              Ordering::Greater => *val * u,
+            };
+            acc + val
+          })
+      })
+      .collect_into_vec(&mut result);
+    result
   }
 
   /// number of non-zero entries

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -143,7 +143,7 @@ impl<F: PrimeField> SparseMatrix<F> {
         self
           .get_row_unchecked(ptrs.try_into().unwrap())
           .fold(F::ZERO, |acc, (val, col_idx)| {
-            if *col_idx < num_vars {
+            let val = if *col_idx < num_vars {
               *val * W[*col_idx]
             } else {
               *val * u_and_X[*col_idx - num_vars]

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -135,7 +135,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
     // convert the instance and witness to relaxed form
     let (u_relaxed, w_relaxed) = (
-      RelaxedR1CSInstance::from_r1cs_instance_unchecked(u.comm_W, u.X),
+      RelaxedR1CSInstance::from_r1cs_instance_unchecked(u.comm_W, &u.one_and_X[1..]),
       RelaxedR1CSWitness::from_r1cs_witness(&pk.S, w),
     );
 
@@ -152,7 +152,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
   /// Verifies a proof of satisfiability
   pub fn verify(&self, vk: &VerifierKey<G, S>, io: &[G::Scalar]) -> Result<(), NovaError> {
     // construct an instance using the provided commitment to the witness and z_i and z_{i+1}
-    let u_relaxed = RelaxedR1CSInstance::from_r1cs_instance_unchecked(self.comm_W, io.to_vec());
+    let u_relaxed = RelaxedR1CSInstance::from_r1cs_instance_unchecked(self.comm_W, io);
 
     // verify the snark using the constructed instance
     self.snark.verify(&vk.vk, &u_relaxed)?;

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -135,8 +135,8 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
     // convert the instance and witness to relaxed form
     let (u_relaxed, w_relaxed) = (
-      RelaxedR1CSInstance::from_r1cs_instance_unchecked(&u.comm_W, &u.X),
-      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, &w),
+      RelaxedR1CSInstance::from_r1cs_instance_unchecked(u.comm_W, u.X),
+      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, w),
     );
 
     // prove the instance using Spartan
@@ -152,7 +152,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
   /// Verifies a proof of satisfiability
   pub fn verify(&self, vk: &VerifierKey<G, S>, io: &[G::Scalar]) -> Result<(), NovaError> {
     // construct an instance using the provided commitment to the witness and z_i and z_{i+1}
-    let u_relaxed = RelaxedR1CSInstance::from_r1cs_instance_unchecked(&self.comm_W, io);
+    let u_relaxed = RelaxedR1CSInstance::from_r1cs_instance_unchecked(self.comm_W, io.to_vec());
 
     // verify the snark using the constructed instance
     self.snark.verify(&vk.vk, &u_relaxed)?;

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1031,7 +1031,7 @@ where
     let z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     // compute Az, Bz, Cz
-    let (mut Az, mut Bz, mut Cz) = S.multiply_vec(&z)?;
+    let (mut Az, mut Bz, mut Cz) = S.multiply_witness(&W.W, &U.u, &U.X)?;
 
     // commit to Az, Bz, Cz
     let (comm_Az, (comm_Bz, comm_Cz)) = rayon::join(

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -811,29 +811,29 @@ where
     {
       for (i, r_U_primary_i) in self.r_U_primary.iter().enumerate() {
         if let Some(u) = r_U_primary_i {
-          if u.X.len() != 2 {
+          if u.u_and_X.len() != 3 {
             debug!(
               "r_U_primary[{:?}] got instance length {:?} != 2",
               i,
-              u.X.len(),
+              u.u_and_X.len() - 1,
             );
             return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
           }
         }
       }
 
-      if self.l_u_secondary.X.len() != 2 {
+      if self.l_u_secondary.one_and_X.len() != 3 {
         debug!(
           "l_U_secondary got instance length {:?} != 2",
-          self.l_u_secondary.X.len(),
+          self.l_u_secondary.one_and_X.len() - 1,
         );
         return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
       }
 
-      if self.r_U_secondary.X.len() != 2 {
+      if self.r_U_secondary.u_and_X.len() != 3 {
         debug!(
           "r_U_secondary got instance length {:?} != 2",
-          self.r_U_secondary.X.len(),
+          self.r_U_secondary.u_and_X.len() - 1,
         );
         return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
       }
@@ -890,17 +890,17 @@ where
       )
     };
 
-    if hash_primary != self.l_u_secondary.X[0] {
+    if hash_primary != self.l_u_secondary.one_and_X[1] {
       debug!(
         "hash_primary {:?} not equal l_u_secondary.X[0] {:?}",
-        hash_primary, self.l_u_secondary.X[0]
+        hash_primary, self.l_u_secondary.one_and_X[1]
       );
       return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
     }
-    if hash_secondary != scalar_as_base::<G2>(self.l_u_secondary.X[1]) {
+    if hash_secondary != scalar_as_base::<G2>(self.l_u_secondary.one_and_X[2]) {
       debug!(
         "hash_secondary {:?} not equal l_u_secondary.X[1] {:?}",
-        hash_secondary, self.l_u_secondary.X[1]
+        hash_secondary, self.l_u_secondary.one_and_X[2]
       );
       return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
     }

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -473,11 +473,9 @@ where
       num_augmented_circuits,
     );
 
-    let (zi_primary_pc_next, zi_primary) =
-      circuit_primary.synthesize(&mut cs_primary).map_err(|err| {
-        debug!("err {:?}", err);
-        NovaError::SynthesisError
-      })?;
+    let (zi_primary_pc_next, zi_primary) = circuit_primary
+      .synthesize(&mut cs_primary)
+      .map_err(|_| NovaError::SynthesisError)?;
     if zi_primary.len() != pp[circuit_index].F_arity {
       return Err(SuperNovaError::NovaError(
         NovaError::InvalidStepOutputLength,
@@ -485,10 +483,7 @@ where
     }
     let (u_primary, w_primary) = cs_primary
       .r1cs_instance_and_witness(&pp[circuit_index].r1cs_shape, &pp.ck_primary)
-      .map_err(|err| {
-        debug!("err {:?}", err);
-        NovaError::SynthesisError
-      })?;
+      .map_err(|_| NovaError::SynthesisError)?;
 
     // base case for the secondary
     let mut cs_secondary = SatisfyingAssignment::<G2>::new();
@@ -526,12 +521,12 @@ where
     let l_w_primary = w_primary;
     let l_u_primary = u_primary;
     let r_W_primary =
-      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, &l_w_primary);
+      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, l_w_primary);
 
     let r_U_primary = RelaxedR1CSInstance::from_r1cs_instance(
       &pp.ck_primary,
       &pp[circuit_index].r1cs_shape,
-      &l_u_primary,
+      l_u_primary,
     );
 
     // IVC proof of the secondary circuit


### PR DESCRIPTION
This PR restructures the way `arecibo` approaches memory allocation and restructures the entire memory pipeline. See the [notion design doc](https://www.notion.so/lurk-lab/Memory-pipeline-arecibo-8d64ce4eb0a34e76a127ec0fddf96f27#ad0d92ef3ad64cb1a9e1105994e243a3) for more info.

## Notable improvements
- The critical sections in `prove_step` and `R1CSShape::commit_T` no longer clone the large witness. 
- Downstream in `lurk-rs`, this PR fixes the strange regression we observed when using loaded public parameters. This is a strong indicator that inefficient memory allocations in `arecibo` was creating (and could've created) very unpredictable performance regressions.
- Generally, the memory consumption of Nova is now very predictable, and this new memory pipeline is much safer to scale.

## To-dos and other outstanding issues 
- [ ] We only refactor the Nova side of `arecibo`, and left the SuperNova untouched. This contains the scope of the PR. In the future, we should be interested in converting SuperNova to the same memory strategy as well.
- [ ] The `ResourceSink` structure was temporarily created to manage the extra buffers `prove_step` needs. This should be integrated into the `RecursiveSNARK` API. Maybe with some sort of `RecursiveSNARKEngine` / `RecursiveSNARKEngineTrait` to manage folding. 
- [ ] There is one last inefficiency, which is that we recompute R1CS multiplication against the running witness in `commit_T`. The `Z` vectors should be moved into the `ResourceSink` to de-duplicate this.
- [ ] Audit the security of these changes. @gabriel-barrett brought up possible security concerns when I re-introduced `l_w_primary` and `l_u_primary` into `RecursiveSNARK`, pointing out the [revisiting Nova paper](https://eprint.iacr.org/2023/969.pdf). I think `ResourceSink` fixes this, but we should make sure.
- [ ] Refactor `WitnessCS` in upstream `bellpepper` to unify with `WitnessViewCS`, which is redundant.