### PR TITLE
Allocation free synthesis

### DIFF
--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -40,15 +40,15 @@ pub trait NovaShape<E: Engine> {
 impl<E: Engine> NovaWitness<E> for SatisfyingAssignment<E> {
   fn r1cs_instance_and_witness(
     &self,
-    shape: &R1CSShape<G>,
-    ck: &CommitmentKey<G>,
-  ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError> {
-    let W = R1CSWitness::<G>::new(shape, self.aux_assignment().to_owned())?;
+    shape: &R1CSShape<E>,
+    ck: &CommitmentKey<E>,
+  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError> {
+    let W = R1CSWitness::<E>::new(shape, self.aux_assignment().to_owned())?;
     let X = self.input_assignment()[1..].to_owned();
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<G>::new(shape, comm_W, X)?;
+    let instance = R1CSInstance::<E>::new(shape, comm_W, X)?;
 
     Ok((instance, W))
   }

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -40,15 +40,15 @@ pub trait NovaShape<E: Engine> {
 impl<E: Engine> NovaWitness<E> for SatisfyingAssignment<E> {
   fn r1cs_instance_and_witness(
     &self,
-    shape: &R1CSShape<E>,
-    ck: &CommitmentKey<E>,
-  ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError> {
-    let W = R1CSWitness::<E>::new(shape, self.aux_assignment())?;
-    let X = &self.input_assignment()[1..];
+    shape: &R1CSShape<G>,
+    ck: &CommitmentKey<G>,
+  ) -> Result<(R1CSInstance<G>, R1CSWitness<G>), NovaError> {
+    let W = R1CSWitness::<G>::new(shape, self.aux_assignment().to_owned())?;
+    let X = self.input_assignment()[1..].to_owned();
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<E>::new(shape, &comm_W, X)?;
+    let instance = R1CSInstance::<G>::new(shape, comm_W, X)?;
 
     Ok((instance, W))
   }

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,8 +1,146 @@
-//! Support for generating R1CS witness using bellpepper.
-
-use crate::traits::Engine;
+use crate::traits::Group;
+use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use ff::PrimeField;
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
-pub type SatisfyingAssignment<E> = WitnessCS<<E as Engine>::Scalar>;
+pub type SatisfyingAssignment<G> = WitnessCS<<G as Group>::Scalar>;
+
+#[derive(Debug, PartialEq, Eq)]
+/// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
+pub struct WitnessViewCS<'a, Scalar>
+where
+  Scalar: PrimeField,
+{
+  // Assignments of variables
+  pub(crate) input_assignment: &'a mut Vec<Scalar>,
+  pub(crate) aux_assignment: &'a mut Vec<Scalar>,
+}
+
+impl<'a, Scalar> ConstraintSystem<Scalar> for WitnessViewCS<'a, Scalar>
+where
+  Scalar: PrimeField,
+{
+  type Root = Self;
+
+  fn new() -> Self {
+    unimplemented!()
+  }
+
+  fn alloc<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+  where
+    F: FnOnce() -> Result<Scalar, SynthesisError>,
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+  {
+    self.aux_assignment.push(f()?);
+
+    Ok(Variable(Index::Aux(self.aux_assignment.len() - 1)))
+  }
+
+  fn alloc_input<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+  where
+    F: FnOnce() -> Result<Scalar, SynthesisError>,
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+  {
+    self.input_assignment.push(f()?);
+
+    Ok(Variable(Index::Input(self.input_assignment.len() - 1)))
+  }
+
+  fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _a: LA, _b: LB, _c: LC)
+  where
+    A: FnOnce() -> AR,
+    AR: Into<String>,
+    LA: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+    LB: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+    LC: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+  {
+    // Do nothing: we don't care about linear-combination evaluations in this context.
+  }
+
+  fn push_namespace<NR, N>(&mut self, _: N)
+  where
+    NR: Into<String>,
+    N: FnOnce() -> NR,
+  {
+    // Do nothing; we don't care about namespaces in this context.
+  }
+
+  fn pop_namespace(&mut self) {
+    // Do nothing; we don't care about namespaces in this context.
+  }
+
+  fn get_root(&mut self) -> &mut Self::Root {
+    self
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Extensible
+  fn is_extensible() -> bool {
+    true
+  }
+
+  /// This should not be used because the whole point of [`WitnessViewCS`] is to
+  /// hold the witness in a external buffer, in which case we shouldn't have
+  /// two [`WitnessViewCS`]s.
+  fn extend(&mut self, _other: &Self) {
+    panic!("WitnessViewCS::extend");
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Witness generator
+  fn is_witness_generator(&self) -> bool {
+    true
+  }
+
+  fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
+    self.input_assignment.extend_from_slice(new_inputs);
+  }
+
+  fn extend_aux(&mut self, new_aux: &[Scalar]) {
+    self.aux_assignment.extend_from_slice(new_aux);
+  }
+
+  fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
+    let allocated_aux = {
+      let i = self.aux_assignment.len();
+      self.aux_assignment.resize(aux_n + i, Scalar::ZERO);
+      &mut self.aux_assignment[i..]
+    };
+
+    let allocated_inputs = {
+      let i = self.input_assignment.len();
+      self.input_assignment.resize(inputs_n + i, Scalar::ZERO);
+      &mut self.input_assignment[i..]
+    };
+
+    (allocated_aux, allocated_inputs)
+  }
+
+  fn inputs_slice(&self) -> &[Scalar] {
+    self.input_assignment
+  }
+
+  fn aux_slice(&self) -> &[Scalar] {
+    self.aux_assignment
+  }
+}
+
+impl<'a, Scalar: PrimeField> WitnessViewCS<'a, Scalar> {
+  pub fn new_view(
+    input_assignment: &'a mut Vec<Scalar>,
+    aux_assignment: &'a mut Vec<Scalar>,
+  ) -> Self {
+    input_assignment.clear();
+    input_assignment.push(Scalar::ONE);
+    aux_assignment.clear();
+
+    Self {
+      input_assignment,
+      aux_assignment,
+    }
+  }
+}

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,11 +1,11 @@
-use crate::traits::Group;
+use crate::traits::Engine;
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use ff::PrimeField;
 
 use bellpepper::util_cs::witness_cs::WitnessCS;
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
-pub type SatisfyingAssignment<G> = WitnessCS<<G as Group>::Scalar>;
+pub type SatisfyingAssignment<E> = WitnessCS<<E as Engine>::Scalar>;
 
 #[derive(Debug, PartialEq, Eq)]
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -347,13 +347,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, &vars);
+          let res = R1CSWitness::new(&S, vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, &X);
+          let res = R1CSInstance::new(&S, comm_W, X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -136,7 +136,7 @@ impl<E: Engine, S: RelaxedR1CSSNARKTrait<E>, C: StepCircuit<E::Scalar>> DirectSN
     // convert the instance and witness to relaxed form
     let (u_relaxed, w_relaxed) = (
       RelaxedR1CSInstance::from_r1cs_instance_unchecked(&u.comm_W, &u.X),
-      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, &w),
+      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, w),
     );
 
     // prove the instance using Spartan

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -527,12 +527,12 @@ where
     let l_w_primary = w_primary;
     let l_u_primary = u_primary;
     let r_W_primary =
-      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, &l_w_primary);
+      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, l_w_primary);
 
     let r_U_primary = RelaxedR1CSInstance::from_r1cs_instance(
       &pp.ck_primary,
       &pp[circuit_index].r1cs_shape,
-      &l_u_primary,
+      l_u_primary,
     );
 
     // IVC proof of the secondary circuit


### PR DESCRIPTION
Addresses #137.

This PR introduces `WitnessViewCS`, a slightly modified version of `WitnessCS` that does not own the witness buffers. Instead, we have `RecursiveSNARK` own the witness buffers, and `WitnessViewCS` takes mutable handles into those buffers. 

By allowing `RecursiveSNARK` to directly manage its own witness memory, we remove the extra allocations `WitnessCS` demands. 

Benchmark results from downstream `lurk-rs` confirm that this improves performance: https://github.com/lurk-lab/lurk-rs/pull/922

## Pasted Benchmark
  <details>
    <summary>Click to view benchmark</summary>

| Test | Base         | PR               | % |
|------|--------------|------------------|---|
| LEM Fibonacci Prove - rc = 100/fib/num-100 | 6.0±0.06s | **5.6±0.04s** | **-6.67%** |
| LEM Fibonacci Prove - rc = 100/fib/num-200 | 12.4±0.07s | **12.0±0.04s** | **-3.23%** |
| LEM Fibonacci Prove - rc = 600/fib/num-100 | 5.3±0.06s | N/A | N/A |
| LEM Fibonacci Prove - rc = 600/fib/num-200 | 12.1±0.04s | N/A | N/A |

  </details>
  