### PR TITLE
Preallocate witness before synthesis

### DIFF
--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -16,7 +16,7 @@ use ff::PrimeField;
 pub trait NovaWitness<E: Engine> {
   /// Return an instance and witness, given a shape and ck.
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
   ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError>;
@@ -39,16 +39,17 @@ pub trait NovaShape<E: Engine> {
 
 impl<E: Engine> NovaWitness<E> for SatisfyingAssignment<E> {
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
   ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError> {
-    let W = R1CSWitness::<E>::new(shape, self.aux_assignment())?;
-    let X = &self.input_assignment()[1..];
+    let (input_assignment, aux_assignment) = self.to_assignments();
+    let W = R1CSWitness::<E>::new(shape, aux_assignment)?;
+    let X = input_assignment[1..].to_owned();
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<E>::new(shape, &comm_W, X)?;
+    let instance = R1CSInstance::<E>::new(shape, comm_W, X)?;
 
     Ok((instance, W))
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,11 +368,11 @@ where
     let l_w_primary = w_primary;
     let l_u_primary = u_primary;
     let r_W_primary =
-      RelaxedR1CSWitness::from_r1cs_witness(&pp.circuit_shape_primary.r1cs_shape, &l_w_primary);
+      RelaxedR1CSWitness::from_r1cs_witness(&pp.circuit_shape_primary.r1cs_shape, l_w_primary);
     let r_U_primary = RelaxedR1CSInstance::from_r1cs_instance(
       &pp.ck_primary,
       &pp.circuit_shape_primary.r1cs_shape,
-      &l_u_primary,
+      l_u_primary,
     );
 
     // IVC proof for the secondary circuit
@@ -443,7 +443,10 @@ where
     )
     .expect("Unable to fold secondary");
 
-    let mut cs_primary = SatisfyingAssignment::<E1>::new();
+    let mut cs_primary = SatisfyingAssignment::<E1>::with_capacity(
+      pp.circuit_shape_primary.r1cs_shape.num_io + 1,
+      pp.circuit_shape_primary.r1cs_shape.num_vars,
+    );
     let inputs_primary: NovaAugmentedCircuitInputs<E2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<E1>(pp.digest()),
       E1::Scalar::from(self.i as u64),
@@ -483,7 +486,10 @@ where
     )
     .expect("Unable to fold primary");
 
-    let mut cs_secondary = SatisfyingAssignment::<E2>::new();
+    let mut cs_secondary = SatisfyingAssignment::<E2>::with_capacity(
+      pp.circuit_shape_secondary.r1cs_shape.num_io + 1,
+      pp.circuit_shape_secondary.r1cs_shape.num_vars,
+    );
     let inputs_secondary: NovaAugmentedCircuitInputs<E1> = NovaAugmentedCircuitInputs::new(
       pp.digest(),
       E2::Scalar::from(self.i as u64),

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -347,13 +347,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, &vars);
+          let res = R1CSWitness::new(&S, vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, &X);
+          let res = R1CSInstance::new(&S, comm_W, X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -403,11 +403,11 @@ impl<E: Engine> R1CSShape<E> {
 
 impl<E: Engine> R1CSWitness<E> {
   /// A method to create a witness object using a vector of scalars
-  pub fn new(S: &R1CSShape<E>, W: &[E::Scalar]) -> Result<R1CSWitness<E>, NovaError> {
+  pub fn new(S: &R1CSShape<E>, W: Vec<E::Scalar>) -> Result<R1CSWitness<E>, NovaError> {
     if S.num_vars != W.len() {
       Err(NovaError::InvalidWitnessLength)
     } else {
-      Ok(R1CSWitness { W: W.to_owned() })
+      Ok(R1CSWitness { W })
     }
   }
 
@@ -421,16 +421,13 @@ impl<E: Engine> R1CSInstance<E> {
   /// A method to create an instance object using consitituent elements
   pub fn new(
     S: &R1CSShape<E>,
-    comm_W: &Commitment<E>,
-    X: &[E::Scalar],
+    comm_W: Commitment<E>,
+    X: Vec<E::Scalar>,
   ) -> Result<R1CSInstance<E>, NovaError> {
     if S.num_io != X.len() {
       Err(NovaError::InvalidInputLength)
     } else {
-      Ok(R1CSInstance {
-        comm_W: *comm_W,
-        X: X.to_owned(),
-      })
+      Ok(R1CSInstance { comm_W, X })
     }
   }
 }
@@ -454,9 +451,9 @@ impl<E: Engine> RelaxedR1CSWitness<E> {
   }
 
   /// Initializes a new `RelaxedR1CSWitness` from an `R1CSWitness`
-  pub fn from_r1cs_witness(S: &R1CSShape<E>, witness: &R1CSWitness<E>) -> RelaxedR1CSWitness<E> {
+  pub fn from_r1cs_witness(S: &R1CSShape<E>, witness: R1CSWitness<E>) -> RelaxedR1CSWitness<E> {
     RelaxedR1CSWitness {
-      W: witness.W.clone(),
+      W: witness.W,
       E: vec![E::Scalar::ZERO; S.num_cons],
     }
   }
@@ -519,15 +516,18 @@ impl<E: Engine> RelaxedR1CSInstance<E> {
 
   /// Initializes a new `RelaxedR1CSInstance` from an `R1CSInstance`
   pub fn from_r1cs_instance(
-    ck: &CommitmentKey<E>,
+    _ck: &CommitmentKey<E>,
     S: &R1CSShape<E>,
-    instance: &R1CSInstance<E>,
+    instance: R1CSInstance<E>,
   ) -> RelaxedR1CSInstance<E> {
-    let mut r_instance = RelaxedR1CSInstance::default(ck, S);
-    r_instance.comm_W = instance.comm_W;
-    r_instance.u = E::Scalar::ONE;
-    r_instance.X = instance.X.clone();
-    r_instance
+    assert_eq!(S.num_io, instance.X.len());
+
+    RelaxedR1CSInstance {
+      comm_W: instance.comm_W,
+      comm_E: Commitment::<E>::default(),
+      u: E::Scalar::ONE,
+      X: instance.X,
+    }
   }
 
   /// Initializes a new `RelaxedR1CSInstance` from an `R1CSInstance`

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -136,7 +136,7 @@ impl<E: Engine, S: RelaxedR1CSSNARKTrait<E>, C: StepCircuit<E::Scalar>> DirectSN
     // convert the instance and witness to relaxed form
     let (u_relaxed, w_relaxed) = (
       RelaxedR1CSInstance::from_r1cs_instance_unchecked(&u.comm_W, &u.X),
-      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, &w),
+      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, w),
     );
 
     // prove the instance using Spartan

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -527,12 +527,12 @@ where
     let l_w_primary = w_primary;
     let l_u_primary = u_primary;
     let r_W_primary =
-      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, &l_w_primary);
+      RelaxedR1CSWitness::from_r1cs_witness(&pp[circuit_index].r1cs_shape, l_w_primary);
 
     let r_U_primary = RelaxedR1CSInstance::from_r1cs_instance(
       &pp.ck_primary,
       &pp[circuit_index].r1cs_shape,
-      &l_u_primary,
+      l_u_primary,
     );
 
     // IVC proof of the secondary circuit


### PR DESCRIPTION
Addresses #137 and replaces #138.

This PR uses the new API in `WitnessCS` to preallocate the witness buffers before calling `synthesize`. This ensures that we do not unnecessarily grow and reallocate these large witness buffers, which adds overhead. 