### PR TITLE
Fix Batched SNARK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-texray = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
+itertools = "0.12.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -20,11 +20,15 @@ use super::{
   sumcheck::SumcheckProof,
   PolyEvalInstance, PolyEvalWitness,
 };
+
 use crate::{
   digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness, SparseMatrix},
-  spartan::{polys::multilinear::SparsePolynomial, snark::batch_eval_verify},
+  spartan::{
+    polys::{multilinear::SparsePolynomial, power::PowPolynomial},
+    snark::batch_eval_verify,
+  },
   traits::{
     evaluation::EvaluationEngineTrait,
     snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait},
@@ -127,6 +131,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
     U: &[RelaxedR1CSInstance<G>],
     W: &[RelaxedR1CSWitness<G>],
   ) -> Result<Self, NovaError> {
+    let num_instances = U.len();
     // Pad shapes and ensure their sizes are correct
     let S = S
       .iter()
@@ -154,94 +159,56 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       transcript.absorb(b"U", u);
     });
 
-    let (W_polys, E_polys): (Vec<_>, Vec<_>) = W
-      .into_iter()
-      .map(|w| {
-        (
-          MultilinearPolynomial::new(w.W),
-          MultilinearPolynomial::new(w.E),
-        )
-      })
-      .unzip();
+    let (polys_W, polys_E): (Vec<_>, Vec<_>) = W.into_iter().map(|w| (w.W, w.E)).unzip();
 
     // Append public inputs to W: Z = [W, u, X]
-    let z = W_polys
+    let polys_Z = polys_W
       .iter()
       .zip(U.iter())
-      .map(|(w, u)| [w.Z.clone(), vec![u.u], u.X.clone()].concat())
+      .map(|(w, u)| [w.clone(), vec![u.u], u.X.clone()].concat())
       .collect::<Vec<Vec<_>>>();
 
-    let (num_vars_x, num_vars_y): (Vec<_>, Vec<_>) = S
+    let (num_rounds_x, num_rounds_y): (Vec<_>, Vec<_>) = S
       .iter()
       .map(|s| (s.num_cons.log_2(), s.num_vars.log_2() + 1))
       .unzip();
-    let num_rounds_x = *num_vars_x.iter().max().unwrap();
-    let num_rounds_y = *num_vars_y.iter().max().unwrap();
+    let num_rounds_x_max = num_rounds_x.iter().cloned().max().unwrap();
+    let num_rounds_y_max = num_rounds_y.iter().cloned().max().unwrap();
 
     // Generate tau polynomial corresponding to eq(τ, τ², τ⁴ , …)
     // for a random challenge τ
-    let mut poly_tau = {
-      let mut tau = transcript.squeeze(b"t")?;
-
-      // The MLE of eq(τ, τ², τ⁴ , …) is a polynomial whose evaluations are
-      // (1, τ, τ², τ³, …)
-      let tau_vars = (0..num_rounds_x)
-        .map(|_| {
-          let t = tau;
-          tau = tau.square();
-          t
-        })
-        .collect::<Vec<_>>();
-
-      Ok(MultilinearPolynomial::new(
-        EqPolynomial::new(tau_vars).evals(),
-      ))
-    }?;
+    let tau = transcript.squeeze(b"t")?;
+    let polys_tau = num_rounds_x
+      .iter()
+      .map(|&num_rounds_x| PowPolynomial::new(&tau, num_rounds_x))
+      .collect::<Vec<_>>();
 
     // Compute MLEs of Az, Bz, Cz, uCz + E
-    let (mut vec_poly_Az, mut vec_poly_Bz, vec_poly_Cz, mut vec_poly_uCz_E) = {
-      let (vec_poly_Az, vec_poly_Bz, vec_poly_Cz) = S.iter().zip(z.iter()).fold(
-        (vec![], vec![], vec![]),
-        |(mut vec_A, mut vec_B, mut vec_C), (s, z)| {
-          let (poly_Az, poly_Bz, poly_Cz) = s.multiply_vec(z).unwrap();
-          vec_A.push(poly_Az);
-          vec_B.push(poly_Bz);
-          vec_C.push(poly_Cz);
-          (vec_A, vec_B, vec_C)
-        },
-      );
+    let (polys_Az_Bz, polys_Cz): (Vec<_>, Vec<_>) = S
+      .par_iter()
+      .zip(polys_Z.par_iter())
+      .map(|(s, poly_Z)| {
+        let (poly_Az, poly_Bz, poly_Cz) = s.multiply_vec(poly_Z)?;
+        Ok(((poly_Az, poly_Bz), poly_Cz))
+      })
+      .collect::<Result<Vec<_>, _>>()?
+      .into_iter()
+      .unzip();
 
-      let vec_poly_uCz_E = S
-        .iter()
-        .zip(U.iter())
-        .zip(E_polys.iter())
-        .zip(vec_poly_Cz.iter())
-        .map(|(((s, u), e), poly_Cz)| {
-          (0..s.num_cons)
-            .map(|i| u.u * poly_Cz[i] + e[i])
-            .collect::<Vec<G::Scalar>>()
-        })
-        .collect::<Vec<_>>();
+    let (polys_Az, polys_Bz): (Vec<_>, Vec<_>) = polys_Az_Bz.into_iter().unzip();
 
-      (
-        vec_poly_Az
-          .into_iter()
-          .map(MultilinearPolynomial::new)
-          .collect::<Vec<_>>(),
-        vec_poly_Bz
-          .into_iter()
-          .map(MultilinearPolynomial::new)
-          .collect::<Vec<_>>(),
-        vec_poly_Cz
-          .into_iter()
-          .map(MultilinearPolynomial::new)
-          .collect::<Vec<_>>(),
-        vec_poly_uCz_E
-          .into_iter()
-          .map(MultilinearPolynomial::new)
-          .collect::<Vec<_>>(),
-      )
-    };
+    let polys_uCz_E = U
+      .par_iter()
+      .zip(polys_E.par_iter())
+      .zip(polys_Cz.par_iter())
+      .map(|((u, poly_E), poly_Cz)| {
+        poly_Cz
+          .par_iter()
+          .zip(poly_E.par_iter())
+          .map(|(cz, e)| u.u * cz + e)
+          .collect::<Vec<G::Scalar>>()
+      })
+      .collect::<Vec<_>>();
 
     let comb_func_outer =
       |poly_A_comp: &G::Scalar,
@@ -254,165 +221,215 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
     let outer_r = transcript.squeeze(b"out_r")?;
     let outer_r_powers = powers::<G>(&outer_r, S.len());
 
-    // Verify outer sumcheck: Az * Bz * Cz - uCz_E for each instance
-    let (sc_proof_outer, r_x, _claim_tau, claims_outer): (
-      SumcheckProof<G>,
-      Vec<G::Scalar>,
-      G::Scalar,
-      Vec<_>,
-    ) = SumcheckProof::prove_cubic_with_additive_term_batch(
-      &G::Scalar::ZERO,
-      num_rounds_x,
-      &mut poly_tau,
-      &mut vec_poly_Az,
-      &mut vec_poly_Bz,
-      &mut vec_poly_uCz_E,
+    // Verify outer sumcheck: Az * Bz - uCz_E for each instance
+    let (sc_proof_outer, r_x, claims_outer) = SumcheckProof::prove_cubic_with_additive_term_batch(
+      &vec![G::Scalar::ZERO; num_instances],
+      &num_rounds_x,
+      polys_tau
+        .iter()
+        .map(PowPolynomial::evals)
+        .map(MultilinearPolynomial::new)
+        .collect(),
+      polys_Az
+        .iter()
+        .cloned()
+        .map(MultilinearPolynomial::new)
+        .collect(),
+      polys_Bz
+        .iter()
+        .cloned()
+        .map(MultilinearPolynomial::new)
+        .collect(),
+      polys_uCz_E
+        .iter()
+        .cloned()
+        .map(MultilinearPolynomial::new)
+        .collect(),
       &outer_r_powers,
       comb_func_outer,
       &mut transcript,
     )?;
+    assert_eq!(num_rounds_x_max, r_x.len());
 
-    // Extract evaluations of Az, Bz from Sumcheck and E at r_x
-    let (claims_Az, claims_Bz, claims_Cz) = (
-      claims_outer[0].clone(),
-      claims_outer[1].clone(),
-      vec_poly_Cz
-        .iter()
-        .map(|poly| poly.evaluate(&r_x))
-        .collect::<Vec<_>>(),
-    );
-
-    let evals_E = E_polys.iter().map(|e| e.evaluate(&r_x)).collect::<Vec<_>>();
-
-    claims_Az
+    let r_x = num_rounds_x
       .iter()
-      .zip(claims_Bz.iter())
-      .zip(claims_Cz.iter())
-      .zip(evals_E.iter())
-      .for_each(|(((&claim_Az, &claim_Bz), &claim_Cz), &eval_E)| {
+      .map(|&num_rounds| r_x[(num_rounds_x_max - num_rounds)..].to_vec())
+      .collect::<Vec<_>>();
+
+    // DEBUG
+    for ((eval, poly), r_x) in claims_outer[1].iter().zip(polys_Az.iter()).zip(r_x.iter()) {
+      assert_eq!(*eval, MultilinearPolynomial::evaluate_with(poly, r_x));
+    }
+    for ((eval, poly), r_x) in claims_outer[2].iter().zip(polys_Bz.iter()).zip(r_x.iter()) {
+      assert_eq!(*eval, MultilinearPolynomial::evaluate_with(poly, r_x));
+    }
+
+    // Extract evaluations of Az, Bz from Sumcheck and Cz, E at r_x
+    let (evals_Az_Bz_Cz, evals_E): (Vec<_>, Vec<_>) = claims_outer[1]
+      .par_iter()
+      .zip(claims_outer[2].par_iter())
+      .zip(polys_Cz.par_iter())
+      .zip(polys_E.par_iter())
+      .zip(r_x.par_iter())
+      .map(|((((&eval_Az, &eval_Bz), poly_Cz), poly_E), r_x)| {
+        let (eval_Cz, eval_E) = rayon::join(
+          || MultilinearPolynomial::evaluate_with(poly_Cz, r_x),
+          || MultilinearPolynomial::evaluate_with(poly_E, r_x),
+        );
+        ([eval_Az, eval_Bz, eval_Cz], eval_E)
+      })
+      .unzip();
+
+    evals_Az_Bz_Cz.iter().zip(evals_E.iter()).for_each(
+      |(&[eval_Az, eval_Bz, eval_Cz], &eval_E)| {
         transcript.absorb(
           b"claims_outer",
-          &[claim_Az, claim_Bz, claim_Cz, eval_E].as_slice(),
+          &[eval_Az, eval_Bz, eval_Cz, eval_E].as_slice(),
         )
-      });
+      },
+    );
 
     let inner_r = transcript.squeeze(b"in_r")?;
     let inner_r_square = inner_r.square();
     let inner_r_cube = inner_r_square * inner_r;
     let inner_r_powers = powers::<G>(&inner_r_cube, S.len());
 
-    let claim_inner_joint = inner_r_powers
+    let claims_inner_joint = evals_Az_Bz_Cz
       .iter()
-      .zip(claims_Az.iter())
-      .zip(claims_Bz.iter())
-      .zip(claims_Cz.iter())
-      .fold(
-        G::Scalar::ZERO,
-        |acc, (((r_i, claim_Az), claim_Bz), claim_Cz)| {
-          acc + *r_i * (*claim_Az + inner_r * claim_Bz + inner_r * inner_r * claim_Cz)
-        },
-      );
+      .map(|[eval_Az, eval_Bz, eval_Cz]| *eval_Az + inner_r * eval_Bz + inner_r_square * eval_Cz)
+      .collect::<Vec<_>>();
 
-    let mut poly_ABCs = {
-      let evals_rx = EqPolynomial::new(r_x.clone()).evals();
-
-      let (evals_As, evals_Bs, evals_Cs) = S.iter().fold(
-        (vec![], vec![], vec![]),
-        |(mut acc_A, mut acc_B, mut acc_C), s| {
-          let mut truncated_evals_rx = evals_rx.clone();
-          truncated_evals_rx.truncate(s.num_cons);
-          let (evals_A, evals_B, evals_C) = compute_eval_table_sparse(s, &truncated_evals_rx); // TODO: Truncate
-          acc_A.push(evals_A);
-          acc_B.push(evals_B);
-          acc_C.push(evals_C);
-          (acc_A, acc_B, acc_C)
-        },
-      );
-
+    let polys_ABCs = {
       let inner = |M_evals_As: Vec<G::Scalar>,
                    M_evals_Bs: Vec<G::Scalar>,
                    M_evals_Cs: Vec<G::Scalar>|
        -> Vec<G::Scalar> {
         M_evals_As
-          .into_iter()
-          .zip(M_evals_Bs)
-          .zip(M_evals_Cs)
+          .into_par_iter()
+          .zip(M_evals_Bs.into_par_iter())
+          .zip(M_evals_Cs.into_par_iter())
           .map(|((eval_A, eval_B), eval_C)| eval_A + inner_r * eval_B + inner_r_square * eval_C)
           .collect::<Vec<_>>()
       };
 
-      evals_As
-        .into_iter()
-        .zip(evals_Bs)
-        .zip(evals_Cs)
-        .map(|((eval_A, eval_B), eval_C)| MultilinearPolynomial::new(inner(eval_A, eval_B, eval_C)))
+      S.par_iter()
+        .zip(r_x.par_iter())
+        .map(|(s, r_x)| {
+          let evals_rx = EqPolynomial::new(r_x.clone()).evals();
+          let (eval_A, eval_B, eval_C) = compute_eval_table_sparse(s, &evals_rx);
+          MultilinearPolynomial::new(inner(eval_A, eval_B, eval_C))
+        })
         .collect::<Vec<_>>()
     };
 
-    let mut poly_zs = z
+    let polys_Z = polys_Z
       .into_iter()
-      .zip(S.iter())
-      .map(|(mut z, s)| {
-        z.resize(2 * s.num_vars, G::Scalar::ZERO);
+      .zip(num_rounds_y.iter())
+      .map(|(mut z, &num_rounds_y)| {
+        z.resize(1 << num_rounds_y, G::Scalar::ZERO);
         MultilinearPolynomial::new(z)
       })
       .collect::<Vec<_>>();
+
+    // DEBUG
+    for ((poly_Mz, poly_Z), claim) in polys_ABCs
+      .iter()
+      .zip(polys_Z.iter())
+      .zip(claims_inner_joint.iter())
+    {
+      let claim_expected = poly_Mz
+        .Z
+        .par_iter()
+        .zip(poly_Z.Z.par_iter())
+        .map(|(a, b)| *a * b)
+        .sum::<G::Scalar>();
+      assert_eq!(*claim, claim_expected);
+    }
 
     let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
       *poly_A_comp * *poly_B_comp
     };
 
-    let (sc_proof_inner, r_y, _claims_inner): (SumcheckProof<G>, Vec<G::Scalar>, (Vec<_>, Vec<_>)) =
+    let (sc_proof_inner, r_y, claims_inner): (SumcheckProof<G>, Vec<G::Scalar>, (Vec<_>, Vec<_>)) =
       SumcheckProof::prove_quad_batch(
-        &claim_inner_joint,
-        num_rounds_y,
-        &mut poly_ABCs,
-        &mut poly_zs,
+        &claims_inner_joint,
+        &num_rounds_y,
+        polys_ABCs.clone(), //TODO
+        polys_Z.clone(),    // TODO
         &inner_r_powers,
         comb_func,
         &mut transcript,
       )?;
 
-    let evals_W = W_polys
+    let r_y = num_rounds_y
       .iter()
-      .map(|w| w.evaluate(&r_y[1..]))
+      .map(|num_rounds| {
+        let (_, r_y_hi) = r_y.split_at(num_rounds_y_max - num_rounds);
+        r_y_hi
+      })
+      .collect::<Vec<_>>();
+
+    // DEBUG
+    for ((eval, poly), r_y) in claims_inner.0.iter().zip(polys_ABCs.iter()).zip(r_y.iter()) {
+      assert_eq!(*eval, MultilinearPolynomial::evaluate_with(&poly.Z, r_y));
+    }
+    for ((eval, poly), r_y) in claims_inner.1.iter().zip(polys_Z.iter()).zip(r_y.iter()) {
+      assert_eq!(*eval, MultilinearPolynomial::evaluate_with(&poly.Z, r_y));
+    }
+
+    let evals_W = polys_W
+      .par_iter()
+      .zip(r_y.par_iter())
+      .map(|(poly, r_y)| MultilinearPolynomial::evaluate_with(poly, &r_y[1..]))
       .collect::<Vec<_>>();
 
     // Create evaluation instances for W(r_y[1..]) and E(r_x)
-    let (w_vec, u_vec) = {
-      let mut w_vec = Vec::with_capacity(2 * S.len());
-      let mut u_vec = Vec::with_capacity(2 * S.len());
-      w_vec.extend(
-        W_polys
-          .into_iter()
-          .map(|poly| PolyEvalWitness { p: poly.Z }),
-      );
-      u_vec.extend(evals_W.iter().zip(U.iter()).zip(num_vars_y.iter()).map(
-        |((&eval, u), &num_vars)| PolyEvalInstance {
-          c: u.comm_W,
-          x: r_y[1..num_vars].to_vec(),
-          e: eval,
-        },
-      ));
+    let (w_vec, u_vec) =
+      {
+        let mut w_vec = Vec::with_capacity(2 * S.len());
+        let mut u_vec = Vec::with_capacity(2 * S.len());
+        w_vec.extend(polys_W.into_iter().map(|poly| PolyEvalWitness { p: poly }));
+        u_vec.extend(
+          evals_W
+            .iter()
+            .zip(U.iter())
+            .zip(r_y)
+            .map(|((&eval, u), r_y)| PolyEvalInstance {
+              c: u.comm_W,
+              x: r_y[1..].to_vec(),
+              e: eval,
+            }),
+        );
 
-      w_vec.extend(
-        E_polys
-          .into_iter()
-          .map(|poly| PolyEvalWitness { p: poly.Z }),
+        w_vec.extend(polys_E.into_iter().map(|poly| PolyEvalWitness { p: poly }));
+        u_vec.extend(evals_E.iter().zip(U.iter()).zip(r_x.into_iter()).map(
+          |((eval_E, u), r_x)| PolyEvalInstance {
+            c: u.comm_E,
+            x: r_x,
+            e: *eval_E,
+          },
+        ));
+        (w_vec, u_vec)
+      };
+
+    for (i, (w, u)) in w_vec.iter().zip(u_vec.iter()).enumerate() {
+      assert_eq!(
+        u.e,
+        MultilinearPolynomial::evaluate_with(&w.p, &u.x),
+        "{}",
+        i
       );
-      u_vec.extend(evals_E.iter().zip(U.iter()).zip(num_vars_x.iter()).map(
-        |((&eval, u), &num_vars)| PolyEvalInstance {
-          c: u.comm_E,
-          x: r_x[..num_vars].to_vec(),
-          e: eval,
-        },
-      ));
-      (w_vec, u_vec)
-    };
+    }
 
     let (batched_u, batched_w, sc_proof_batch, claims_batch_left) =
       batch_eval_prove(u_vec, w_vec, &mut transcript)?;
+    assert_eq!(
+      batched_u.e,
+      MultilinearPolynomial::evaluate_with(&batched_w.p, &batched_u.x),
+    );
 
+    let t = transcript.squeeze(b"t")?;
+    println!("t: {:?}", t);
     let eval_arg = EE::prove(
       ck,
       &pk.pk_ee,
@@ -423,9 +440,15 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       &batched_u.e,
     )?;
 
+    let (evals_Az_Bz, evals_Cz): (Vec<_>, Vec<_>) = evals_Az_Bz_Cz
+      .into_iter()
+      .map(|[eval_Az, eval_Bz, eval_Cz]| ((eval_Az, eval_Bz), eval_Cz))
+      .unzip();
+    let (evals_Az, evals_Bz): (Vec<_>, Vec<_>) = evals_Az_Bz.into_iter().unzip();
+
     Ok(BatchedRelaxedR1CSSNARK {
       sc_proof_outer,
-      claims_outer: (claims_Az, claims_Bz, claims_Cz),
+      claims_outer: (evals_Az, evals_Bz, evals_Cz),
       evals_E,
       sc_proof_inner,
       evals_W,
@@ -443,38 +466,35 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       transcript.absorb(b"U", u);
     });
 
-    let (num_vars_x, num_vars_y): (Vec<_>, Vec<_>) = vk
+    let (num_rounds_x, num_rounds_y): (Vec<_>, Vec<_>) = vk
       .S
       .iter()
       .map(|s| (s.num_cons.log_2(), s.num_vars.log_2() + 1))
       .unzip();
-    let num_rounds_x = *num_vars_x.iter().max().unwrap();
-    let num_rounds_y = *num_vars_y.iter().max().unwrap();
+    let num_rounds_x_max = num_rounds_x.iter().cloned().max().unwrap();
+    let num_rounds_y_max = num_rounds_y.iter().cloned().max().unwrap();
 
-    let tau_poly = {
-      let mut tau = transcript.squeeze(b"t")?;
+    let polys_tau = {
+      let tau = transcript.squeeze(b"t")?;
 
-      // The MLE of eq(τ, τ², τ⁴ , …) is a polynomial whose evaluations are
-      // (1, τ, τ², τ³, …)
-      let tau_vars = (0..num_rounds_x)
-        .map(|_| {
-          let t = tau;
-          tau = tau.square();
-          t
-        })
-        .collect::<Vec<_>>();
-
-      Ok(EqPolynomial::new(tau_vars))
-    }?;
+      num_rounds_x
+        .iter()
+        .map(|&num_rounds| PowPolynomial::new(&tau, num_rounds))
+        .collect::<Vec<_>>()
+    };
 
     // Sample challenge for random linear-combination of outer claims
     let outer_r = transcript.squeeze(b"out_r")?;
-    let coeffs = powers::<G>(&outer_r, vk.S.len());
+    let outer_r_powers = powers::<G>(&outer_r, vk.S.len());
 
     let (claim_outer_final, r_x) =
       self
         .sc_proof_outer
-        .verify(G::Scalar::ZERO, num_rounds_x, 3, &mut transcript)?;
+        .verify(G::Scalar::ZERO, num_rounds_x_max, 3, &mut transcript)?;
+    let r_x = num_rounds_x
+      .iter()
+      .map(|num_rounds| r_x[(num_rounds_x_max - num_rounds)..].to_vec())
+      .collect::<Vec<_>>();
 
     // Extract evaluations into a vector [(Azᵢ, Bzᵢ, Czᵢ, Eᵢ)]
     let ABCE_evals = self
@@ -498,19 +518,23 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       });
 
     // Evaluate τ(rₓ)
-    let tau_eval = tau_poly.evaluate(&r_x);
+    let evals_tau = polys_tau
+      .iter()
+      .zip(r_x.iter())
+      .map(|(poly_tau, r_x)| poly_tau.evaluate(r_x))
+      .collect::<Vec<_>>();
 
     // Compute expected claim τ(rₓ)⋅∑ᵢ rⁱ⋅(Azᵢ⋅Bzᵢ − uᵢ⋅Czᵢ − Eᵢ)
-    let claim_outer_final_expected = tau_eval
-      * ABCE_evals
-        .iter()
-        .zip(U.iter())
-        .map(|((claim_Az, claim_Bz, claim_Cz, eval_E), u)| {
-          *claim_Az * claim_Bz - u.u * claim_Cz - eval_E
-        })
-        .zip(coeffs.iter())
-        .map(|(claim, coeff)| claim * coeff)
-        .sum::<G::Scalar>();
+    let claim_outer_final_expected = ABCE_evals
+      .iter()
+      .zip(U.iter())
+      .zip(evals_tau.into_iter())
+      .map(|(((claim_Az, claim_Bz, claim_Cz, eval_E), u), eval_tau)| {
+        eval_tau * (*claim_Az * claim_Bz - u.u * claim_Cz - eval_E)
+      })
+      .zip(outer_r_powers.iter())
+      .map(|(eval, r)| eval * r)
+      .sum::<G::Scalar>();
 
     if claim_outer_final != claim_outer_final_expected {
       return Err(NovaError::InvalidSumcheckProof);
@@ -527,13 +551,22 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       .map(|(claim_Az, claim_Bz, claim_Cz, _)| {
         *claim_Az + inner_r * *claim_Bz + inner_r_square * *claim_Cz
       })
+      .zip(num_rounds_y.iter())
+      .map(|(eval, num_rounds)| {
+        let scaling = 1 << (num_rounds_y_max - num_rounds);
+        eval * G::Scalar::from(scaling as u64)
+      })
       .zip(inner_r_powers.iter())
       .fold(G::Scalar::ZERO, |acc, (claim, r_i)| acc + claim * r_i);
 
     let (claim_inner_final, r_y) =
       self
         .sc_proof_inner
-        .verify(claim_inner_joint, num_rounds_y, 2, &mut transcript)?;
+        .verify(claim_inner_joint, num_rounds_y_max, 2, &mut transcript)?;
+    let r_y: Vec<Vec<G::Scalar>> = num_rounds_y
+      .iter()
+      .map(|num_rounds| r_y[(num_rounds_y_max - num_rounds)..].to_vec())
+      .collect();
 
     // Compute evaluations of Zᵢ = [Wᵢ, uᵢ, Xᵢ] at r_y
     // Zᵢ(r_y) = (1−r_y[0])⋅W(r_y[1..]) + r_y[0]⋅MLE([uᵢ, Xᵢ])(r_y[1..])
@@ -541,8 +574,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       .evals_W
       .iter()
       .zip(U.iter())
-      .zip(num_vars_y.iter())
-      .map(|((eval_W, U), &num_vars)| {
+      .zip(r_y.iter())
+      .map(|((eval_W, U), r_y)| {
         let eval_X = {
           // constant term
           let mut poly_X = vec![(0, U.u)];
@@ -554,7 +587,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
               .map(|(i, x_i)| (i + 1, *x_i))
               .collect::<Vec<(usize, G::Scalar)>>(),
           );
-          SparsePolynomial::new(num_vars - 1, poly_X).evaluate(&r_y[1..num_vars])
+          SparsePolynomial::new(r_y.len() - 1, poly_X).evaluate(&r_y[1..])
         };
         (G::Scalar::ONE - r_y[0]) * eval_W + r_y[0] * eval_X
       })
@@ -583,9 +616,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
         || EqPolynomial::new(r_y.to_vec()).evals(),
       );
 
-      (0..M_vec.len())
-        .into_par_iter()
-        .map(|i| evaluate_with_table(M_vec[i], &T_x, &T_y))
+      M_vec
+        .par_iter()
+        .map(|&M_vec| evaluate_with_table(M_vec, &T_x, &T_y))
         .collect()
     };
 
@@ -593,16 +626,15 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
     let claim_inner_final_expected = vk
       .S
       .iter()
-      .zip(num_vars_x.iter().zip(num_vars_y.iter()))
-      .map(|(S, (&vars_x, &vars_y))| {
-        let evals = multi_evaluate(&[&S.A, &S.B, &S.C], &r_x[..vars_x], &r_y[..vars_y]);
+      .zip(r_x.iter().zip(r_y.iter()))
+      .map(|(S, (r_x, r_y))| {
+        let evals = multi_evaluate(&[&S.A, &S.B, &S.C], &r_x, &r_y);
         evals[0] + inner_r * evals[1] + inner_r_square * evals[2]
       })
       .zip(evals_Z.iter())
       .zip(inner_r_powers.iter())
-      .fold(G::Scalar::ZERO, |acc, ((eval, r_i), eval_Z)| {
-        acc + eval * r_i * eval_Z
-      });
+      .map(|((eval, eval_Z), r_i)| eval * r_i * eval_Z)
+      .sum::<G::Scalar>();
 
     if claim_inner_final != claim_inner_final_expected {
       return Err(NovaError::InvalidSumcheckProof);
@@ -616,10 +648,10 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
           .evals_W
           .iter()
           .zip(U.iter())
-          .zip(num_vars_y.iter())
-          .map(|((&eval, u), &num_vars)| PolyEvalInstance {
+          .zip(r_y.iter())
+          .map(|((&eval, u), r_y)| PolyEvalInstance {
             c: u.comm_W,
-            x: r_y[1..num_vars].to_vec(),
+            x: r_y[1..].to_vec(),
             e: eval,
           }),
       );
@@ -629,10 +661,10 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
           .evals_E
           .iter()
           .zip(U.iter())
-          .zip(num_vars_x.iter())
-          .map(|((&eval, u), &num_vars)| PolyEvalInstance {
+          .zip(r_x.iter())
+          .map(|((&eval, u), r_x)| PolyEvalInstance {
             c: u.comm_E,
-            x: r_x[..num_vars].to_vec(),
+            x: r_x.to_vec(),
             e: eval,
           }),
       );
@@ -645,6 +677,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
       &self.sc_proof_batch,
       &self.evals_batch,
     )?;
+
+    let t = transcript.squeeze(b"t")?;
+    println!("t: {:?}", t);
 
     // verify
     EE::verify(

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -38,29 +38,20 @@ pub struct PolyEvalWitness<G: Group> {
 }
 
 impl<G: Group> PolyEvalWitness<G> {
-  // fn pad(W: &[PolyEvalWitness<G>]) -> Vec<PolyEvalWitness<G>> {
-  //   // determine the maximum size
-  //   if let Some(n) = W.iter().map(|w| w.p.len()).max() {
-  //     W.iter()
-  //       .map(|w| {
-  //         let mut p = vec![G::Scalar::ZERO; n];
-  //         p[..w.p.len()].copy_from_slice(&w.p);
-  //         PolyEvalWitness { p }
-  //       })
-  //       .collect()
-  //   } else {
-  //     Vec::new()
-  //   }
-  // }
-
-  fn weighted_sum(W: Vec<PolyEvalWitness<G>>, s: &[G::Scalar]) -> PolyEvalWitness<G> {
-    assert_eq!(W.len(), s.len());
+  /// Given [Pᵢ] and [sᵢ], compute P = ∑ᵢ sᵢ⋅Pᵢ
+  ///
+  /// # Details
+  ///
+  /// We allow the input polynomials to have different sizes, and interpret smaller ones as
+  /// being padded with 0 to the maximum size of all polynomials.
+  fn batch_diff_size(W: Vec<PolyEvalWitness<G>>, s: G::Scalar) -> PolyEvalWitness<G> {
+    let powers = powers::<G>(&s, W.len());
 
     let size_max = W.iter().map(|w| w.p.len()).max().unwrap();
 
     let p = W
       .into_par_iter()
-      .zip(s.par_iter())
+      .zip(powers.par_iter())
       .map(|(mut w, s)| {
         w.p.par_iter_mut().for_each(|e| *e *= s);
         w.p
@@ -68,6 +59,7 @@ impl<G: Group> PolyEvalWitness<G> {
       .reduce(
         || vec![G::Scalar::ZERO; size_max],
         |left, right| {
+          // Sum into the largest polynomial
           let (mut big, small) = if left.len() > right.len() {
             (left, right)
           } else {
@@ -121,20 +113,59 @@ pub struct PolyEvalInstance<G: Group> {
 }
 
 impl<G: Group> PolyEvalInstance<G> {
-  // fn pad(U: &[PolyEvalInstance<G>]) -> Vec<PolyEvalInstance<G>> {
-  //   // determine the maximum size
-  //   if let Some(ell) = U.iter().map(|u| u.x.len()).max() {
-  //     U.iter()
-  //       .map(|u| {
-  //         let mut x = vec![G::Scalar::ZERO; ell - u.x.len()];
-  //         x.extend(u.x.clone());
-  //         PolyEvalInstance { c: u.c, x, e: u.e }
-  //       })
-  //       .collect()
-  //   } else {
-  //     Vec::new()
-  //   }
-  // }
+  fn batch_diff_size(
+    c_vec: &[Commitment<G>],
+    e_vec: &[G::Scalar],
+    num_vars: &[usize],
+    x: Vec<G::Scalar>,
+    s: G::Scalar,
+  ) -> PolyEvalInstance<G> {
+    let num_instances = num_vars.len();
+    assert_eq!(c_vec.len(), num_instances);
+    assert_eq!(e_vec.len(), num_instances);
+
+    let num_vars_max = x.len();
+    let powers: Vec<G::Scalar> = powers::<G>(&s, num_instances);
+    // Rescale evaluations by the first Lagrange polynomial,
+    // so that we can check its evaluation against x
+    let evals_scaled = e_vec
+      .iter()
+      .zip(num_vars.iter())
+      .map(|(eval, num_rounds)| {
+        // x_lo = [ x[0]   , ..., x[n-nᵢ-1] ]
+        // x_hi = [ x[n-nᵢ], ..., x[n]      ]
+        let (r_lo, _r_hi) = x.split_at(num_vars_max - num_rounds);
+        // Compute L₀(x_lo)
+        let lagrange_eval = r_lo
+          .iter()
+          .map(|r| G::Scalar::ONE - r)
+          .product::<G::Scalar>();
+
+        // vᵢ = L₀(x_lo)⋅Pᵢ(x_hi)
+        lagrange_eval * eval
+      })
+      .collect::<Vec<_>>();
+
+    // C = ∑ᵢ γⁱ⋅Cᵢ
+    let comm_joint = c_vec
+      .iter()
+      .zip(powers.iter())
+      .map(|(c, g_i)| *c * *g_i)
+      .fold(Commitment::<G>::default(), |acc, item| acc + item);
+
+    // v = ∑ᵢ γⁱ⋅vᵢ
+    let eval_joint = evals_scaled
+      .into_iter()
+      .zip(powers.iter())
+      .map(|(e, g_i)| e * g_i)
+      .sum();
+
+    PolyEvalInstance {
+      c: comm_joint,
+      x,
+      e: eval_joint,
+    }
+  }
 
   fn batch(
     c_vec: &[Commitment<G>],
@@ -142,12 +173,17 @@ impl<G: Group> PolyEvalInstance<G> {
     e_vec: &[G::Scalar],
     s: &G::Scalar,
   ) -> PolyEvalInstance<G> {
-    let powers_of_s = powers::<G>(s, c_vec.len());
+    let num_instances = c_vec.len();
+    assert_eq!(e_vec.len(), num_instances);
+
+    let powers_of_s = powers::<G>(s, num_instances);
+    // Weighted sum of evaluations
     let e = e_vec
       .par_iter()
       .zip(powers_of_s.par_iter())
       .map(|(e, p)| *e * p)
       .sum();
+    // Weighted sum of commitments
     let c = c_vec
       .par_iter()
       .zip(powers_of_s.par_iter())

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -48,12 +48,14 @@ impl<G: Group> PolyEvalWitness<G> {
     let powers = powers::<G>(&s, W.len());
 
     let size_max = W.iter().map(|w| w.p.len()).max().unwrap();
-
+    // Scale the input polynomials by the power of s
     let p = W
       .into_par_iter()
       .zip(powers.par_iter())
       .map(|(mut w, s)| {
-        w.p.par_iter_mut().for_each(|e| *e *= s);
+        if *s != G::Scalar::ONE {
+          w.p.par_iter_mut().for_each(|e| *e *= s);
+        }
         w.p
       })
       .reduce(

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -68,9 +68,10 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   ///
   /// This operation modifies the polynomial in-place.
   pub fn bind_poly_var_top(&mut self, r: &Scalar) {
-    if self.num_vars == 0 {
-      return;
-    }
+    assert!(self.num_vars > 0);
+    // if self.num_vars == 0 {
+    //   return;
+    // }
 
     let n = self.len() / 2;
 
@@ -105,6 +106,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
 
   /// Evaluates the polynomial with the given evaluations and point.
   pub fn evaluate_with(Z: &[Scalar], r: &[Scalar]) -> Scalar {
+    assert_eq!(1 << r.len(), Z.len());
     EqPolynomial::new(r.to_vec())
       .evals()
       .into_par_iter()

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -69,9 +69,6 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   /// This operation modifies the polynomial in-place.
   pub fn bind_poly_var_top(&mut self, r: &Scalar) {
     assert!(self.num_vars > 0);
-    // if self.num_vars == 0 {
-    //   return;
-    // }
 
     let n = self.len() / 2;
 

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -443,38 +443,42 @@ pub(super) fn batch_eval_prove<G: Group>(
   ),
   NovaError,
 > {
-  assert_eq!(u_vec.len(), w_vec.len());
+  let num_claims = u_vec.len();
+  assert_eq!(w_vec.len(), num_claims);
 
-  let w_vec_padded = PolyEvalWitness::pad(&w_vec); // pad the polynomials to be of the same size
-  let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
+  let num_rounds = u_vec.iter().map(|u| u.x.len()).collect::<Vec<_>>();
+  // let num_rounds_max = num_rounds.iter().cloned().max().unwrap();
+  w_vec
+    .iter()
+    .zip(num_rounds.iter())
+    .for_each(|(w, num_vars)| assert_eq!(w.p.len(), 1 << num_vars));
 
   // generate a challenge
   let rho = transcript.squeeze(b"r")?;
-  let num_claims = w_vec_padded.len();
-  let powers_of_rho = powers::<G>(&rho, num_claims);
-  let claim_batch_joint = u_vec_padded
-    .iter()
-    .zip(powers_of_rho.iter())
-    .map(|(u, p)| u.e * p)
-    .sum();
 
-  let mut polys_left: Vec<MultilinearPolynomial<G::Scalar>> = w_vec_padded
+  let powers_of_rho = powers::<G>(&rho, num_claims);
+
+  let polys_left: Vec<MultilinearPolynomial<G::Scalar>> = w_vec
     .iter()
     .map(|w| MultilinearPolynomial::new(w.p.clone()))
     .collect();
-  let mut polys_right: Vec<MultilinearPolynomial<G::Scalar>> = u_vec_padded
+  let polys_right: Vec<MultilinearPolynomial<G::Scalar>> = u_vec
     .iter()
     .map(|u| MultilinearPolynomial::new(EqPolynomial::new(u.x.clone()).evals()))
     .collect();
+  let claims = u_vec.iter().map(|u| u.e).collect::<Vec<_>>();
+  // let claims = u_vec.iter().map(|u| {
+  //   let scaling_factor = 1 << (num_rounds_max - u.x.len());
+  //   u.e * G::Scalar::from(scaling_factor as u64)
+  // }).collect::<Vec<_>>();
 
-  let num_rounds_z = u_vec_padded[0].x.len();
   let comb_func =
     |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar { *poly_A_comp * *poly_B_comp };
   let (sc_proof_batch, r_z, claims_batch) = SumcheckProof::prove_quad_batch(
-    &claim_batch_joint,
-    num_rounds_z,
-    &mut polys_left,
-    &mut polys_right,
+    &claims,
+    &num_rounds,
+    polys_left,
+    polys_right,
     &powers_of_rho,
     comb_func,
     transcript,
@@ -487,28 +491,38 @@ pub(super) fn batch_eval_prove<G: Group>(
   // we now combine evaluation claims at the same point rz into one
   let gamma = transcript.squeeze(b"g")?;
   let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
-  let comm_joint = u_vec_padded
+
+  let w_joint = PolyEvalWitness::weighted_sum(w_vec, &powers_of_gamma);
+
+  let scaling_factors = num_rounds.iter().map(|&num_rounds| {
+    r_z
+      .iter()
+      .rev()
+      .skip(num_rounds)
+      .map(|r| G::Scalar::ONE - r)
+      .product::<G::Scalar>()
+  });
+
+  let comm_joint = u_vec
     .iter()
     .zip(powers_of_gamma.iter())
     .map(|(u, g_i)| u.c * *g_i)
     .fold(Commitment::<G>::default(), |acc, item| acc + item);
-  let poly_joint = PolyEvalWitness::weighted_sum(&w_vec_padded, &powers_of_gamma);
+
   let eval_joint = claims_batch_left
     .iter()
+    .zip(scaling_factors)
     .zip(powers_of_gamma.iter())
-    .map(|(e, g_i)| *e * *g_i)
+    .map(|((e, scaling_factor), g_i)| scaling_factor * e * g_i)
     .sum();
 
-  Ok((
-    PolyEvalInstance::<G> {
-      c: comm_joint,
-      x: r_z,
-      e: eval_joint,
-    },
-    poly_joint,
-    sc_proof_batch,
-    claims_batch_left,
-  ))
+  let u_joint = PolyEvalInstance {
+    c: comm_joint,
+    x: r_z,
+    e: eval_joint,
+  };
+
+  Ok((u_joint, w_joint, sc_proof_batch, claims_batch_left))
 }
 
 /// Verifies a batch of polynomial evaluation claims using Sumcheck
@@ -519,37 +533,40 @@ pub(super) fn batch_eval_verify<G: Group>(
   sc_proof_batch: &SumcheckProof<G>,
   evals_batch: &[G::Scalar],
 ) -> Result<PolyEvalInstance<G>, NovaError> {
-  assert_eq!(evals_batch.len(), evals_batch.len());
-
-  let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
+  assert_eq!(evals_batch.len(), u_vec.len());
 
   // generate a challenge
   let rho = transcript.squeeze(b"r")?;
   let num_claims = u_vec.len();
   let powers_of_rho = powers::<G>(&rho, num_claims);
+
+  let num_rounds = u_vec.iter().map(|u| u.x.len()).collect::<Vec<_>>();
+  let num_rounds_max = num_rounds.iter().cloned().max().unwrap();
+
   let claim_batch_joint = u_vec
     .iter()
+    .zip(num_rounds.iter())
+    .map(|(u, num_rounds)| {
+      let scaling_factor = 1 << (num_rounds_max - num_rounds);
+      u.e * G::Scalar::from(scaling_factor as u64)
+    })
     .zip(powers_of_rho.iter())
-    .map(|(u, p)| u.e * p)
+    .map(|(e, p)| e * p)
     .sum();
 
-  let num_rounds_z = u_vec_padded[0].x.len();
-
   let (claim_batch_final, r_z) =
-    sc_proof_batch.verify(claim_batch_joint, num_rounds_z, 2, transcript)?;
+    sc_proof_batch.verify(claim_batch_joint, num_rounds_max, 2, transcript)?;
 
   let claim_batch_final_expected = {
-    let poly_rz = EqPolynomial::new(r_z.clone());
-    let evals = u_vec_padded
-      .iter()
-      .map(|u| poly_rz.evaluate(&u.x))
-      .collect::<Vec<G::Scalar>>();
+    let evals_rz = u_vec.iter().map(|u| {
+      let (_, r_z_hi) = r_z.split_at(num_rounds_max - u.x.len());
+      EqPolynomial::new(r_z_hi.to_vec()).evaluate(&u.x)
+    });
 
-    evals
-      .iter()
+    evals_rz
       .zip(evals_batch.iter())
       .zip(powers_of_rho.iter())
-      .map(|((e_i, p_i), rho_i)| *e_i * *p_i * rho_i)
+      .map(|((e_i, p_i), rho_i)| e_i * *p_i * rho_i)
       .sum()
   };
 
@@ -562,15 +579,25 @@ pub(super) fn batch_eval_verify<G: Group>(
   // we now combine evaluation claims at the same point rz into one
   let gamma = transcript.squeeze(b"g")?;
   let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
-  let comm_joint = u_vec_padded
+
+  let scaling_factors = u_vec.iter().map(|u| {
+    r_z
+      .iter()
+      .rev()
+      .skip(u.x.len())
+      .map(|r| G::Scalar::ONE - r)
+      .product::<G::Scalar>()
+  });
+
+  let comm_joint = u_vec
     .iter()
     .zip(powers_of_gamma.iter())
-    .map(|(u, g_i)| u.c * *g_i)
-    .fold(Commitment::<G>::default(), |acc, item| acc + item);
-  let eval_joint = evals_batch
-    .iter()
+    .fold(Commitment::<G>::default(), |acc, (u, g_i)| acc + u.c * *g_i);
+
+  let eval_joint = scaling_factors
+    .zip(evals_batch.iter())
     .zip(powers_of_gamma.iter())
-    .map(|(e, g_i)| *e * *g_i)
+    .map(|((s, e), g_i)| s * *e * *g_i)
     .sum();
 
   Ok(PolyEvalInstance::<G> {

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -74,7 +74,7 @@ impl<G: Group> SumcheckProof<G> {
     assert_eq!(coeffs.len(), num_instances);
 
     // n = maxᵢ{nᵢ}
-    let num_rounds_max = num_rounds.iter().cloned().max().unwrap();
+    let num_rounds_max = *num_rounds.iter().max().unwrap();
 
     // Random linear combination of claims,
     // where each claim is scaled by 2^{n-nᵢ} to account for the padding.
@@ -191,16 +191,30 @@ impl<G: Group> SumcheckProof<G> {
     assert_eq!(poly_B_vec.len(), num_claims);
     assert_eq!(coeffs.len(), num_claims);
 
-    num_rounds
-      .iter()
-      .zip(poly_A_vec.iter().zip(poly_B_vec.iter()))
-      .for_each(|(num_rounds, (poly_A, poly_B))| {
-        let poly_size = 1 << num_rounds;
-        assert_eq!(poly_A.len(), poly_size);
-        assert_eq!(poly_B.len(), poly_size);
-      });
+    for &num_rounds in num_rounds.iter() {
+      let expected_size = 1 << num_rounds;
 
-    let num_rounds_max = num_rounds.iter().cloned().max().unwrap();
+      for i in 0..num_claims {
+        // Direct indexing with the assumption that the index will always be in bounds
+        let a = &poly_A_vec[i];
+        let b = &poly_B_vec[i];
+
+        assert_eq!(
+          a.len(),
+          expected_size,
+          "Mismatch in size for poly_A_vec at index {}",
+          i
+        );
+        assert_eq!(
+          b.len(),
+          expected_size,
+          "Mismatch in size for poly_B_vec at index {}",
+          i
+        );
+      }
+    }
+
+    let num_rounds_max = *num_rounds.iter().max().unwrap();
     let mut e = claims
       .iter()
       .zip(num_rounds)
@@ -472,20 +486,44 @@ impl<G: Group> SumcheckProof<G> {
     assert_eq!(poly_C_vec.len(), num_instances);
     assert_eq!(poly_D_vec.len(), num_instances);
 
-    num_rounds
-      .iter()
-      .zip(poly_A_vec.iter())
-      .zip(poly_B_vec.iter())
-      .zip(poly_C_vec.iter())
-      .zip(poly_D_vec.iter())
-      .for_each(|((((num_rounds, a), b), c), d)| {
-        let expected_size = 1 << num_rounds;
-        assert_eq!(a.len(), expected_size);
-        assert_eq!(b.len(), expected_size);
-        assert_eq!(c.len(), expected_size);
-        assert_eq!(d.len(), expected_size);
-      });
-    let num_rounds_max = num_rounds.iter().cloned().max().unwrap();
+    for &num_rounds in num_rounds.iter() {
+      let expected_size = 1 << num_rounds;
+
+      for i in 0..num_instances {
+        // Direct indexing with the assumption that the index will always be in bounds
+        let a = &poly_A_vec[i];
+        let b = &poly_B_vec[i];
+        let c = &poly_C_vec[i];
+        let d = &poly_D_vec[i];
+
+        assert_eq!(
+          a.len(),
+          expected_size,
+          "Mismatch in size for poly_A_vec at index {}",
+          i
+        );
+        assert_eq!(
+          b.len(),
+          expected_size,
+          "Mismatch in size for poly_B_vec at index {}",
+          i
+        );
+        assert_eq!(
+          c.len(),
+          expected_size,
+          "Mismatch in size for poly_C_vec at index {}",
+          i
+        );
+        assert_eq!(
+          d.len(),
+          expected_size,
+          "Mismatch in size for poly_D_vec at index {}",
+          i
+        );
+      }
+    }
+
+    let num_rounds_max = *num_rounds.iter().max().unwrap();
 
     let mut r: Vec<G::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<G::Scalar>> = Vec::new();

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -191,27 +191,25 @@ impl<G: Group> SumcheckProof<G> {
     assert_eq!(poly_B_vec.len(), num_claims);
     assert_eq!(coeffs.len(), num_claims);
 
-    for &num_rounds in num_rounds.iter() {
+    for (i, &num_rounds) in num_rounds.iter().enumerate() {
       let expected_size = 1 << num_rounds;
 
-      for i in 0..num_claims {
-        // Direct indexing with the assumption that the index will always be in bounds
-        let a = &poly_A_vec[i];
-        let b = &poly_B_vec[i];
+      // Direct indexing with the assumption that the index will always be in bounds
+      let a = &poly_A_vec[i];
+      let b = &poly_B_vec[i];
 
-        assert_eq!(
-          a.len(),
-          expected_size,
-          "Mismatch in size for poly_A_vec at index {}",
-          i
-        );
-        assert_eq!(
-          b.len(),
-          expected_size,
-          "Mismatch in size for poly_B_vec at index {}",
-          i
-        );
-      }
+      assert_eq!(
+        a.len(),
+        expected_size,
+        "Mismatch in size for poly_A_vec at index {}",
+        i
+      );
+      assert_eq!(
+        b.len(),
+        expected_size,
+        "Mismatch in size for poly_B_vec at index {}",
+        i
+      );
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();
@@ -486,41 +484,39 @@ impl<G: Group> SumcheckProof<G> {
     assert_eq!(poly_C_vec.len(), num_instances);
     assert_eq!(poly_D_vec.len(), num_instances);
 
-    for &num_rounds in num_rounds.iter() {
+    for (i, &num_rounds) in num_rounds.iter().enumerate() {
       let expected_size = 1 << num_rounds;
 
-      for i in 0..num_instances {
-        // Direct indexing with the assumption that the index will always be in bounds
-        let a = &poly_A_vec[i];
-        let b = &poly_B_vec[i];
-        let c = &poly_C_vec[i];
-        let d = &poly_D_vec[i];
+      // Direct indexing with the assumption that the index will always be in bounds
+      let a = &poly_A_vec[i];
+      let b = &poly_B_vec[i];
+      let c = &poly_C_vec[i];
+      let d = &poly_D_vec[i];
 
-        assert_eq!(
-          a.len(),
-          expected_size,
-          "Mismatch in size for poly_A_vec at index {}",
-          i
-        );
-        assert_eq!(
-          b.len(),
-          expected_size,
-          "Mismatch in size for poly_B_vec at index {}",
-          i
-        );
-        assert_eq!(
-          c.len(),
-          expected_size,
-          "Mismatch in size for poly_C_vec at index {}",
-          i
-        );
-        assert_eq!(
-          d.len(),
-          expected_size,
-          "Mismatch in size for poly_D_vec at index {}",
-          i
-        );
-      }
+      assert_eq!(
+        a.len(),
+        expected_size,
+        "Mismatch in size for poly_A_vec at index {}",
+        i
+      );
+      assert_eq!(
+        b.len(),
+        expected_size,
+        "Mismatch in size for poly_B_vec at index {}",
+        i
+      );
+      assert_eq!(
+        c.len(),
+        expected_size,
+        "Mismatch in size for poly_C_vec at index {}",
+        i
+      );
+      assert_eq!(
+        d.len(),
+        expected_size,
+        "Mismatch in size for poly_D_vec at index {}",
+        i
+      );
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -685,7 +685,7 @@ mod test {
     <G1::Scalar as PrimeField>::Repr: Abomonation,
     <G2::Scalar as PrimeField>::Repr: Abomonation,
   {
-    const NUM_STEPS: usize = 6;
+    const NUM_STEPS: usize = 4;
 
     let secondary_circuit = TrivialSecondaryCircuit::default();
     let test_circuits = BigTestCircuit::new(NUM_STEPS);


### PR DESCRIPTION
- Rework all batched Sumcheck provers to handle instances of different sizes
- Add `SumcheckProof::verify_batch` to handle scaling. 
- Improve `batch_verify` of MLE evaluations to also handle different sized claims -> should help existing SNARK as well.