### PR TITLE
refactor: Replace zip with zip_eq for iterator safety

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,7 @@
 type-complexity-threshold = 9999
 too-many-arguments-threshold = 20
+disallowed-methods = [
+    # we are strict about size checks in iterators
+    { path = "core::iter::traits::iterator::Iterator::zip", reason = "use itertools::zip_eq instead" },
+    { path = "rayon::iter::IndexedParallelIterator::zip", reason = "use rayon::iter::IndexedParallelIterator::zip_eq instead" },
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-texray = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
+itertools = "0.12.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git="https://github.com/lurk-lab/pasta-msm", branch="dev", version = "0.1.4" }

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
+use itertools::Itertools as _;
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
 use std::borrow::Borrow;
@@ -267,7 +268,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
     // swap the option and iterator
     let limb_values_split =
       (0..self.limbs.len()).map(|i| self.limb_values.as_ref().map(|vs| vs[i]));
-    for (i, (limb, limb_value)) in self.limbs.iter().zip(limb_values_split).enumerate() {
+    for (i, (limb, limb_value)) in self.limbs.iter().zip_eq(limb_values_split).enumerate() {
       Num::new(limb_value, limb.clone())
         .fits_in_bits(cs.namespace(|| format!("{i}")), self.params.limb_width)?;
     }
@@ -284,7 +285,7 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
     let bitvectors: Vec<Bitvector<Scalar>> = self
       .limbs
       .iter()
-      .zip(limb_values_split)
+      .zip_eq(limb_values_split)
       .enumerate()
       .map(|(i, (limb, limb_value))| {
         Num::new(limb_value, limb.clone()).decompose(

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -18,6 +18,7 @@ use crate::{
 use bellpepper::gadgets::{boolean::Boolean, num::AllocatedNum, Assignment};
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 use ff::Field;
+use itertools::Itertools as _;
 
 /// An Allocated R1CS Instance
 #[derive(Clone)]
@@ -390,7 +391,7 @@ pub fn conditionally_select_vec_allocated_relaxed_r1cs_instance<
 ) -> Result<Vec<AllocatedRelaxedR1CSInstance<E>>, SynthesisError> {
   a.iter()
     .enumerate()
-    .zip(b.iter())
+    .zip_eq(b.iter())
     .map(|((i, a), b)| {
       a.conditionally_select(
         cs.namespace(|| format!("cond ? a[{}]: b[{}]", i, i)),

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -8,6 +8,7 @@ use bellpepper_core::{
   ConstraintSystem, LinearCombination, SynthesisError,
 };
 use ff::{Field, PrimeField, PrimeFieldBits};
+use itertools::Itertools as _;
 use num_bigint::BigInt;
 
 /// Gets as input the little indian representation of a number and spits out the number
@@ -212,7 +213,7 @@ pub fn conditionally_select_vec<F: PrimeField, CS: ConstraintSystem<F>>(
   condition: &Boolean,
 ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
   a.iter()
-    .zip(b.iter())
+    .zip_eq(b.iter())
     .enumerate()
     .map(|(i, (a, b))| {
       conditionally_select(cs.namespace(|| format!("select_{i}")), a, b, condition)

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -245,13 +245,13 @@ where
       // fold the left half and the right half
       let a_vec_folded = a_vec[0..n / 2]
         .par_iter()
-        .zip(a_vec[n / 2..n].par_iter())
+        .zip_eq(a_vec[n / 2..n].par_iter())
         .map(|(a_L, a_R)| *a_L * r + r_inverse * *a_R)
         .collect::<Vec<E::Scalar>>();
 
       let b_vec_folded = b_vec[0..n / 2]
         .par_iter()
-        .zip(b_vec[n / 2..n].par_iter())
+        .zip_eq(b_vec[n / 2..n].par_iter())
         .map(|(b_L, b_R)| *b_L * r_inverse + r * *b_R)
         .collect::<Vec<E::Scalar>>();
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -122,6 +122,7 @@ mod tests {
   use digest::{ExtendableOutput, Update};
   use group::{ff::Field, Curve, Group};
   use halo2curves::{CurveAffine, CurveExt};
+  use itertools::Itertools as _;
   use pasta_curves::{pallas, vesta};
   use rand_core::OsRng;
   use sha3::Shake256;
@@ -164,7 +165,7 @@ mod tests {
       .collect::<Vec<_>>();
     let naive = coeffs
       .iter()
-      .zip(bases.iter())
+      .zip_eq(bases.iter())
       .fold(A::CurveExt::identity(), |acc, (coeff, base)| {
         acc + *base * coeff
       });

--- a/src/provider/msm.rs
+++ b/src/provider/msm.rs
@@ -23,7 +23,8 @@ fn cpu_msm_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve
     }
 
     let mut v = [0; 8];
-    for (v, o) in v.iter_mut().zip_eq(bytes.as_ref()[skip_bytes..].iter()) {
+    #[allow(clippy::disallowed_methods)]
+    for (v, o) in v.iter_mut().zip(bytes.as_ref()[skip_bytes..].iter()) {
       *v = *o;
     }
 

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -327,9 +327,9 @@ impl<E: Engine> R1CSShape<E> {
     let T = tracing::trace_span!("T").in_scope(|| {
       AZ_1_circ_BZ_2
         .par_iter()
-        .zip(&AZ_2_circ_BZ_1)
-        .zip(&u_1_cdot_CZ_2)
-        .zip(&u_2_cdot_CZ_1)
+        .zip_eq(&AZ_2_circ_BZ_1)
+        .zip_eq(&u_1_cdot_CZ_2)
+        .zip_eq(&u_2_cdot_CZ_1)
         .map(|(((a, b), c), d)| *a + *b - *c - *d)
         .collect::<Vec<E::Scalar>>()
     });
@@ -479,12 +479,12 @@ impl<E: Engine> RelaxedR1CSWitness<E> {
 
     let W = W1
       .par_iter()
-      .zip(W2)
+      .zip_eq(W2)
       .map(|(a, b)| *a + *r * *b)
       .collect::<Vec<E::Scalar>>();
     let E = E1
       .par_iter()
-      .zip(T)
+      .zip_eq(T)
       .map(|(a, b)| *a + *r * *b)
       .collect::<Vec<E::Scalar>>();
     Ok(RelaxedR1CSWitness { W, E })
@@ -557,7 +557,7 @@ impl<E: Engine> RelaxedR1CSInstance<E> {
     // weighted sum of X, comm_W, comm_E, and u
     let X = X1
       .par_iter()
-      .zip(X2)
+      .zip_eq(X2)
       .map(|(a, b)| *a + *r * *b)
       .collect::<Vec<E::Scalar>>();
     let comm_W = *comm_W_1 + *comm_W_2 * *r;

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use ff::PrimeField;
+use itertools::Itertools as _;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -90,7 +91,7 @@ impl<F: PrimeField> SparseMatrix<F> {
   pub fn get_row_unchecked(&self, ptrs: &[usize; 2]) -> impl Iterator<Item = (&F, &usize)> {
     self.data[ptrs[0]..ptrs[1]]
       .iter()
-      .zip(&self.indices[ptrs[0]..ptrs[1]])
+      .zip_eq(&self.indices[ptrs[0]..ptrs[1]])
   }
 
   /// Multiply by a dense vector; uses rayon to parallelize.

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -14,6 +14,7 @@ mod sumcheck;
 
 use crate::{traits::Engine, Commitment};
 use ff::Field;
+use itertools::Itertools as _;
 use polys::multilinear::SparsePolynomial;
 use rayon::{iter::IntoParallelRefIterator, prelude::*};
 
@@ -66,7 +67,7 @@ impl<E: Engine> PolyEvalWitness<E> {
 
     let p = p_vec
       .par_iter()
-      .zip(powers_of_s.par_iter())
+      .zip_eq(powers_of_s.par_iter())
       .map(|(v, &weight)| {
         // compute the weighted sum for each vector
         v.iter().map(|&x| x * weight).collect::<Vec<E::Scalar>>()
@@ -75,7 +76,7 @@ impl<E: Engine> PolyEvalWitness<E> {
         || vec![E::Scalar::ZERO; p_vec[0].len()],
         |acc, v| {
           // perform vector addition to combine the weighted vectors
-          acc.into_iter().zip(v).map(|(x, y)| x + y).collect()
+          acc.into_iter().zip_eq(v).map(|(x, y)| x + y).collect()
         },
       );
 
@@ -115,12 +116,12 @@ impl<E: Engine> PolyEvalInstance<E> {
     let powers_of_s = powers::<E>(s, c_vec.len());
     let e = e_vec
       .par_iter()
-      .zip(powers_of_s.par_iter())
+      .zip_eq(powers_of_s.par_iter())
       .map(|(e, p)| *e * p)
       .sum();
     let c = c_vec
       .par_iter()
-      .zip(powers_of_s.par_iter())
+      .zip_eq(powers_of_s.par_iter())
       .map(|(c, p)| *c * *p)
       .reduce(Commitment::<E>::default, |acc, item| acc + item);
 

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -54,7 +54,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
 
       evals_left
         .par_iter_mut()
-        .zip(evals_right.par_iter_mut())
+        .zip_eq(evals_right.par_iter_mut())
         .for_each(|(x, y)| {
           *y = *x * r;
           *x -= &*y;

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -5,6 +5,7 @@
 use std::ops::{Add, Index};
 
 use ff::PrimeField;
+use itertools::Itertools as _;
 use rayon::prelude::{
   IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
   IntoParallelRefMutIterator, ParallelIterator,
@@ -67,7 +68,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
 
     left
       .par_iter_mut()
-      .zip(right.par_iter())
+      .zip_eq(right.par_iter())
       .for_each(|(a, b)| {
         *a += *r * (*b - *a);
       });
@@ -97,7 +98,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     EqPolynomial::new(r.to_vec())
       .evals()
       .into_par_iter()
-      .zip(Z.into_par_iter())
+      .zip_eq(Z.into_par_iter())
       .map(|(a, b)| a * b)
       .sum()
   }
@@ -170,7 +171,7 @@ impl<Scalar: PrimeField> Add for MultilinearPolynomial<Scalar> {
     let sum: Vec<Scalar> = self
       .Z
       .iter()
-      .zip(other.Z.iter())
+      .zip_eq(other.Z.iter())
       .map(|(a, b)| *a + *b)
       .collect();
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -32,6 +32,7 @@ use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use core::cmp::max;
 use ff::{Field, PrimeField};
+use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -352,7 +353,7 @@ impl<E: Engine> MemorySumcheckInstance<E> {
               Ok(
                 inv
                   .par_iter()
-                  .zip(TS.par_iter())
+                  .zip_eq(TS.par_iter())
                   .map(|(e1, e2)| *e1 * *e2)
                   .collect::<Vec<_>>(),
               )
@@ -871,7 +872,7 @@ where
     // compute the joint claim
     let claim = claims
       .iter()
-      .zip(coeffs.iter())
+      .zip_eq(coeffs.iter())
       .map(|(c_1, c_2)| *c_1 * c_2)
       .sum();
 
@@ -1115,8 +1116,8 @@ where
           .S_repr
           .val_A
           .par_iter()
-          .zip(pk.S_repr.val_B.par_iter())
-          .zip(pk.S_repr.val_C.par_iter())
+          .zip_eq(pk.S_repr.val_B.par_iter())
+          .zip_eq(pk.S_repr.val_C.par_iter())
           .map(|((v_a, v_b), v_c)| *v_a + c * *v_b + c * c * *v_c)
           .collect::<Vec<E::Scalar>>();
         let inner_sc_inst = InnerSumcheckInstance {

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -158,7 +158,7 @@ impl<E: Engine> SumcheckProof<E> {
     for _ in 0..num_rounds {
       let evals: Vec<(E::Scalar, E::Scalar)> = poly_A_vec
         .par_iter()
-        .zip(poly_B_vec.par_iter())
+        .zip_eq(poly_B_vec.par_iter())
         .map(|(poly_A, poly_B)| Self::compute_eval_points_quad(poly_A, poly_B, &comb_func))
         .collect();
 
@@ -178,7 +178,7 @@ impl<E: Engine> SumcheckProof<E> {
       // bound all tables to the verifier's challenge
       poly_A_vec
         .par_iter_mut()
-        .zip(poly_B_vec.par_iter_mut())
+        .zip_eq(poly_B_vec.par_iter_mut())
         .for_each(|(poly_A, poly_B)| {
           let _ = rayon::join(
             || poly_A.bind_poly_var_top(&r_i),

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -42,6 +42,7 @@ use bellpepper::gadgets::Assignment;
 
 use abomonation_derive::Abomonation;
 use ff::Field;
+use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -392,7 +393,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
     // update AllocatedRelaxedR1CSInstance on index match augmented circuit index
     let U_next: Vec<AllocatedRelaxedR1CSInstance<E>> = U
       .iter()
-      .zip(last_augmented_circuit_selector.iter())
+      .zip_eq(last_augmented_circuit_selector.iter())
       .map(|(U, equal_bit)| {
         conditionally_select_alloc_relaxed_r1cs(
           cs.namespace(|| "select on index namespace"),

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use ff::{Field, PrimeField};
+use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -794,7 +795,7 @@ where
     self
       .r_U_primary
       .iter()
-      .zip(self.r_W_primary.iter())
+      .zip_eq(self.r_W_primary.iter())
       .enumerate()
       .try_for_each(|(i, (u, w))| match (u, w) {
         (Some(_), Some(_)) | (None, None) => Ok(()),
@@ -919,7 +920,7 @@ where
         self
           .r_U_primary
           .par_iter()
-          .zip(self.r_W_primary.par_iter())
+          .zip_eq(self.r_W_primary.par_iter())
           .enumerate()
           .try_for_each(|(i, (u, w))| {
             if let (Some(u), Some(w)) = (u, w) {

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -55,7 +55,7 @@ fn next_rom_index_and_pc<F: PrimeField, CS: ConstraintSystem<F>>(
   )?;
 
   // Enforce that allocated_rom[rom_index] = pc
-  for (rom, bit) in allocated_rom.iter().zip(current_rom_selector.iter()) {
+  for (rom, bit) in allocated_rom.iter().zip_eq(current_rom_selector.iter()) {
     // if bit = 1, then rom = pc
     // bit * (rom - pc) = 0
     cs.enforce(

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -4,6 +4,7 @@ use bellpepper_core::{
   ConstraintSystem, LinearCombination, SynthesisError,
 };
 use ff::PrimeField;
+use itertools::Itertools as _;
 
 use crate::{
   gadgets::r1cs::{conditionally_select_alloc_relaxed_r1cs, AllocatedRelaxedR1CSInstance},
@@ -37,7 +38,7 @@ pub fn get_from_vec_alloc_relaxed_r1cs<E: Engine, CS: ConstraintSystem<<E as Eng
   // Otherwise, the correct instance will be selected.
   let selected = a
     .iter()
-    .zip(selector_vec.iter())
+    .zip_eq(selector_vec.iter())
     .enumerate()
     .skip(1)
     .try_fold(first, |matched, (i, (candidate, equal_bit))| {


### PR DESCRIPTION
## The issue

We very often use the zip combinator for iterators (often computed over a vector) in order to set up a computation loop. Typically:
```rust
A_vec.into_par_iter().zip(B_vec.par_iter()).map(|(a, b)| foo(a, b)).collect::<Vec<_>>()
```
We very often mean for `A_vec` and `B_vec` to have exactly the same size, but the construction above will not actually check that, as `zip` returns an iterator that will yield as many pairs as the length of the smaller iterator between A and B.

In order to make sure we aren't bitten by a missing length check, this replaces zip with iterators that panic if the length of their arguments are unequal. 

## In detail:
- Replaced `.zip` method with `.zip_eq` from Itertools across multiple files to ensure equal length iteration between zipped arrays,
- Updated the clippy configuration to disallow zip methods which do not check the size of their iterator arguments.
- Removed redundant assertions and parallel processing that became unnecessary after the inclusion of `zip_eq`.

<details><summary>Other details:</summary>

- Updated import statements in numerous files to include `Itertools` from itertools for the efficient usage of iterator tools.
- Added the `itertools` dependency version `0.12.0` to the `Cargo.toml` file.
</details>