### PR TITLE
Avoid EqPolynomial when only for evals.

### DIFF
--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -73,7 +73,7 @@ where
     point: &[E::Scalar],
     eval: &E::Scalar,
   ) -> Result<Self::EvaluationArgument, NovaError> {
-    let u = InnerProductInstance::new(comm, &EqPolynomial::new(point.to_vec()).evals(), eval);
+    let u = InnerProductInstance::new(comm, &EqPolynomial::evals_from_points(point), eval);
     let w = InnerProductWitness::new(poly);
 
     InnerProductArgument::prove(ck, &pk.ck_s, &u, &w, transcript)
@@ -88,7 +88,7 @@ where
     eval: &E::Scalar,
     arg: &Self::EvaluationArgument,
   ) -> Result<(), NovaError> {
-    let u = InnerProductInstance::new(comm, &EqPolynomial::new(point.to_vec()).evals(), eval);
+    let u = InnerProductInstance::new(comm, &EqPolynomial::evals_from_points(point), eval);
 
     arg.verify(
       &vk.ck_v,

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -307,7 +307,7 @@ where
       };
 
       zip_with!((S.par_iter(), r_x.par_iter()), |s, r_x| {
-        let evals_rx = EqPolynomial::evals_from_points(&r_x);
+        let evals_rx = EqPolynomial::evals_from_points(r_x);
         let (eval_A, eval_B, eval_C) = compute_eval_table_sparse(s, &evals_rx);
         MultilinearPolynomial::new(inner(eval_A, eval_B, eval_C))
       })
@@ -568,8 +568,8 @@ where
         };
 
       let (T_x, T_y) = rayon::join(
-        || EqPolynomial::evals_from_points(&r_x),
-        || EqPolynomial::evals_from_points(&r_y),
+        || EqPolynomial::evals_from_points(r_x),
+        || EqPolynomial::evals_from_points(r_y),
       );
 
       M_vec

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -307,7 +307,7 @@ where
       };
 
       zip_with!((S.par_iter(), r_x.par_iter()), |s, r_x| {
-        let evals_rx = EqPolynomial::new(r_x.clone()).evals();
+        let evals_rx = EqPolynomial::evals_from_points(&r_x);
         let (eval_A, eval_B, eval_C) = compute_eval_table_sparse(s, &evals_rx);
         MultilinearPolynomial::new(inner(eval_A, eval_B, eval_C))
       })
@@ -568,8 +568,8 @@ where
         };
 
       let (T_x, T_y) = rayon::join(
-        || EqPolynomial::new(r_x.to_vec()).evals(),
-        || EqPolynomial::new(r_y.to_vec()).evals(),
+        || EqPolynomial::evals_from_points(&r_x),
+        || EqPolynomial::evals_from_points(&r_y),
       );
 
       M_vec

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -110,7 +110,7 @@ impl<E: Engine> WitnessBoundSumcheck<E> {
       .iter_mut()
       .take(num_vars_log)
       .for_each(|c| *c = E::Scalar::ONE);
-    let poly_eq = EqPolynomial::new(tau_coordinate).evals();
+    let poly_eq = EqPolynomial::evals_from_points(&tau_coordinate);
     Self {
       poly_W: MultilinearPolynomial::new(poly_W_padded),
       poly_eq: MultilinearPolynomial::new(poly_eq),
@@ -646,7 +646,7 @@ where
           let [_, _, Cz] = ABCzs;
           let log_Ni = s_repr.N.log_2();
           let (_, rand_sc) = rand_sc.split_at(num_rounds_sc - log_Ni);
-          let rand_sc_evals = EqPolynomial::new(rand_sc.to_vec()).evals();
+          let rand_sc_evals = EqPolynomial::evals_from_points(&rand_sc);
           let e = [
             Cz,
             poly_E,

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -646,7 +646,7 @@ where
           let [_, _, Cz] = ABCzs;
           let log_Ni = s_repr.N.log_2();
           let (_, rand_sc) = rand_sc.split_at(num_rounds_sc - log_Ni);
-          let rand_sc_evals = EqPolynomial::evals_from_points(&rand_sc);
+          let rand_sc_evals = EqPolynomial::evals_from_points(rand_sc);
           let e = [
             Cz,
             poly_E,

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -43,12 +43,20 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   ///
   /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
   pub fn evals(&self) -> Vec<Scalar> {
-    let ell = self.r.len();
+    Self::evals_from_points(&self.r)
+  }
+
+  /// Evaluates the `EqPolynomial` from the `2^|r|` points in its domain, without creating an intermediate polynomial
+  /// representation.
+  ///
+  /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
+  pub fn evals_from_points(r: &[Scalar]) -> Vec<Scalar> {
+    let ell = r.len();
     let mut evals: Vec<Scalar> = vec![Scalar::ZERO; (2_usize).pow(ell as u32)];
     let mut size = 1;
     evals[0] = Scalar::ONE;
 
-    for r in self.r.iter().rev() {
+    for r in r.iter().rev() {
       let (evals_left, evals_right) = evals.split_at_mut(size);
       let (evals_right, _) = evals_right.split_at_mut(size);
 

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -85,7 +85,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   pub fn evaluate(&self, r: &[Scalar]) -> Scalar {
     // r must have a value for each variable
     assert_eq!(r.len(), self.get_num_vars());
-    let chis = EqPolynomial::new(r.to_vec()).evals();
+    let chis = EqPolynomial::evals_from_points(r);
 
     zip_with!(
       (chis.into_par_iter(), self.Z.par_iter()),
@@ -98,7 +98,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   pub fn evaluate_with(Z: &[Scalar], r: &[Scalar]) -> Scalar {
     zip_with!(
       (
-        EqPolynomial::new(r.to_vec()).evals().into_par_iter(),
+        EqPolynomial::evals_from_points(r).into_par_iter(),
         Z.par_iter()
       ),
       |a, b| a * b

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -37,7 +37,7 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
   /// `t_pow.len() > ell` must be true.
   pub(crate) fn evals_with_powers(powers: &[Scalar], ell: usize) -> Vec<Scalar> {
     let t_pow = powers[..ell].to_vec();
-    EqPolynomial::new(t_pow).evals()
+    EqPolynomial::evals_from_points(&t_pow)
   }
 
   /// Evaluates the `PowPolynomial` at a given point `rx`.

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -201,7 +201,7 @@ where
 
     let poly_ABC = {
       // compute the initial evaluation table for R(\tau, x)
-      let evals_rx = EqPolynomial::new(r_x.clone()).evals();
+      let evals_rx = EqPolynomial::evals_from_points(&r_x.clone());
 
       let (evals_A, evals_B, evals_C) = compute_eval_table_sparse(&S, &evals_rx);
 
@@ -377,8 +377,8 @@ where
         };
 
       let (T_x, T_y) = rayon::join(
-        || EqPolynomial::new(r_x.to_vec()).evals(),
-        || EqPolynomial::new(r_y.to_vec()).evals(),
+        || EqPolynomial::evals_from_points(r_x),
+        || EqPolynomial::evals_from_points(r_y),
       );
 
       (0..M_vec.len())
@@ -484,7 +484,7 @@ pub(super) fn batch_eval_prove<E: Engine>(
   // eq(xᵢ, X)
   let polys_eq: Vec<MultilinearPolynomial<E::Scalar>> = u_xs
     .into_iter()
-    .map(|ux| MultilinearPolynomial::new(EqPolynomial::new(ux).evals()))
+    .map(|ux| MultilinearPolynomial::new(EqPolynomial::evals_from_points(&ux)))
     .collect();
 
   // For each i, check eᵢ = ∑ₓ Pᵢ(x)eq(xᵢ,x), where x ∈ {0,1}^nᵢ


### PR DESCRIPTION
This eliminates some unnecessary cloning caused by unused intermediate `EqPolynomial`s.