### PR TITLE
Adhere to `C-Caller-Control`

### DIFF
--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -173,7 +173,7 @@ fn bench_one_augmented_circuit_compressed_snark(c: &mut Criterion) {
     // Benchmark the verification time
     group.bench_function("Verify", |b| {
       b.iter(|| {
-        assert!(black_box(&compressed_snark)
+        assert!(black_box(compressed_snark.clone())
           .verify(
             black_box(&pp),
             black_box(&verifier_key),
@@ -281,7 +281,7 @@ fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
     // Benchmark the verification time
     group.bench_function("Verify", |b| {
       b.iter(|| {
-        assert!(black_box(&compressed_snark)
+        assert!(black_box(compressed_snark.clone())
           .verify(
             black_box(&pp),
             black_box(&verifier_key),
@@ -389,7 +389,7 @@ fn bench_two_augmented_circuit_compressed_snark_with_computational_commitments(c
     // Benchmark the verification time
     group.bench_function("Verify", |b| {
       b.iter(|| {
-        assert!(black_box(&compressed_snark)
+        assert!(black_box(compressed_snark.clone())
           .verify(
             black_box(&pp),
             black_box(&verifier_key),

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -136,9 +136,9 @@ where
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
-    U: &[RelaxedR1CSInstance<E>],
-    W: &[RelaxedR1CSWitness<E>],
+    S: Vec<R1CSShape<E>>,
+    U: Vec<RelaxedR1CSInstance<E>>,
+    W: Vec<RelaxedR1CSWitness<E>>,
   ) -> Result<Self, NovaError> {
     let num_instances = U.len();
     // Pad shapes and ensure their sizes are correct
@@ -405,7 +405,7 @@ where
     })
   }
 
-  fn verify(&self, vk: &Self::VerifierKey, U: &[RelaxedR1CSInstance<E>]) -> Result<(), NovaError> {
+  fn verify(self, vk: &Self::VerifierKey, U: Vec<RelaxedR1CSInstance<E>>) -> Result<(), NovaError> {
     let mut transcript = E::TE::new(b"BatchedRelaxedR1CSSNARK");
 
     transcript.absorb(b"vk", &vk.digest());

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -241,9 +241,9 @@ where
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
-    U: &[RelaxedR1CSInstance<E>],
-    W: &[RelaxedR1CSWitness<E>],
+    S: Vec<R1CSShape<E>>,
+    U: Vec<RelaxedR1CSInstance<E>>,
+    W: Vec<RelaxedR1CSWitness<E>>,
   ) -> Result<Self, NovaError> {
     // Pad shapes so that num_vars = num_cons = Nᵢ and check the sizes are correct
     let S = S
@@ -817,7 +817,7 @@ where
     })
   }
 
-  fn verify(&self, vk: &Self::VerifierKey, U: &[RelaxedR1CSInstance<E>]) -> Result<(), NovaError> {
+  fn verify(self, vk: &Self::VerifierKey, U: Vec<RelaxedR1CSInstance<E>>) -> Result<(), NovaError> {
     let mut transcript = E::TE::new(b"BatchedRelaxedR1CSSNARK");
 
     transcript.absorb(b"vk", &vk.digest());

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -154,9 +154,9 @@ where
     let r_W_snark_primary = S1::prove(
       &pp.ck_primary,
       &pk.pk_primary,
-      &pp.primary_r1cs_shapes(),
-      &r_U_primary,
-      &r_W_primary,
+      pp.primary_r1cs_shapes(),
+      r_U_primary,
+      r_W_primary,
     )?;
 
     let f_W_snark_secondary = S2::prove(
@@ -201,7 +201,7 @@ where
 
   /// Verify the correctness of the `CompressedSNARK`
   pub fn verify(
-    &self,
+    self,
     pp: &PublicParams<E1, E2, C1, C2>,
     vk: &VerifierKey<E1, E2, C1, C2, S1, S2>,
     z0_primary: Vec<E1::Scalar>,
@@ -272,7 +272,7 @@ where
 
     let res_primary = self
       .r_W_snark_primary
-      .verify(&vk.vk_primary, &self.r_U_primary);
+      .verify(&vk.vk_primary, self.r_U_primary);
 
     let f_U_secondary = self.nifs_secondary.verify(
       &pp.ro_consts_secondary,

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -94,13 +94,13 @@ pub trait BatchedRelaxedR1CSSNARKTrait<E: Engine>:
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
-    U: &[RelaxedR1CSInstance<E>],
-    W: &[RelaxedR1CSWitness<E>],
+    S: Vec<R1CSShape<E>>,
+    U: Vec<RelaxedR1CSInstance<E>>,
+    W: Vec<RelaxedR1CSWitness<E>>,
   ) -> Result<Self, NovaError>;
 
   /// Verifies a SNARK for a batch of relaxed R1CS
-  fn verify(&self, vk: &Self::VerifierKey, U: &[RelaxedR1CSInstance<E>]) -> Result<(), NovaError>;
+  fn verify(self, vk: &Self::VerifierKey, U: Vec<RelaxedR1CSInstance<E>>) -> Result<(), NovaError>;
 }
 
 /// A helper trait that defines the behavior of a verifier key of `zkSNARK`


### PR DESCRIPTION
This PR tries to address the comments about [C-Caller-Control](https://rust-lang.github.io/api-guidelines/flexibility.html#caller-decides-where-to-copy-and-place-data-c-caller-control) API design.

I noticed some further changes that could be made, but they would require changes in code unrelated to Supernova/CompressedSNARKs. As such I decided not to touch them for now.