### PR TITLE
SuperNova: Fix ROM test and remove dead code

### DIFF
--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -68,26 +68,6 @@ pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(mut cs: CS) -> Allocate
   one
 }
 
-/// alloc a field as a constant
-/// implemented refer from <https://github.com/lurk-lab/lurk-rs/blob/4335fbb3290ed1a1176e29428f7daacb47f8033d/src/circuit/gadgets/data.rs#L387-L402>
-#[allow(unused)]
-pub fn alloc_const<F: PrimeField, CS: ConstraintSystem<F>>(
-  mut cs: CS,
-  val: F,
-) -> Result<AllocatedNum<F>, SynthesisError> {
-  let allocated = AllocatedNum::<F>::alloc(cs.namespace(|| "allocate const"), || Ok(val))?;
-
-  // allocated * 1 = val
-  cs.enforce(
-    || "enforce constant",
-    |lc| lc + allocated.get_variable(),
-    |lc| lc + CS::one(),
-    |_| Boolean::Constant(true).lc(CS::one(), val),
-  );
-
-  Ok(allocated)
-}
-
 /// Allocate a scalar as a base. Only to be used if the scalar fits in base!
 pub fn alloc_scalar_as_base<G, CS>(
   mut cs: CS,
@@ -191,47 +171,6 @@ pub fn alloc_num_equals<F: PrimeField, CS: ConstraintSystem<F>>(
     || "r*(a - b) = 0",
     |lc| lc + r.get_variable(),
     |lc| lc + a.get_variable() - b.get_variable(),
-    |lc| lc,
-  );
-
-  Ok(r)
-}
-
-/// Check that two numbers are equal and return a bit
-#[allow(unused)]
-pub fn alloc_num_equals_const<F: PrimeField, CS: ConstraintSystem<F>>(
-  mut cs: CS,
-  a: &AllocatedNum<F>,
-  b: F,
-) -> Result<AllocatedBit, SynthesisError> {
-  // Allocate and constrain `r`: result boolean bit.
-  // It equals `true` if `a` equals `b`, `false` otherwise
-  let r_value = a.get_value().map(|a_val| a_val == b);
-
-  let r = AllocatedBit::alloc(cs.namespace(|| "r"), r_value)?;
-
-  // Allocate t s.t. t=1 if a == b else 1/(a - b)
-
-  let t = AllocatedNum::alloc(cs.namespace(|| "t"), || {
-    let a_val = *a.get_value().get()?;
-    Ok(if a_val == b {
-      F::ONE
-    } else {
-      (a_val - b).invert().unwrap()
-    })
-  })?;
-
-  cs.enforce(
-    || "t*(a - b) = 1 - r",
-    |lc| lc + t.get_variable(),
-    |lc| lc + a.get_variable() - (b, CS::one()),
-    |lc| lc + CS::one() - r.get_variable(),
-  );
-
-  cs.enforce(
-    || "r*(a - b) = 0",
-    |lc| lc + r.get_variable(),
-    |lc| lc + a.get_variable() - (b, CS::one()),
     |lc| lc,
   );
 
@@ -485,31 +424,4 @@ pub fn select_num_or_one<F: PrimeField, CS: ConstraintSystem<F>>(
   );
 
   Ok(c)
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use crate::r1cs::util::FWrap;
-  use bellpepper_core::test_cs::TestConstraintSystem;
-  use pasta_curves::pallas::Scalar as Fr;
-  use proptest::prelude::*;
-
-  proptest! {
-    #[test]
-    fn test_enforce_alloc_num_equal_const((a, b) in any::<(FWrap<Fr>, FWrap<Fr>)>()) {
-      prop_assume!(a != b);
-
-        let test_a_b = |a, b| {
-            let mut cs = TestConstraintSystem::<Fr>::new();
-            let a_num = AllocatedNum::alloc_infallible(cs.namespace(|| "a_num"), || a);
-            let r = alloc_num_equals_const(&mut cs, &a_num, b);
-            assert_eq!(r.unwrap().get_value().unwrap(), a==b);
-        };
-        // negative testing
-        test_a_b(a.0, b.0);
-        // positive testing
-        test_a_b(a.0, a.0);
-    }
-  }
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -404,20 +404,21 @@ where
   let mut recursive_snark_option: Option<RecursiveSNARK<G1, G2>> = None;
 
   for &op_code in test_rom.rom.iter() {
+    let circuit_primary = test_rom.primary_circuit(op_code);
+    let circuit_secondary = test_rom.secondary_circuit();
+
     let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
       RecursiveSNARK::new(
         &pp,
         &test_rom,
-        &test_rom.primary_circuit(op_code),
-        &test_rom.secondary_circuit(),
+        &circuit_primary,
+        &circuit_secondary,
         &z0_primary,
         &z0_secondary,
       )
       .unwrap()
     });
 
-    let circuit_primary = test_rom.primary_circuit(op_code);
-    let circuit_secondary = test_rom.secondary_circuit();
     recursive_snark
       .prove_step(&pp, &circuit_primary, &circuit_secondary)
       .unwrap();

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -619,7 +619,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<G1, G2, _, _, _>(
     &test_rom,
-    "e6b6b796fb32c09d487e07f34967cb146497b4fae85a8e22c151a3aa6aa83602",
+    "7e203fdfeab0ee8f56f8948497f8de73539d52e64cef89e44fff84711cf8b100",
   );
 
   let rom = vec![
@@ -634,7 +634,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _, _>(
     &test_rom_grumpkin,
-    "0faa3a07d225e8f92a0823f93f462abbb34c063fefa500a8fb131c0829b68600",
+    "6f72db6927b6a12e95e1d5237298e1e20f0215b63ef8d76a361930eb76f71003",
   );
 
   let rom = vec![
@@ -649,7 +649,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _, _>(
     &test_rom_secp,
-    "2322ae73400aa1cf488bfb342036f7d1e799c2aad22551ccbdf6c769840a1802",
+    "0c2f7c68efcc5f4c42a25670ea896bc082c9753d04fc2e5b3a41531ed4e91602",
   );
 }
 

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -108,7 +108,6 @@ pub fn get_selector_vec_from_index<F: PrimeField, CS: ConstraintSystem<F>>(
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::gadgets::utils::alloc_const;
   use bellpepper_core::test_cs::TestConstraintSystem;
   use pasta_curves::pallas::{Base, Point};
 
@@ -118,8 +117,9 @@ mod test {
     for selected in 0..(2 * n) {
       let mut cs = TestConstraintSystem::<Base>::new();
 
-      let allocated_target =
-        alloc_const(&mut cs.namespace(|| "target"), Base::from(selected as u64)).unwrap();
+      let allocated_target = AllocatedNum::alloc_infallible(&mut cs.namespace(|| "target"), || {
+        Base::from(selected as u64)
+      });
 
       let selector_vec = get_selector_vec_from_index(&mut cs, &allocated_target, n).unwrap();
 
@@ -153,7 +153,9 @@ mod test {
         let mut cs = TestConstraintSystem::<Base>::new();
 
         let allocated_target =
-          alloc_const(&mut cs.namespace(|| "target"), Base::from(selected as u64)).unwrap();
+          AllocatedNum::alloc_infallible(&mut cs.namespace(|| "target"), || {
+            Base::from(selected as u64)
+          });
 
         let selector_vec = get_selector_vec_from_index(&mut cs, &allocated_target, n).unwrap();
 


### PR DESCRIPTION
The ROM test was broken and not actually doing what it was supposed to. 
In particular:
- The input rom_index was initialized with the first opcode, rather than 0
- `SquareCircuit::synthesize` was checking the next opcode twice
- `constrain_augmented_circuit_index` was not checking what it was supposed to.

This issue was found while trying to remove dead code in PR #120. 