### PR TITLE
Remove large vector allocations

### DIFF
--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -4,7 +4,9 @@
 use crate::{
   constants::{NUM_CHALLENGE_BITS, NUM_FE_FOR_RO},
   errors::NovaError,
-  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness},
+  r1cs::{
+    R1CSInstance, R1CSResult, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
+  },
   scalar_as_base,
   traits::{commitment::CommitmentTrait, AbsorbInROTrait, Engine, ROTrait},
   Commitment, CommitmentKey, CompressedCommitment,
@@ -73,6 +75,57 @@ impl<E: Engine> NIFS<E> {
       },
       (U, W),
     ))
+  }
+
+  /// Takes as input a Relaxed R1CS instance-witness tuple `(U1, W1)` and
+  /// an R1CS instance-witness tuple `(U2, W2)` with the same structure `shape`
+  /// and defined with respect to the same `ck`, and updates `(U1, W1)` by folding
+  /// `(U2, W2)` into it with the guarantee that the updated witness `W` satisfies
+  /// the updated instance `U` if and only if `W1` satisfies `U1` and `W2` satisfies `U2`.
+  #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all, level = "trace", name = "NIFS::prove_mut")]
+  pub fn prove_mut(
+    ck: &CommitmentKey<E>,
+    ro_consts: &ROConstants<E>,
+    pp_digest: &E::Scalar,
+    S: &R1CSShape<E>,
+    U1: &mut RelaxedR1CSInstance<E>,
+    W1: &mut RelaxedR1CSWitness<E>,
+    U2: &R1CSInstance<E>,
+    W2: &R1CSWitness<E>,
+    T: &mut Vec<E::Scalar>,
+    ABC_Z_1: &mut R1CSResult<E>,
+    ABC_Z_2: &mut R1CSResult<E>,
+  ) -> Result<NIFS<E>, NovaError> {
+    // initialize a new RO
+    let mut ro = E::RO::new(ro_consts.clone(), NUM_FE_FOR_RO);
+
+    // append the digest of pp to the transcript
+    ro.absorb(scalar_as_base::<E>(*pp_digest));
+
+    // append U1 and U2 to transcript
+    U1.absorb_in_ro(&mut ro);
+    U2.absorb_in_ro(&mut ro);
+
+    // compute a commitment to the cross-term
+    let comm_T = S.commit_T_into(ck, U1, W1, U2, W2, T, ABC_Z_1, ABC_Z_2)?;
+
+    // append `comm_T` to the transcript and obtain a challenge
+    comm_T.absorb_in_ro(&mut ro);
+
+    // compute a challenge from the RO
+    let r = ro.squeeze(NUM_CHALLENGE_BITS);
+
+    // fold the instance using `r` and `comm_T`
+    U1.fold_mut(U2, &comm_T, &r);
+
+    // fold the witness using `r` and `T`
+    W1.fold_mut(W2, T, &r)?;
+
+    // return the commitment
+    Ok(Self {
+      comm_T: comm_T.compress(),
+    })
   }
 
   /// Takes as input a relaxed R1CS instance `U1` and R1CS instance `U2`

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -414,8 +414,8 @@ impl<E: Engine> R1CSShape<E> {
         .map(|i| {
           let AZ_1_circ_BZ_2 = AZ_1[i] * BZ_2[i];
           let AZ_2_circ_BZ_1 = AZ_2[i] * BZ_1[i];
-          let u_1_cdot_CZ_2 = U1.u * CZ_2[i];
-          AZ_1_circ_BZ_2 + AZ_2_circ_BZ_1 - u_1_cdot_CZ_2 - CZ_1[i]
+          let u_1_cdot_Cz_2_plus_Cz_1 = U1.u * CZ_2[i] + CZ_1[i];
+          AZ_1_circ_BZ_2 + AZ_2_circ_BZ_1 - u_1_cdot_Cz_2_plus_Cz_1
         })
         .collect_into_vec(T)
     });
@@ -599,12 +599,12 @@ impl<E: Engine> RelaxedR1CSWitness<E> {
     self
       .W
       .par_iter_mut()
-      .zip(&W2.W)
+      .zip_eq(&W2.W)
       .for_each(|(a, b)| *a += *r * *b);
     self
       .E
       .par_iter_mut()
-      .zip(T)
+      .zip_eq(T)
       .for_each(|(a, b)| *a += *r * *b);
 
     Ok(())
@@ -697,7 +697,7 @@ impl<E: Engine> RelaxedR1CSInstance<E> {
     let (X2, comm_W_2) = (&U2.X, &U2.comm_W);
 
     // weighted sum of X, comm_W, comm_E, and u
-    self.X.par_iter_mut().zip(X2).for_each(|(a, b)| {
+    self.X.par_iter_mut().zip_eq(X2).for_each(|(a, b)| {
       *a += *r * *b;
     });
     self.comm_W = self.comm_W + *comm_W_2 * *r;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -44,6 +44,14 @@ pub struct R1CSShape<E: Engine> {
 
 impl<E: Engine> SimpleDigestible for R1CSShape<E> {}
 
+/// A type that holds the result of a R1CS multiplication
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct R1CSResult<E: Engine> {
+  pub(crate) AZ: Vec<E::Scalar>,
+  pub(crate) BZ: Vec<E::Scalar>,
+  pub(crate) CZ: Vec<E::Scalar>,
+}
+
 /// A type that holds a witness for a given R1CS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct R1CSWitness<E: Engine> {
@@ -210,6 +218,32 @@ impl<E: Engine> R1CSShape<E> {
     Ok((Az, Bz, Cz))
   }
 
+  pub(crate) fn multiply_witness_into(
+    &self,
+    W: &[E::Scalar],
+    u: &E::Scalar,
+    X: &[E::Scalar],
+    ABC_Z: &mut R1CSResult<E>,
+  ) -> Result<(), NovaError> {
+    if X.len() != self.num_io || W.len() != self.num_vars {
+      return Err(NovaError::InvalidWitnessLength);
+    }
+
+    let R1CSResult { AZ, BZ, CZ } = ABC_Z;
+
+    rayon::join(
+      || self.A.multiply_witness_into(W, u, X, AZ),
+      || {
+        rayon::join(
+          || self.B.multiply_witness_into(W, u, X, BZ),
+          || self.C.multiply_witness_into(W, u, X, CZ),
+        )
+      },
+    );
+
+    Ok(())
+  }
+
   /// Checks if the Relaxed R1CS instance is satisfiable given a witness and its shape
   pub fn is_sat_relaxed(
     &self,
@@ -339,6 +373,56 @@ impl<E: Engine> R1CSShape<E> {
     Ok((T, comm_T))
   }
 
+  /// A method to compute a commitment to the cross-term `T` given a
+  /// Relaxed R1CS instance-witness pair and an R1CS instance-witness pair
+  ///
+  /// This is [`R1CSShape::commit_T`] but into a buffer.
+  pub fn commit_T_into(
+    &self,
+    ck: &CommitmentKey<E>,
+    U1: &RelaxedR1CSInstance<E>,
+    W1: &RelaxedR1CSWitness<E>,
+    U2: &R1CSInstance<E>,
+    W2: &R1CSWitness<E>,
+    T: &mut Vec<E::Scalar>,
+    ABC_Z_1: &mut R1CSResult<E>,
+    ABC_Z_2: &mut R1CSResult<E>,
+  ) -> Result<Commitment<E>, NovaError> {
+    tracing::info_span!("AZ_1, BZ_1, CZ_1")
+      .in_scope(|| self.multiply_witness_into(&W1.W, &U1.u, &U1.X, ABC_Z_1))?;
+
+    let R1CSResult {
+      AZ: AZ_1,
+      BZ: BZ_1,
+      CZ: CZ_1,
+    } = ABC_Z_1;
+
+    tracing::info_span!("AZ_2, BZ_2, CZ_2")
+      .in_scope(|| self.multiply_witness_into(&W2.W, &E::Scalar::ONE, &U2.X, ABC_Z_2))?;
+
+    let R1CSResult {
+      AZ: AZ_2,
+      BZ: BZ_2,
+      CZ: CZ_2,
+    } = ABC_Z_2;
+
+    // this doesn't allocate memory but has bad temporal cache locality -- should test to see which is faster
+    T.clear();
+    tracing::info_span!("T").in_scope(|| {
+      (0..AZ_1.len())
+        .into_par_iter()
+        .map(|i| {
+          let AZ_1_circ_BZ_2 = AZ_1[i] * BZ_2[i];
+          let AZ_2_circ_BZ_1 = AZ_2[i] * BZ_1[i];
+          let u_1_cdot_CZ_2 = U1.u * CZ_2[i];
+          AZ_1_circ_BZ_2 + AZ_2_circ_BZ_1 - u_1_cdot_CZ_2 - CZ_1[i]
+        })
+        .collect_into_vec(T)
+    });
+
+    Ok(CE::<E>::commit(ck, T))
+  }
+
   /// Pads the `R1CSShape` so that the number of variables is a power of two
   /// Renumbers variables to accomodate padded variables
   pub fn pad(&self) -> Self {
@@ -397,6 +481,17 @@ impl<E: Engine> R1CSShape<E> {
       B: B_padded,
       C: C_padded,
       digest: OnceCell::new(),
+    }
+  }
+}
+
+impl<E: Engine> R1CSResult<E> {
+  /// Produces a default `R1CSResult` given an `R1CSShape`
+  pub fn default(S: &R1CSShape<E>) -> R1CSResult<E> {
+    R1CSResult {
+      AZ: vec![E::Scalar::ZERO; S.num_cons],
+      BZ: vec![E::Scalar::ZERO; S.num_cons],
+      CZ: vec![E::Scalar::ZERO; S.num_cons],
     }
   }
 }
@@ -490,6 +585,31 @@ impl<E: Engine> RelaxedR1CSWitness<E> {
     Ok(RelaxedR1CSWitness { W, E })
   }
 
+  /// Mutably folds an incoming `R1CSWitness` into the current one
+  pub fn fold_mut(
+    &mut self,
+    W2: &R1CSWitness<E>,
+    T: &[E::Scalar],
+    r: &E::Scalar,
+  ) -> Result<(), NovaError> {
+    if self.W.len() != W2.W.len() {
+      return Err(NovaError::InvalidWitnessLength);
+    }
+
+    self
+      .W
+      .par_iter_mut()
+      .zip(&W2.W)
+      .for_each(|(a, b)| *a += *r * *b);
+    self
+      .E
+      .par_iter_mut()
+      .zip(T)
+      .for_each(|(a, b)| *a += *r * *b);
+
+    Ok(())
+  }
+
   /// Pads the provided witness to the correct length
   pub fn pad(&self, S: &R1CSShape<E>) -> RelaxedR1CSWitness<E> {
     let mut W = self.W.clone();
@@ -571,6 +691,19 @@ impl<E: Engine> RelaxedR1CSInstance<E> {
       u,
     }
   }
+
+  /// Mutably folds an incoming `RelaxedR1CSInstance` into the current one
+  pub fn fold_mut(&mut self, U2: &R1CSInstance<E>, comm_T: &Commitment<E>, r: &E::Scalar) {
+    let (X2, comm_W_2) = (&U2.X, &U2.comm_W);
+
+    // weighted sum of X, comm_W, comm_E, and u
+    self.X.par_iter_mut().zip(X2).for_each(|(a, b)| {
+      *a += *r * *b;
+    });
+    self.comm_W = self.comm_W + *comm_W_2 * *r;
+    self.comm_E = self.comm_E + *comm_T * *r;
+    self.u += *r;
+  }
 }
 
 impl<E: Engine> TranscriptReprTrait<E::GE> for RelaxedR1CSInstance<E> {
@@ -599,6 +732,11 @@ impl<E: Engine> AbsorbInROTrait<E> for RelaxedR1CSInstance<E> {
       }
     }
   }
+}
+
+/// Empty buffer for `commit_T_into`
+pub fn default_T<E: Engine>(shape: &R1CSShape<E>) -> Vec<E::Scalar> {
+  Vec::with_capacity(shape.num_cons)
 }
 
 #[cfg(test)]

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -136,9 +136,23 @@ impl<F: PrimeField> SparseMatrix<F> {
     name = "SparseMatrix::multiply_vec_unchecked"
   )]
   pub fn multiply_witness_unchecked(&self, W: &[F], u: &F, X: &[F]) -> Vec<F> {
-    let num_vars = W.len();
     // preallocate the result vector
-    let mut result = Vec::with_capacity(self.indptr.len() - 1);
+    let mut sink = Vec::with_capacity(self.indptr.len() - 1);
+    self.multiply_witness_into_unchecked(W, u, X, &mut sink);
+    sink
+  }
+
+  /// Multiply by a witness representing a dense vector; uses rayon to parallelize.
+  pub fn multiply_witness_into(&self, W: &[F], u: &F, X: &[F], sink: &mut Vec<F>) {
+    assert_eq!(self.cols, W.len() + X.len() + 1, "invalid shape");
+
+    self.multiply_witness_into_unchecked(W, u, X, sink);
+  }
+
+  /// Multiply by a witness representing a dense vector; uses rayon to parallelize.
+  /// This does not check that the shape of the matrix/vector are compatible.
+  pub fn multiply_witness_into_unchecked(&self, W: &[F], u: &F, X: &[F], sink: &mut Vec<F>) {
+    let num_vars = W.len();
     self
       .indptr
       .par_windows(2)
@@ -154,8 +168,7 @@ impl<F: PrimeField> SparseMatrix<F> {
             acc + val
           })
       })
-      .collect_into_vec(&mut result);
-    result
+      .collect_into_vec(sink);
   }
 
   /// number of non-zero entries


### PR DESCRIPTION
Addresses #137.

This PR addresses the cloning/allocation of large vectors used in the intermediary steps of each Nova `prove_step` computation. In particular, we focus on `NIFS::prove`, which allocates new vectors to compute the fold step, when technically we could be reusing and overwriting the already allocated vectors from the previous step. Concretely, we add the functions `NIFS::prove_mut` and `R1CSRelaxedWitness/Instance::prove_mut`. We also add a `ResourceSink` with preallocated buffers for `ABC_Z{1,2}` and `T`s to help as stratch memory for the `commit_T_into` operation. 