### PR TITLE
Restore zip_with_for_each.

### DIFF
--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -31,8 +31,8 @@ use crate::{
     snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait},
     Engine, TranscriptEngineTrait,
   },
-  zip_with, zip_with_iter, zip_with_par_iter, zip_with_par_iter_mut, Commitment, CommitmentKey,
-  CompressedCommitment,
+  zip_with, zip_with_iter, zip_with_par_iter, zip_with_par_iter_mut_for_each, Commitment,
+  CommitmentKey, CompressedCommitment,
 };
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
@@ -1301,7 +1301,7 @@ where
       let r_i = transcript.squeeze(b"c")?;
       r.push(r_i);
 
-      let _ = zip_with_par_iter_mut!(
+      zip_with_par_iter_mut_for_each!(
         (mem, outer, inner, witness),
         |mem, outer, inner, witness| {
           rayon::join(

--- a/src/spartan/macros.rs
+++ b/src/spartan/macros.rs
@@ -41,14 +41,6 @@ macro_rules! zip_with_par_iter {
     }};
 }
 
-/// Like `zip_with` but call `par_iter_mut()` on each input to produce the iterators.
-#[macro_export]
-macro_rules! zip_with_par_iter_mut {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with_fn!(par_iter_mut, ($e $(, $rest)*), $($move)? |$($i),+| $($work)*)
-    }};
-}
-
 /// Like `zip_with` but call `into_iter()` on each input to produce the iterators.
 #[macro_export]
 macro_rules! zip_with_into_iter {
@@ -80,6 +72,26 @@ macro_rules! zip_with_fn {
             .map($($move)? |$crate::nested_idents!($($i),+)| {
                 $($work)*
             })
+    }};
+}
+
+/// Like `zip_with` but use `for_each` instead of `map`.
+#[macro_export]
+macro_rules! zip_with_for_each {
+    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
+        $crate::zip_all!(($e $(, $rest)*))
+            .for_each($($move)? |$crate::nested_idents!($($i),+)| {
+                $($work)*
+            })
+    }};
+}
+
+/// Like `zip_with` but call `par_iter_mut()` on each input to produce the iterators, and apply `for_each` instead of
+/// `map` after zipping.
+#[macro_export]
+macro_rules! zip_with_par_iter_mut_for_each {
+    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
+        $crate::zip_with_fn!(par_iter_mut, ($e $(, $rest)*), [for_each], $($move)? |$($i),+| $($work)*)
     }};
 }
 

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -253,7 +253,7 @@ impl<E: Engine> SumcheckProof<E> {
       r.push(r_i);
 
       // bound all tables to the verifier's challenge
-      let _ = zip_with!(
+      zip_with_for_each!(
         (
           num_rounds.par_iter(),
           poly_A_vec.par_iter_mut(),
@@ -573,7 +573,7 @@ impl<E: Engine> SumcheckProof<E> {
 
       // bound all the tables to the verifier's challenge
 
-      let _ = zip_with!(
+      zip_with_for_each!(
         (
           num_rounds.par_iter(),
           poly_A_vec.par_iter_mut(),


### PR DESCRIPTION
The base branch (`batched_spartan`) was broken by this (squashed) commit of #158: https://github.com/lurk-lab/arecibo/pull/158/commits/1ced24b1e610b1a53b94a15c931275e27a88f217.

It had effectively replaced instances of `foo.for_each(…)` with `let _ = foo.map(…)`. However, these are not equivalent since `map` creates an iterator which may have no effect if not consumed. While we *could* do something like `let _ = foo.map(…).count()` to force side effects to manifest, this is brittle and works against the goal of removing the cognitive burden of incidental plumbing in these pipelines.

For that reason, I'm simply reverting the changes that broke the test that led to discovering this.