### PR TITLE
Only create taus once.

### DIFF
--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -180,9 +180,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
     // Generate tau polynomial corresponding to eq(τ, τ², τ⁴ , …)
     // for a random challenge τ
     let tau = transcript.squeeze(b"t")?;
+    let all_taus = PowPolynomial::powers(&tau, num_rounds_x_max);
+
     let polys_tau = num_rounds_x
       .iter()
-      .map(|&num_rounds_x| PowPolynomial::new(&tau, num_rounds_x).evals())
+      .map(|&num_rounds_x| PowPolynomial::new_from_powers(&all_taus, num_rounds_x).evals())
       .map(MultilinearPolynomial::new)
       .collect::<Vec<_>>();
 

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -184,7 +184,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> BatchedRelaxedR1CSSNARKTrait<G>
 
     let polys_tau = num_rounds_x
       .iter()
-      .map(|&num_rounds_x| PowPolynomial::new_from_powers(&all_taus, num_rounds_x).evals())
+      .map(|&num_rounds_x| PowPolynomial::evals_with_powers(&all_taus, num_rounds_x))
       .map(MultilinearPolynomial::new)
       .collect::<Vec<_>>();
 

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -266,8 +266,9 @@ where
       .map(|&N_i| {
         let log_Ni = N_i.log_2();
         let poly = PowPolynomial::new(&tau, log_Ni);
+        let evals = poly.evals();
         let coords = poly.coordinates();
-        (poly.evals(), coords)
+        (evals, coords)
       })
       .unzip();
 

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -500,6 +500,8 @@ where
 
       // Sample new random variable for eq polynomial
       let rho = transcript.squeeze(b"r")?;
+      let N_max = N.iter().max().unwrap();
+      let all_rhos = PowPolynomial::powers(&rho, N_max.log_2());
 
       let instances = pk
         .S_repr
@@ -511,7 +513,7 @@ where
           MemorySumcheckInstance::<G>::new(
             polys_mem_oracles.clone(),
             polys_aux,
-            PowPolynomial::new(&rho, Ni.log_2()).evals().to_vec(),
+            PowPolynomial::evals_with_powers(&all_rhos, Ni.log_2()),
             s_repr.ts_row.clone(),
             s_repr.ts_col.clone(),
           )

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -23,9 +23,10 @@ use ff::Field;
 use polys::multilinear::SparsePolynomial;
 use rayon::{iter::IntoParallelRefIterator, prelude::*};
 
+// Creates a vector of the first `n` powers of `s`.
 fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
   assert!(n >= 1);
-  let mut powers = Vec::new();
+  let mut powers = Vec::with_capacity(n);
   powers.push(G::Scalar::ONE);
   for i in 1..n {
     powers.push(powers[i - 1] * s);

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -15,7 +15,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, Parall
 ///
 /// For instance, for e = 6 (with a binary representation of 0b110), the vector r would be [1, 1, 0].
 pub struct EqPolynomial<Scalar: PrimeField> {
-  r: Vec<Scalar>,
+  pub(crate) r: Vec<Scalar>,
 }
 
 impl<Scalar: PrimeField> EqPolynomial<Scalar> {

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -2,6 +2,7 @@
 
 use crate::spartan::polys::eq::EqPolynomial;
 use ff::PrimeField;
+use std::iter::successors;
 
 /// Represents the multilinear extension polynomial (MLE) of the equality polynomial $pow(x,t)$, denoted as $\tilde{pow}(x, t)$.
 ///
@@ -10,7 +11,6 @@ use ff::PrimeField;
 /// \tilde{power}(x, t) = \prod_{i=1}^m(1 + (t^{2^i} - 1) * x_i)
 /// $$
 pub struct PowPolynomial<Scalar: PrimeField> {
-  t_pow: Vec<Scalar>,
   eq: EqPolynomial<Scalar>,
 }
 
@@ -18,14 +18,9 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
   /// Creates a new `PowPolynomial` from a Scalars `t`.
   pub fn new(t: &Scalar, ell: usize) -> Self {
     // t_pow = [t^{2^0}, t^{2^1}, ..., t^{2^{ell-1}}]
-    let mut t_pow = vec![Scalar::ONE; ell];
-    t_pow[0] = *t;
-    for i in 1..ell {
-      t_pow[i] = t_pow[i - 1].square();
-    }
+    let t_pow = Self::powers(t, ell);
 
     PowPolynomial {
-      t_pow: t_pow.clone(),
       eq: EqPolynomial::new(t_pow),
     }
   }
@@ -33,12 +28,9 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
   /// Create powers the following powers of `t`:
   /// [t^{2^0}, t^{2^1}, ..., t^{2^{ell-1}}]
   pub(crate) fn powers(t: &Scalar, ell: usize) -> Vec<Scalar> {
-    let mut t_pow = vec![Scalar::ONE; ell];
-    t_pow[0] = *t;
-    for i in 1..ell {
-      t_pow[i] = t_pow[i - 1].square();
-    }
-    t_pow
+    successors(Some(*t), |p: &Scalar| Some(p.square()))
+      .take(ell)
+      .collect::<Vec<_>>()
   }
 
   /// Creates the evals corresponding to a `PowPolynomial` from an already-existing vector of powers.
@@ -58,8 +50,8 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
     self.eq.evaluate(rx)
   }
 
-  pub fn coordinates(&self) -> Vec<Scalar> {
-    self.t_pow.clone()
+  pub fn coordinates(self) -> Vec<Scalar> {
+    self.eq.r
   }
 
   /// Evaluates the `PowPolynomial` at all the `2^|t_pow|` points in its domain.

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -41,14 +41,11 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
     t_pow
   }
 
-  /// Creates a new `PowPolynomial` from an already-existing vector of powers.
-  /// `t_pow.len()` must be > `ell`
-  pub fn new_from_powers(powers: &[Scalar], ell: usize) -> Self {
+  /// Creates the evals corresponding to a `PowPolynomial` from an already-existing vector of powers.
+  /// `t_pow.len() > ell` must be true.
+  pub(crate) fn evals_with_powers(powers: &[Scalar], ell: usize) -> Vec<Scalar> {
     let t_pow = powers[..ell].to_vec();
-    PowPolynomial {
-      t_pow: t_pow.clone(),
-      eq: EqPolynomial::new(t_pow),
-    }
+    EqPolynomial::new(t_pow).evals()
   }
 
   /// Evaluates the `PowPolynomial` at a given point `rx`.

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -30,6 +30,27 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
     }
   }
 
+  /// Create powers the following powers of `t`:
+  /// [t^{2^0}, t^{2^1}, ..., t^{2^{ell-1}}]
+  pub(crate) fn powers(t: &Scalar, ell: usize) -> Vec<Scalar> {
+    let mut t_pow = vec![Scalar::ONE; ell];
+    t_pow[0] = *t;
+    for i in 1..ell {
+      t_pow[i] = t_pow[i - 1].square();
+    }
+    t_pow
+  }
+
+  /// Creates a new `PowPolynomial` from an already-existing vector of powers.
+  /// `t_pow.len()` must be > `ell`
+  pub fn new_from_powers(powers: &[Scalar], ell: usize) -> Self {
+    let t_pow = powers[..ell].to_vec();
+    PowPolynomial {
+      t_pow: t_pow.clone(),
+      eq: EqPolynomial::new(t_pow),
+    }
+  }
+
   /// Evaluates the `PowPolynomial` at a given point `rx`.
   ///
   /// This function computes the value of the polynomial at the point specified by `rx`.


### PR DESCRIPTION
Don't create all the powers for every `PowPolynomial` when batching. Instead create all the powers once and copy the ones needed. Also, don't even make the `PowPolynomial` (cloning all the powers), when only doing so to get the evals.

This may not matter much, since I guess the concrete number of powers grows logarithmically so may be smallish. Nevertheless, if we aspire to very large circuit sets, it may be worth thinking this way.
