### PR TITLE
Pre-allocate in SatisfyingAssignment<G>

### DIFF
--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -2,6 +2,7 @@
 
 use crate::{r1cs::R1CSShape, traits::Group};
 
+use ff::Field;
 use bellpepper::util_cs::witness_cs::WitnessCS;
 use bellpepper_core::ConstraintSystem;
 
@@ -18,6 +19,9 @@ pub trait WithShapeBasedPreAllocation<G: Group>: ConstraintSystem<<G as Group>::
 /// SatisfyingAssignment knows how to pre-allocate its internal storage given an R1CSShape.
 impl<G: Group> WithShapeBasedPreAllocation<G> for SatisfyingAssignment<G> {
   fn new_from_shape_parameters(r1cs_shape: &R1CSShape<G>) -> Self {
-    SatisfyingAssignment::<G>::with_capacity(r1cs_shape.num_io + 1, r1cs_shape.num_vars)
+    let mut cs = SatisfyingAssignment::<G>::with_capacity(r1cs_shape.num_io + 1, r1cs_shape.num_vars);
+    // TODO: fix this bug in WitnessCS, compare SatisfyingAssignment::new()
+    cs.extend_inputs(&[G::Scalar::ONE]);
+    cs
   }
 }

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,8 +1,23 @@
 //! Support for generating R1CS witness using bellpepper.
 
-use crate::traits::Group;
+use crate::{r1cs::R1CSShape, traits::Group};
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
+use bellpepper_core::ConstraintSystem;
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 pub type SatisfyingAssignment<G> = WitnessCS<<G as Group>::Scalar>;
+
+/// This extension trait is implemented by constraint systems that know how to pre-allocate their internal
+/// storage based on an R1CSShape, which has (among others) a documented count for the number of io variables
+/// the CS should encounter during synthesis.
+pub trait WithShapeBasedPreAllocation<G: Group>: ConstraintSystem<<G as Group>::Scalar> {
+  fn new_from_shape_parameters(r1cs_shape: &R1CSShape<G>) -> Self;
+}
+
+/// SatisfyingAssignment knows how to pre-allocate its internal storage given an R1CSShape.
+impl<G: Group> WithShapeBasedPreAllocation<G> for SatisfyingAssignment<G> {
+  fn new_from_shape_parameters(r1cs_shape: &R1CSShape<G>) -> Self {
+    SatisfyingAssignment::<G>::with_capacity(r1cs_shape.num_io + 1, r1cs_shape.num_vars)
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod supernova;
 
 use once_cell::sync::OnceCell;
 
+use crate::bellpepper::solver::WithShapeBasedPreAllocation;
 use crate::bellpepper::{
   r1cs::{NovaShape, NovaWitness},
   shape_cs::ShapeCS,
@@ -37,7 +38,6 @@ use crate::bellpepper::{
 use crate::digest::{DigestComputer, SimpleDigestible};
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
-use bellpepper_core::ConstraintSystem;
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};
 use core::marker::PhantomData;
@@ -312,7 +312,8 @@ where
     }
 
     // base case for the primary
-    let mut cs_primary = SatisfyingAssignment::<G1>::new();
+    let mut cs_primary =
+      SatisfyingAssignment::<G1>::new_from_shape_parameters(&pp.circuit_shape_primary.r1cs_shape);
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest()),
       G1::Scalar::ZERO,
@@ -339,7 +340,8 @@ where
       .expect("Nova error unsat");
 
     // base case for the secondary
-    let mut cs_secondary = SatisfyingAssignment::<G2>::new();
+    let mut cs_secondary =
+      SatisfyingAssignment::<G2>::new_from_shape_parameters(&pp.circuit_shape_secondary.r1cs_shape);
     let inputs_secondary: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       pp.digest(),
       G2::Scalar::ZERO,
@@ -443,7 +445,8 @@ where
     )
     .expect("Unable to fold secondary");
 
-    let mut cs_primary = SatisfyingAssignment::<G1>::new();
+    let mut cs_primary =
+      SatisfyingAssignment::<G1>::new_from_shape_parameters(&pp.circuit_shape_primary.r1cs_shape);
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest()),
       G1::Scalar::from(self.i as u64),
@@ -483,7 +486,8 @@ where
     )
     .expect("Unable to fold primary");
 
-    let mut cs_secondary = SatisfyingAssignment::<G2>::new();
+    let mut cs_secondary =
+      SatisfyingAssignment::<G2>::new_from_shape_parameters(&pp.circuit_shape_secondary.r1cs_shape);
     let inputs_secondary: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       pp.digest(),
       G2::Scalar::from(self.i as u64),

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -5,7 +5,7 @@ use crate::{
   bellpepper::{
     r1cs::{NovaShape, NovaWitness},
     shape_cs::ShapeCS,
-    solver::SatisfyingAssignment,
+    solver::{SatisfyingAssignment, WithShapeBasedPreAllocation},
   },
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
@@ -121,7 +121,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
   /// Produces a proof of satisfiability of the provided circuit
   pub fn prove(pk: &ProverKey<G, S>, sc: C, z_i: &[G::Scalar]) -> Result<Self, NovaError> {
-    let mut cs = SatisfyingAssignment::<G>::new();
+    let mut cs = SatisfyingAssignment::<G>::new_from_shape_parameters(&pk.S);
 
     let circuit: DirectCircuit<G, C> = DirectCircuit {
       z_i: Some(z_i.to_vec()),

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::ops::Index;
 
 use crate::{
-  bellpepper::shape_cs::ShapeCS,
+  bellpepper::{shape_cs::ShapeCS, solver::WithShapeBasedPreAllocation},
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
   digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
@@ -450,7 +450,9 @@ where
     }
 
     // base case for the primary
-    let mut cs_primary = SatisfyingAssignment::<G1>::new();
+    let mut cs_primary = SatisfyingAssignment::<G1>::new_from_shape_parameters(
+      &pp.circuit_shapes[circuit_index].r1cs_shape,
+    );
     let program_counter = G1::Scalar::from(circuit_index as u64);
     let inputs_primary: SuperNovaAugmentedCircuitInputs<'_, G2> =
       SuperNovaAugmentedCircuitInputs::new(
@@ -491,7 +493,8 @@ where
       })?;
 
     // base case for the secondary
-    let mut cs_secondary = SatisfyingAssignment::<G2>::new();
+    let mut cs_secondary =
+      SatisfyingAssignment::<G2>::new_from_shape_parameters(&pp.circuit_shape_secondary.r1cs_shape);
     let u_primary_index = G2::Scalar::from(circuit_index as u64);
     let inputs_secondary: SuperNovaAugmentedCircuitInputs<'_, G1> =
       SuperNovaAugmentedCircuitInputs::new(


### PR DESCRIPTION
This PR breaks down just one contribution of #118 : pre-allocating the storage of `WtinessCS`.

Lurk gpu benchmark: https://github.com/lurk-lab/lurk-rs/pull/895
