### PR TITLE
refactor: Refactor R1CS for in-place operations and Vec inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-texray = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
+vecshard = "0.2.1"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -11,12 +11,13 @@ use crate::{
 };
 use bellpepper_core::{Index, LinearCombination};
 use ff::PrimeField;
+use vecshard::ShardExt;
 
 /// `NovaWitness` provide a method for acquiring an `R1CSInstance` and `R1CSWitness` from implementers.
 pub trait NovaWitness<G: Group> {
   /// Return an instance and witness, given a shape and ck.
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<G>,
     ck: &CommitmentKey<G>,
   ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError>;
@@ -39,16 +40,19 @@ pub trait NovaShape<G: Group> {
 
 impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<G>,
     ck: &CommitmentKey<G>,
   ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError> {
-    let W = R1CSWitness::<G>::new(shape, self.aux_assignment())?;
-    let X = &self.input_assignment()[1..];
+    let (input_assignment, aux_assignment) = self.to_assignments();
+
+    let W = R1CSWitness::<G>::new(shape, aux_assignment)?;
+
+    let (_, X) = input_assignment.split_inplace_at(1);
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<G>::new(shape, &comm_W, X)?;
+    let instance = R1CSInstance::<G>::new(shape, &comm_W, X.into())?;
 
     Ok((instance, W))
   }

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -356,13 +356,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, &vars);
+          let res = R1CSWitness::new(&S, vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, &X);
+          let res = R1CSInstance::new(&S, &comm_W, X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -386,11 +386,11 @@ impl<G: Group> R1CSShape<G> {
 
 impl<G: Group> R1CSWitness<G> {
   /// A method to create a witness object using a vector of scalars
-  pub fn new(S: &R1CSShape<G>, W: &[G::Scalar]) -> Result<R1CSWitness<G>, NovaError> {
+  pub fn new(S: &R1CSShape<G>, W: Vec<G::Scalar>) -> Result<R1CSWitness<G>, NovaError> {
     if S.num_vars != W.len() {
       Err(NovaError::InvalidWitnessLength)
     } else {
-      Ok(R1CSWitness { W: W.to_owned() })
+      Ok(R1CSWitness { W })
     }
   }
 
@@ -405,15 +405,12 @@ impl<G: Group> R1CSInstance<G> {
   pub fn new(
     S: &R1CSShape<G>,
     comm_W: &Commitment<G>,
-    X: &[G::Scalar],
+    X: Vec<G::Scalar>,
   ) -> Result<R1CSInstance<G>, NovaError> {
     if S.num_io != X.len() {
       Err(NovaError::InvalidInputLength)
     } else {
-      Ok(R1CSInstance {
-        comm_W: *comm_W,
-        X: X.to_owned(),
-      })
+      Ok(R1CSInstance { comm_W: *comm_W, X })
     }
   }
 }


### PR DESCRIPTION
- Added a new dependency `vecshard` version "0.2.1" in the Cargo.toml file.
- Updated `NovaWitness` trait method `r1cs_instance_and_witness` to consume self, impacting its implementation in `SatisfyingAssignment`.
- Replaced slicing operations with in-place split for `input_assignment` using `ShardExt` trait.
- Removed unnecessary variable references in `R1CSWitness::new` and `R1CSInstance::new` function calls.
- Refactored `new` methods in `R1CSWitness` and `R1CSInstance` to accept `Vec` instead of a slice, and removed redundant `.to_owned()` operation.

This offers one possible alternative for some of the changes in #118