### PR TITLE
Refactor: use pub(in crate::foo) rather than pub(super)

### DIFF
--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -93,7 +93,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
       .expect("Failure to retrieve digest!")
   }
 }
-pub(super) struct WitnessBoundSumcheck<E: Engine> {
+pub(in crate::spartan) struct WitnessBoundSumcheck<E: Engine> {
   poly_W: MultilinearPolynomial<E::Scalar>,
   poly_eq: MultilinearPolynomial<E::Scalar>,
 }

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -171,7 +171,8 @@ impl<Scalar: PrimeField> Add for MultilinearPolynomial<Scalar> {
       return Err("The two polynomials must have the same number of variables");
     }
 
-    let sum: Vec<Scalar> = zip_with!((self.Z.into_iter(), other.Z.into_iter()), |a, b| a + b).collect();
+    let sum: Vec<Scalar> =
+      zip_with!((self.Z.into_iter(), other.Z.into_iter()), |a, b| a + b).collect();
 
     Ok(MultilinearPolynomial::new(sum))
   }

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -443,7 +443,7 @@ where
 ///
 /// We allow the polynomial Pᵢ to have different sizes, by appropriately scaling
 /// the claims and resulting evaluations from Sumcheck.
-pub(super) fn batch_eval_prove<E: Engine>(
+pub(in crate::spartan) fn batch_eval_prove<E: Engine>(
   u_vec: Vec<PolyEvalInstance<E>>,
   w_vec: Vec<PolyEvalWitness<E>>,
   transcript: &mut E::TE,
@@ -517,7 +517,7 @@ pub(super) fn batch_eval_prove<E: Engine>(
 
 /// Verifies a batch of polynomial evaluation claims using Sumcheck
 /// reducing them to a single claim at the same point.
-pub(super) fn batch_eval_verify<E: Engine>(
+pub(in crate::spartan) fn batch_eval_verify<E: Engine>(
   u_vec: Vec<PolyEvalInstance<E>>,
   transcript: &mut E::TE,
   sc_proof_batch: &SumcheckProof<E>,

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -45,7 +45,7 @@ use ff::Field;
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 
-use super::{
+use crate::supernova::{
   num_ro_inputs,
   utils::{get_from_vec_alloc_relaxed_r1cs, get_selector_vec_from_index},
 };


### PR DESCRIPTION
Absolute visibility modifiers tend to not inadvertently make things public when you move code, contrarily to (super).

- Changed the visibility scope of several fields and methods within multiple substrates in the `ppsnark.rs` file to be within the `crate::spartan`.
- Altered the module import path in the `circuit.rs` file from `super` to `crate::supernova`.
- Modified the visibility of the `WitnessBoundSumcheck` in `batched_ppsnark.rs`, the visibility scope is now set to `crate::spartan`.
- Scoped `batch_eval_prove` and `batch_eval_verify` functions within `crate::spartan` in `snark.rs`.