### PR TITLE
Sketching a minimal approach to zip_with

### DIFF
--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -271,13 +271,15 @@ where
     )
     .unzip();
 
-    evals_Az_Bz_Cz.iter().zip_eq(evals_E.iter()).for_each(
-      |(&(eval_Az, eval_Bz, eval_Cz), &eval_E)| {
+    let _ = zip_with!(
+      (evals_Az_Bz_Cz.iter(), evals_E.iter()),
+      |eval_ABCz, eval_E| {
+        let (eval_Az, eval_Bz, eval_Cz) = eval_ABCz;
         transcript.absorb(
           b"claims_outer",
-          &[eval_Az, eval_Bz, eval_Cz, eval_E].as_slice(),
+          &[*eval_Az, *eval_Bz, *eval_Cz, *eval_E].as_slice(),
         )
-      },
+      }
     );
 
     let inner_r = transcript.squeeze(b"in_r")?;

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -31,15 +31,6 @@ macro_rules! zip_with {
     }};
 }
 
-macro_rules! zip_with_for_each {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-      zip_all!(($e $(, $rest)*))
-            .for_each($($move)? |nested_idents!($($i),+)| {
-                $($work)*
-            })
-    }};
-}
-
 // Fold-right like nesting pattern for expressions a, b, c, d => (a, (b, (c, d)))
 #[doc(hidden)]
 #[allow(unused_macros)]

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -259,7 +259,7 @@ impl<E: Engine> SumcheckProof<E> {
       r.push(r_i);
 
       // bound all tables to the verifier's challenge
-      zip_with_for_each!(
+      let _ = zip_with!(
         (
           num_rounds.par_iter(),
           poly_A_vec.par_iter_mut(),
@@ -587,7 +587,7 @@ impl<E: Engine> SumcheckProof<E> {
 
       // bound all the tables to the verifier's challenge
 
-      zip_with_for_each!(
+      let _ = zip_with!(
         (
           num_rounds.par_iter(),
           poly_A_vec.par_iter_mut(),


### PR DESCRIPTION

- `foo.iter().zip_eq(bar.iter()).for_each(|(a, b)| f(a, b));` becomes `let _ = zip_with!((foo.iter(), bar.iter()), |a, b| f(a, b));`
- `foo.iter().zip_eq(bar.iter()).flat_map(|(a, b)| f(a, b))` becomes `zip_with!((foo.iter(), bar.iter()), |a, b| f(a, b)).flatten()`

There's precisely two kinds of occurrences of the `zip_eq` pattern left in the relevant portions of this PR after this:
- `foo.iter().zip_eq(bar.iter()).map(|(mut a, b)| f(a, b))`
- `foo.iter().zip_eq(bar.iter()).try_fold(|(a, b)| f(a, b))`