### PR TITLE
SuperNova: Improve circuit

### DIFF
--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -70,6 +70,7 @@ pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS) -> Allocate
 
 /// alloc a field as a constant
 /// implemented refer from <https://github.com/lurk-lab/lurk-rs/blob/4335fbb3290ed1a1176e29428f7daacb47f8033d/src/circuit/gadgets/data.rs#L387-L402>
+#[allow(unused)]
 pub fn alloc_const<F: PrimeField, CS: ConstraintSystem<F>>(
   mut cs: CS,
   val: F,

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -198,6 +198,7 @@ pub fn alloc_num_equals<F: PrimeField, CS: ConstraintSystem<F>>(
 }
 
 /// Check that two numbers are equal and return a bit
+#[allow(unused)]
 pub fn alloc_num_equals_const<F: PrimeField, CS: ConstraintSystem<F>>(
   mut cs: CS,
   a: &AllocatedNum<F>,

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -74,21 +74,21 @@ impl SuperNovaAugmentedCircuitParams {
 pub struct SuperNovaAugmentedCircuitInputs<'a, G: Group> {
   pp_digest: G::Scalar,
   i: G::Base,
-  // Input to the circuit for the base case
+  /// Input to the circuit for the base case
   z0: &'a [G::Base],
-  // Input to the circuit for the non-base case
+  /// Input to the circuit for the non-base case
   zi: Option<&'a [G::Base]>,
-  // List of `RelaxedR1CSInstance`.
-  // `None` if this is the base case.
-  // Elements are `None` if the circuit at that index was not yet executed.
+  /// List of `RelaxedR1CSInstance`.
+  /// `None` if this is the base case.
+  /// Elements are `None` if the circuit at that index was not yet executed.
   U: Option<&'a [Option<RelaxedR1CSInstance<G>>]>,
-  // R1CS proof to be folded into U
+  /// R1CS proof to be folded into U
   u: Option<&'a R1CSInstance<G>>,
-  // Nova folding proof for accumulating u into U[j]
+  /// Nova folding proof for accumulating u into U[j]
   T: Option<&'a Commitment<G>>,
-  // Index of the current circuit
+  /// Index of the current circuit
   program_counter: Option<G::Base>,
-  // Index j of circuit being folded into U[j]
+  /// Index j of circuit being folded into U[j]
   last_augmented_circuit_index: G::Base,
 }
 

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -1056,7 +1056,7 @@ fn num_ro_inputs(num_circuits: usize, num_limbs: usize, arity: usize, is_primary
   let instance_size = 3 + 3 + 1 + 2 * num_limbs;
 
   2 // params, i
-    + is_primary as usize // optional program counter
+    + usize::from(is_primary) // optional program counter
       + 2 * arity // z0, zi
       + num_circuits * instance_size
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -651,7 +651,7 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
-  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9841, 12028);
+  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9842, 12025);
 }
 
 fn test_pp_digest_with<G1, G2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
@@ -697,7 +697,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "f61a0b9d2c6eed97c7e93d9864b6424b348ab38d9fb172e7535c06f0d3b45800",
+    "7522192d3ca008abfa9c8551ec1beb5fa315d8963e4387cc34c5ec3cc5543c03",
   );
 
   let rom = vec![
@@ -712,7 +712,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "7546007400c4c519a993006979d43a06ae6fa82370e3259ac60a4a67fb0eac03",
+    "323ef0a87851d9ca50d3fd503345d000029c1376d206e29a39383d04edf0ed02",
   );
 
   let rom = vec![
@@ -727,7 +727,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "3143fef7d74b7b8582a467959d18da999eae3b4787e953c1ee7f30acfbcc7600",
+    "243c5c71410d9ba3c18b7033c5170951011933d0b800fe0f6a95d1f01dd2d502",
   );
 }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -651,7 +651,7 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
-  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9842, 12025);
+  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9844, 12025);
 }
 
 fn test_pp_digest_with<G1, G2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
@@ -697,7 +697,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "7522192d3ca008abfa9c8551ec1beb5fa315d8963e4387cc34c5ec3cc5543c03",
+    "e6b6b796fb32c09d487e07f34967cb146497b4fae85a8e22c151a3aa6aa83602",
   );
 
   let rom = vec![
@@ -712,7 +712,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "323ef0a87851d9ca50d3fd503345d000029c1376d206e29a39383d04edf0ed02",
+    "0faa3a07d225e8f92a0823f93f462abbb34c063fefa500a8fb131c0829b68600",
   );
 
   let rom = vec![

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -651,7 +651,7 @@ fn test_recursive_circuit() {
   let ro_consts1: ROConstantsCircuit<G2> = PoseidonConstantsCircuit::default();
   let ro_consts2: ROConstantsCircuit<G1> = PoseidonConstantsCircuit::default();
 
-  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9845, 12036);
+  test_recursive_circuit_with::<G1, G2>(&params1, &params2, ro_consts1, ro_consts2, 9841, 12028);
 }
 
 fn test_pp_digest_with<G1, G2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
@@ -697,7 +697,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "1ea5f38a96bbad918d2132d15ac3f463ee97c532988bb4fc16a761bfe7847300",
+    "f61a0b9d2c6eed97c7e93d9864b6424b348ab38d9fb172e7535c06f0d3b45800",
   );
 
   let rom = vec![
@@ -712,7 +712,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "09dc431db3be49a3e4f065a67c9d7260accdaed737fb0bc2abd70c1068b8df00",
+    "7546007400c4c519a993006979d43a06ae6fa82370e3259ac60a4a67fb0eac03",
   );
 
   let rom = vec![
@@ -727,7 +727,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "c695e71fb75c3235471fb53d5b6b02610ac698af294877c20b9d855398679102",
+    "3143fef7d74b7b8582a467959d18da999eae3b4787e953c1ee7f30acfbcc7600",
   );
 }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -727,7 +727,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "243c5c71410d9ba3c18b7033c5170951011933d0b800fe0f6a95d1f01dd2d502",
+    "2322ae73400aa1cf488bfb342036f7d1e799c2aad22551ccbdf6c769840a1802",
   );
 }
 

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -62,18 +62,6 @@ pub fn get_selector_vec_from_index<F: PrimeField, CS: ConstraintSystem<F>>(
 ) -> Result<Vec<Boolean>, SynthesisError> {
   assert_ne!(num_indices, 0);
 
-  // Trivial case: return [1], enforce `target_index == 0`
-  if num_indices == 1 {
-    cs.enforce(
-      || "target_index = 0",
-      |lc| lc,
-      |lc| lc,
-      |lc| lc + target_index.get_variable(),
-    );
-
-    return Ok(vec![Boolean::Constant(true)]);
-  }
-
   // Compute the selector vector non-deterministically
   let selector = (0..num_indices)
     .map(|idx| {

--- a/src/traits/circuit_supernova.rs
+++ b/src/traits/circuit_supernova.rs
@@ -15,7 +15,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   /// Return this `StepCircuit`'s assigned index, for use when enforcing the program counter.
   fn circuit_index(&self) -> usize;
 
-  /// Sythesize the circuit for a computation step and return variable
+  /// Synthesize the circuit for a computation step and return variable
   /// that corresponds to the output of the step `pc_{i+1}` and `z_{i+1}`
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
@@ -109,6 +109,7 @@ where
     z: &[AllocatedNum<F>],
   ) -> Result<(Option<AllocatedNum<F>>, Vec<AllocatedNum<F>>), SynthesisError> {
     assert!(program_counter.is_none());
+    assert_eq!(z.len(), 1, "Arity of trivial step circuit should be 1");
     Ok((None, z.to_vec()))
   }
 }


### PR DESCRIPTION
This PR fixes some minor annoyances in the SuperNova circuit and adds documentation.

- Compute number of RO inputs for public output via a function
- Compute instance selector vector from `last_augmented_circuit_index` in `alloc_witness`
  - Reuse the selector across the base and non-base branches.
- Add comments