### PR TITLE
Revert "refactor: Refactor R1CS for in-place operations and Vec inputs (#121)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ tracing-texray = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
-vecshard = "0.2.1"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -356,13 +356,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, vars);
+          let res = R1CSWitness::new(&S, &vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, X);
+          let res = R1CSInstance::new(&S, &comm_W, &X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -386,11 +386,11 @@ impl<G: Group> R1CSShape<G> {
 
 impl<G: Group> R1CSWitness<G> {
   /// A method to create a witness object using a vector of scalars
-  pub fn new(S: &R1CSShape<G>, W: Vec<G::Scalar>) -> Result<R1CSWitness<G>, NovaError> {
+  pub fn new(S: &R1CSShape<G>, W: &[G::Scalar]) -> Result<R1CSWitness<G>, NovaError> {
     if S.num_vars != W.len() {
       Err(NovaError::InvalidWitnessLength)
     } else {
-      Ok(R1CSWitness { W })
+      Ok(R1CSWitness { W: W.to_owned() })
     }
   }
 
@@ -405,12 +405,15 @@ impl<G: Group> R1CSInstance<G> {
   pub fn new(
     S: &R1CSShape<G>,
     comm_W: &Commitment<G>,
-    X: Vec<G::Scalar>,
+    X: &[G::Scalar],
   ) -> Result<R1CSInstance<G>, NovaError> {
     if S.num_io != X.len() {
       Err(NovaError::InvalidInputLength)
     } else {
-      Ok(R1CSInstance { comm_W: *comm_W, X })
+      Ok(R1CSInstance {
+        comm_W: *comm_W,
+        X: X.to_owned(),
+      })
     }
   }
 }


### PR DESCRIPTION
This reverts commit fdf82964533186e701784b3128897df031c080e1.

This should allow us to investigate the effects of components of https://github.com/lurk-lab/arecibo/pull/118 without noise. We can re-apply this later if we see it as an improvement.