### PR TITLE
Streamline macro syntax

### DIFF
--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -117,7 +117,7 @@ where
 
   fn setup(
     ck: &CommitmentKey<E>,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     let (pk_ee, vk_ee) = EE::setup(ck);
 
@@ -136,7 +136,7 @@ where
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
     U: &[RelaxedR1CSInstance<E>],
     W: &[RelaxedR1CSWitness<E>],
   ) -> Result<Self, NovaError> {

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -35,7 +35,7 @@ use crate::{
     snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait},
     Engine, TranscriptEngineTrait,
   },
-  zip_with, zip_with_into_par_iter, zip_with_iter, zip_with_par_iter, CommitmentKey,
+  zip_with, zip_with_fn, CommitmentKey,
 };
 
 /// A succinct proof of knowledge of a witness to a batch of relaxed R1CS instances
@@ -155,7 +155,7 @@ where
       .collect::<Result<Vec<_>, _>>()?;
 
     // Pad (W,E) for each instance
-    let W = zip_with_iter!((W, S), |w, s| w.pad(s)).collect::<Vec<RelaxedR1CSWitness<E>>>();
+    let W = zip_with_fn!(iter, (W, S), |w, s| w.pad(s)).collect::<Vec<RelaxedR1CSWitness<E>>>();
 
     let mut transcript = E::TE::new(b"BatchedRelaxedR1CSSNARK");
 
@@ -171,8 +171,12 @@ where
     let (polys_W, polys_E): (Vec<_>, Vec<_>) = W.into_iter().map(|w| (w.W, w.E)).unzip();
 
     // Append public inputs to W: Z = [W, u, X]
-    let polys_Z = zip_with_iter!((polys_W, U), |w, u| [w.clone(), vec![u.u], u.X.clone()]
-      .concat())
+    let polys_Z = zip_with_fn!(iter, (polys_W, U), |w, u| [
+      w.clone(),
+      vec![u.u],
+      u.X.clone()
+    ]
+    .concat())
     .collect::<Vec<Vec<_>>>();
 
     let (num_rounds_x, num_rounds_y): (Vec<_>, Vec<_>) = S
@@ -195,7 +199,7 @@ where
 
     // Compute MLEs of Az, Bz, Cz, uCz + E
     let (polys_Az, polys_Bz, polys_Cz): (Vec<_>, Vec<_>, Vec<_>) =
-      zip_with_par_iter!((S, polys_Z), |s, poly_Z| {
+      zip_with_fn!(par_iter, (S, polys_Z), |s, poly_Z| {
         let (poly_Az, poly_Bz, poly_Cz) = s.multiply_vec(poly_Z)?;
         Ok((poly_Az, poly_Bz, poly_Cz))
       })
@@ -203,8 +207,8 @@ where
       .into_iter()
       .multiunzip();
 
-    let polys_uCz_E = zip_with_par_iter!((U, polys_E, polys_Cz), |u, poly_E, poly_Cz| {
-      zip_with_par_iter!((poly_Cz, poly_E), |cz, e| u.u * cz + e).collect::<Vec<E::Scalar>>()
+    let polys_uCz_E = zip_with_fn!(par_iter, (U, polys_E, polys_Cz), |u, poly_E, poly_Cz| {
+      zip_with_fn!(par_iter, (poly_Cz, poly_E), |cz, e| u.u * cz + e).collect::<Vec<E::Scalar>>()
     })
     .collect::<Vec<_>>();
 
@@ -247,7 +251,8 @@ where
       .collect::<Vec<_>>();
 
     // Extract evaluations of Az, Bz from Sumcheck and Cz, E at r_x
-    let (evals_Az_Bz_Cz, evals_E): (Vec<_>, Vec<_>) = zip_with_par_iter!(
+    let (evals_Az_Bz_Cz, evals_E): (Vec<_>, Vec<_>) = zip_with_fn!(
+      par_iter,
       (claims_outer[1], claims_outer[2], polys_Cz, polys_E, r_x),
       |eval_Az, eval_Bz, poly_Cz, poly_E, r_x| {
         let (eval_Cz, eval_E) = rayon::join(
@@ -283,14 +288,15 @@ where
                    M_evals_Bs: Vec<E::Scalar>,
                    M_evals_Cs: Vec<E::Scalar>|
        -> Vec<E::Scalar> {
-        zip_with_into_par_iter!(
+        zip_with_fn!(
+          into_par_iter,
           (M_evals_As, M_evals_Bs, M_evals_Cs),
           |eval_A, eval_B, eval_C| eval_A + inner_r * eval_B + inner_r_square * eval_C
         )
         .collect::<Vec<_>>()
       };
 
-      zip_with_par_iter!((S, r_x), |s, r_x| {
+      zip_with_fn!(par_iter, (S, r_x), |s, r_x| {
         let evals_rx = EqPolynomial::evals_from_points(r_x);
         let (eval_A, eval_B, eval_C) = compute_eval_table_sparse(s, &evals_rx);
         MultilinearPolynomial::new(inner(eval_A, eval_B, eval_C))
@@ -330,7 +336,7 @@ where
       })
       .collect::<Vec<_>>();
 
-    let evals_W = zip_with_par_iter!((polys_W, r_y), |poly, r_y| {
+    let evals_W = zip_with_fn!(par_iter, (polys_W, r_y), |poly, r_y| {
       MultilinearPolynomial::evaluate_with(poly, &r_y[1..])
     })
     .collect::<Vec<_>>();
@@ -340,7 +346,7 @@ where
       let mut w_vec = Vec::with_capacity(2 * num_instances);
       let mut u_vec = Vec::with_capacity(2 * num_instances);
       w_vec.extend(polys_W.into_iter().map(|poly| PolyEvalWitness { p: poly }));
-      u_vec.extend(zip_with_iter!((evals_W, U, r_y), |eval, u, r_y| {
+      u_vec.extend(zip_with_fn!(iter, (evals_W, U, r_y), |eval, u, r_y| {
         PolyEvalInstance {
           c: u.comm_W,
           x: r_y[1..].to_vec(),
@@ -443,7 +449,8 @@ where
 
     // Extract evaluations into a vector [(Azᵢ, Bzᵢ, Czᵢ, Eᵢ)]
     // TODO: This is a multizip, simplify
-    let ABCE_evals = zip_with_iter!(
+    let ABCE_evals = zip_with_fn!(
+      iter,
       (
         self.evals_E,
         self.claims_outer.0,
@@ -465,7 +472,8 @@ where
       });
 
     // Evaluate τ(rₓ) for each instance
-    let evals_tau = zip_with_iter!((polys_tau, r_x), |poly_tau, r_x| poly_tau.evaluate(r_x));
+    let evals_tau = zip_with_fn!(iter, (polys_tau, r_x), |poly_tau, r_x| poly_tau
+      .evaluate(r_x));
 
     // Compute expected claim for all instances ∑ᵢ rⁱ⋅τ(rₓ)⋅(Azᵢ⋅Bzᵢ − uᵢ⋅Czᵢ − Eᵢ)
     let claim_outer_final_expected = zip_with!(
@@ -514,7 +522,7 @@ where
 
     // Compute evaluations of Zᵢ = [Wᵢ, uᵢ, Xᵢ] at r_y
     // Zᵢ(r_y) = (1−r_y[0])⋅W(r_y[1..]) + r_y[0]⋅MLE([uᵢ, Xᵢ])(r_y[1..])
-    let evals_Z = zip_with_iter!((self.evals_W, U, r_y), |eval_W, U, r_y| {
+    let evals_Z = zip_with_fn!(iter, (self.evals_W, U, r_y), |eval_W, U, r_y| {
       let eval_X = {
         // constant term
         let mut poly_X = vec![(0, U.u)];
@@ -563,7 +571,8 @@ where
     };
 
     // Compute inner claim ∑ᵢ r³ⁱ⋅(Aᵢ(r_x, r_y) + r⋅Bᵢ(r_x, r_y) + r²⋅Cᵢ(r_x, r_y))⋅Zᵢ(r_y)
-    let claim_inner_final_expected = zip_with_iter!(
+    let claim_inner_final_expected = zip_with_fn!(
+      iter,
       (vk.S, r_x, r_y, evals_Z, inner_r_powers),
       |S, r_x, r_y, eval_Z, r_i| {
         let evals = multi_evaluate(&[&S.A, &S.B, &S.C], r_x, r_y);
@@ -580,21 +589,29 @@ where
     // Create evaluation instances for W(r_y[1..]) and E(r_x)
     let u_vec = {
       let mut u_vec = Vec::with_capacity(2 * num_instances);
-      u_vec.extend(zip_with_iter!((self.evals_W, U, r_y), |eval, u, r_y| {
-        PolyEvalInstance {
-          c: u.comm_W,
-          x: r_y[1..].to_vec(),
-          e: *eval,
+      u_vec.extend(zip_with_fn!(
+        iter,
+        (self.evals_W, U, r_y),
+        |eval, u, r_y| {
+          PolyEvalInstance {
+            c: u.comm_W,
+            x: r_y[1..].to_vec(),
+            e: *eval,
+          }
         }
-      }));
+      ));
 
-      u_vec.extend(zip_with_iter!((self.evals_E, U, r_x), |eval, u, r_x| {
-        PolyEvalInstance {
-          c: u.comm_E,
-          x: r_x.to_vec(),
-          e: *eval,
+      u_vec.extend(zip_with_fn!(
+        iter,
+        (self.evals_E, U, r_x),
+        |eval, u, r_x| {
+          PolyEvalInstance {
+            c: u.comm_E,
+            x: r_x.to_vec(),
+            e: *eval,
+          }
         }
-      }));
+      ));
       u_vec
     };
 

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -31,8 +31,8 @@ use crate::{
     snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait},
     Engine, TranscriptEngineTrait,
   },
-  zip_with, zip_with_iter, zip_with_par_iter, zip_with_par_iter_mut_for_each, Commitment,
-  CommitmentKey, CompressedCommitment,
+  zip_with, zip_with_fn, zip_with_par_iter_mut_for_each, Commitment, CommitmentKey,
+  CompressedCommitment,
 };
 use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
@@ -281,7 +281,7 @@ where
     let num_instances = U.len();
 
     // Pad [(Wᵢ,Eᵢ)] to the next power of 2 (not to Ni)
-    let W = zip_with_par_iter!((W, S), |w, s| w.pad(s)).collect::<Vec<RelaxedR1CSWitness<E>>>();
+    let W = zip_with_fn!(par_iter, (W, S), |w, s| w.pad(s)).collect::<Vec<RelaxedR1CSWitness<E>>>();
 
     // number of rounds of sum-check
     let num_rounds_sc = N.iter().max().unwrap().log_2();
@@ -298,7 +298,7 @@ where
     });
 
     // Append public inputs to Wᵢ: Zᵢ = [Wᵢ, uᵢ, Xᵢ]
-    let polys_Z = zip_with_par_iter!((W, U, N), |W, U, Ni| {
+    let polys_Z = zip_with_fn!(par_iter, (W, U, N), |W, U, Ni| {
       // poly_Z will be resized later, so we preallocate the correct capacity
       let mut poly_Z = Vec::with_capacity(*Ni);
       poly_Z.extend(W.W.iter().chain([&U.u]).chain(U.X.iter()));
@@ -311,7 +311,7 @@ where
     let (polys_W, polys_E): (Vec<_>, Vec<_>) = W.into_iter().map(|w| (w.W, w.E)).unzip();
 
     // Compute [Az, Bz, Cz]
-    let mut polys_Az_Bz_Cz = zip_with_par_iter!((polys_Z, S), |z, s| {
+    let mut polys_Az_Bz_Cz = zip_with_fn!(par_iter, (polys_Z, S), |z, s| {
       let (Az, Bz, Cz) = s.multiply_vec(z)?;
       Ok([Az, Bz, Cz])
     })
@@ -356,8 +356,10 @@ where
       });
 
     // Evaluate and commit to [Az(tau), Bz(tau), Cz(tau)]
-    let evals_Az_Bz_Cz_at_tau =
-      zip_with_par_iter!((polys_Az_Bz_Cz, coords_tau), |ABCs, tau_coords| {
+    let evals_Az_Bz_Cz_at_tau = zip_with_fn!(
+      par_iter,
+      (polys_Az_Bz_Cz, coords_tau),
+      |ABCs, tau_coords| {
         let [Az, Bz, Cz] = ABCs;
         let (eval_Az, (eval_Bz, eval_Cz)) = rayon::join(
           || MultilinearPolynomial::evaluate_with(Az, tau_coords),
@@ -369,8 +371,9 @@ where
           },
         );
         [eval_Az, eval_Bz, eval_Cz]
-      })
-      .collect::<Vec<_>>();
+      }
+    )
+    .collect::<Vec<_>>();
 
     // absorb the claimed evaluations into the transcript
     evals_Az_Bz_Cz_at_tau.iter().for_each(|evals| {
@@ -410,8 +413,10 @@ where
     // (2) send commitments to the following two oracles
     // L_row(i) = eq(tau, row(i)) for all i in [0..Nᵢ]
     // L_col(i) = z(col(i)) for all i in [0..Nᵢ]
-    let polys_L_row_col =
-      zip_with_par_iter!((S, N, polys_Z, polys_tau), |S, Ni, poly_Z, poly_tau| {
+    let polys_L_row_col = zip_with_fn!(
+      par_iter,
+      (S, N, polys_Z, polys_tau),
+      |S, Ni, poly_Z, poly_tau| {
         let mut L_row = vec![poly_tau[0]; *Ni]; // we place mem_row[0] since resized row is appended with 0s
         let mut L_col = vec![poly_Z[Ni - 1]; *Ni]; // we place mem_col[Ni-1] since resized col is appended with Ni-1
 
@@ -428,8 +433,9 @@ where
         }
 
         [L_row, L_col]
-      })
-      .collect::<Vec<_>>();
+      }
+    )
+    .collect::<Vec<_>>();
 
     let comms_L_row_col = polys_L_row_col
       .par_iter()
@@ -457,7 +463,8 @@ where
       })
       .collect();
 
-    let evals_Mz: Vec<_> = zip_with_iter!(
+    let evals_Mz: Vec<_> = zip_with_fn!(
+      iter,
       (comms_Az_Bz_Cz, evals_Az_Bz_Cz_at_tau),
       |comm_Az_Bz_Cz, evals_Az_Bz_Cz_at_tau| {
         let u = PolyEvalInstance::<E>::batch(
@@ -491,7 +498,7 @@ where
       ),
       |poly_ABC, poly_E, poly_Mz, poly_tau, eval_Mz, u| {
         let [poly_Az, poly_Bz, poly_Cz] = poly_ABC;
-        let poly_uCz_E = zip_with_par_iter!((poly_Cz, poly_E), |cz, e| *u * cz + e).collect();
+        let poly_uCz_E = zip_with_fn!(par_iter, (poly_Cz, poly_E), |cz, e| *u * cz + e).collect();
         OuterSumcheckInstance::new(
           poly_tau.clone(),
           poly_Az.clone(),
@@ -504,12 +511,14 @@ where
     )
     .collect::<Vec<_>>();
 
-    let inner_sc_inst = zip_with_par_iter!(
+    let inner_sc_inst = zip_with_fn!(
+      par_iter,
       (pk.S_repr, evals_Mz, polys_L_row_col),
       |s_repr, eval_Mz, poly_L| {
         let [poly_L_row, poly_L_col] = poly_L;
         let c_square = c.square();
-        let val = zip_with_par_iter!(
+        let val = zip_with_fn!(
+          par_iter,
           (s_repr.val_A, s_repr.val_B, s_repr.val_C),
           |v_a, v_b, v_c| *v_a + c * *v_b + c_square * *v_c
         )
@@ -595,7 +604,7 @@ where
       (instances, comms_mem_oracles, polys_mem_oracles)
     };
 
-    let witness_sc_inst = zip_with_par_iter!((polys_W, S), |poly_W, S| {
+    let witness_sc_inst = zip_with_fn!(par_iter, (polys_W, S), |poly_W, S| {
       WitnessBoundSumcheck::new(tau, poly_W.clone(), S.num_vars)
     })
     .collect::<Vec<_>>();
@@ -642,7 +651,8 @@ where
         .map(|claims| claims[0][0])
         .collect::<Vec<_>>();
 
-      let (evals_Cz_E, evals_mem_val_row_col): (Vec<_>, Vec<_>) = zip_with_iter!(
+      let (evals_Cz_E, evals_mem_val_row_col): (Vec<_>, Vec<_>) = zip_with_fn!(
+        iter,
         (polys_Az_Bz_Cz, polys_E, pk.S_repr),
         |ABCzs, poly_E, s_repr| {
           let [_, _, Cz] = ABCzs;
@@ -661,7 +671,7 @@ where
           .into_iter()
           .map(|p| {
             // Manually compute evaluation to avoid recomputing rand_sc_evals
-            zip_with_par_iter!((p, rand_sc_evals), |p, eq| *p * eq).sum()
+            zip_with_fn!(par_iter, (p, rand_sc_evals), |p, eq| *p * eq).sum()
           })
           .collect::<Vec<E::Scalar>>();
           ([e[0], e[1]], [e[2], e[3], e[4], e[5], e[6]])
@@ -697,7 +707,8 @@ where
       )
     };
 
-    let evals_vec = zip_with_iter!(
+    let evals_vec = zip_with_fn!(
+      iter,
       (
         evals_Az_Bz_Cz_W_E,
         evals_L_row_col,
@@ -712,7 +723,8 @@ where
     )
     .collect::<Vec<_>>();
 
-    let comms_vec = zip_with_iter!(
+    let comms_vec = zip_with_fn!(
+      iter,
       (
         comms_Az_Bz_Cz,
         comms_W_E,
@@ -898,7 +910,8 @@ where
     let c = transcript.squeeze(b"c")?;
 
     // Compute eval_Mz = eval_Az_at_tau + c * eval_Bz_at_tau + c^2 * eval_Cz_at_tau
-    let evals_Mz: Vec<_> = zip_with_iter!(
+    let evals_Mz: Vec<_> = zip_with_fn!(
+      iter,
       (comms_Az_Bz_Cz, self.evals_Az_Bz_Cz_at_tau),
       |comm_Az_Bz_Cz, evals_Az_Bz_Cz_at_tau| {
         let u = PolyEvalInstance::<E>::batch(
@@ -1084,7 +1097,8 @@ where
       return Err(NovaError::InvalidSumcheckProof);
     }
 
-    let evals_vec = zip_with_iter!(
+    let evals_vec = zip_with_fn!(
+      iter,
       (
         self.evals_Az_Bz_Cz_W_E,
         self.evals_L_row_col,
@@ -1246,7 +1260,8 @@ where
     // Collect all claims from the instances. If the instances is defined over `m` variables,
     // which is less that the total number of rounds `n`,
     // the individual claims σ are scaled by 2^{n-m}.
-    let claims = zip_with_iter!(
+    let claims = zip_with_fn!(
+      iter,
       (mem, outer, inner, witness),
       |mem, outer, inner, witness| {
         Self::scaled_claims(mem, num_rounds)
@@ -1266,7 +1281,7 @@ where
     // At the start of each round, the running claim is equal to the random linear combination
     // of the Sumcheck claims, evaluated over the bound polynomials.
     // Initially, it is equal to the random linear combination of the scaled input claims.
-    let mut running_claim = zip_with_iter!((claims, coeffs), |c_1, c_2| *c_1 * c_2).sum();
+    let mut running_claim = zip_with_fn!(iter, (claims, coeffs), |c_1, c_2| *c_1 * c_2).sum();
 
     // Keep track of the verifier challenges r, and the univariate polynomials sent by the prover
     // in each round
@@ -1281,7 +1296,8 @@ where
       // at X = 0, 2, 3. The polynomial is such that S_{j-1}(r_{j-1}) = S_j(0) + S_j(1).
       // If the number of variable m of the claim is m < n-i, then the polynomial is
       // constants and equal to the initial claim σ_j scaled by 2^{n-m-i-1}.
-      let evals = zip_with_par_iter!(
+      let evals = zip_with_fn!(
+        par_iter,
         (mem, outer, inner, witness),
         |mem, outer, inner, witness| {
           let ((evals_mem, evals_outer), (evals_inner, evals_witness)) = rayon::join(

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -225,7 +225,7 @@ where
 
   fn setup(
     ck: &CommitmentKey<E>,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     for s in S.iter() {
       // check the provided commitment key meets minimal requirements
@@ -256,7 +256,7 @@ where
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
     U: &[RelaxedR1CSInstance<E>],
     W: &[RelaxedR1CSWitness<E>],
   ) -> Result<Self, NovaError> {

--- a/src/spartan/macros.rs
+++ b/src/spartan/macros.rs
@@ -25,38 +25,6 @@ macro_rules! zip_with {
     }};
 }
 
-/// Like `zip_with` but call `iter()` on each input to produce the iterators.
-#[macro_export]
-macro_rules! zip_with_iter {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with_fn!(iter, ($e $(, $rest)*), $($move)? |$($i),+| $($work)*)
-    }};
-}
-
-/// Like `zip_with` but call `par_iter()` on each input to produce the iterators.
-#[macro_export]
-macro_rules! zip_with_par_iter {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with_fn!(par_iter, ($e $(, $rest)*), $($move)? |$($i),+| $($work)*)
-    }};
-}
-
-/// Like `zip_with` but call `into_iter()` on each input to produce the iterators.
-#[macro_export]
-macro_rules! zip_with_into_iter {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with_fn!(into_iter, ($e $(, $rest)*), $($move)? |$($i),+| $($work)*)
-    }};
-}
-
-/// Like `zip_with` but call `into_par_iter()` on each input to produce the iterators.
-#[macro_export]
-macro_rules! zip_with_into_par_iter {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-     $crate::zip_with_fn!(into_par_iter, ($e $(, $rest)*), $($move)? |$($i),+| $($work)*)
-    }};
-}
-
 /// General utility macro for `zip_with` variants where iterator-producer and optional post-zip function can be
 /// specified.
 #[macro_export]

--- a/src/spartan/macros.rs
+++ b/src/spartan/macros.rs
@@ -29,12 +29,12 @@ macro_rules! zip_with {
     //   vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).map(|(a, (b, c))| a + b + c)
     // ````
     ($($f:ident,)? ($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with!($($f,)? ($e $(, $rest)*), [map], $($move)? |$($i),+| $($work)*)
+        $crate::zip_with!($($f,)? ($e $(, $rest)*), map, $($move)? |$($i),+| $($work)*)
     }};
     // no iterator projection specified: the macro assumes the arguments *are* iterators
     // optional zipping function specified as well: use it instead of map
     // ```ignore
-    // zip_with!((iter1, iter2, iter3), [for_each], |a, b, c| a + b + c) ->
+    // zip_with!((iter1, iter2, iter3), for_each, |a, b, c| a + b + c) ->
     //   iter1.zip_eq(iter2.zip_eq(iter3)).for_each(|(a, (b, c))| a + b + c)
     // ```
     //
@@ -42,10 +42,10 @@ macro_rules! zip_with {
     // iterator projection specified: use it on each argument
     // optional zipping function specified as well: use it instead of map
     // ```ignore
-    // zip_with!(par_iter, (vec1, vec2, vec3), [for_each], |a, b, c| a + b + c) ->
+    // zip_with!(par_iter, (vec1, vec2, vec3), for_each, |a, b, c| a + b + c) ->
     //   vec1.part_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).for_each(|(a, (b, c))| a + b + c)
     // ```
-    ($($f:ident,)? ($e:expr $(, $rest:expr)*), [$worker:ident], $($move:ident,)? |$($i:ident),+ $(,)?|  $($work:tt)*) => {{
+    ($($f:ident,)? ($e:expr $(, $rest:expr)*), $worker:ident, $($move:ident,)? |$($i:ident),+ $(,)?|  $($work:tt)*) => {{
         $crate::zip_all!($($f,)? ($e $(, $rest)*))
             .$worker($($move)? |$crate::nested_idents!($($i),+)| {
                 $($work)*
@@ -68,7 +68,7 @@ macro_rules! zip_with_for_each {
     //   vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).for_each(|(a, (b, c))| a + b + c)
     // ````
     ($($f:ident,)? ($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with!($($f,)? ($e $(, $rest)*), [for_each], $($move)? |$($i),+| $($work)*)
+        $crate::zip_with!($($f,)? ($e $(, $rest)*), for_each, $($move)? |$($i),+| $($work)*)
     }};
 }
 

--- a/src/spartan/macros.rs
+++ b/src/spartan/macros.rs
@@ -72,20 +72,7 @@ macro_rules! zip_with_for_each {
     }};
 }
 
-// Fold-right like nesting pattern for expressions a, b, c, d => (a, (b, (c, d)))
-#[doc(hidden)]
-#[allow(unused_macros)]
-#[macro_export]
-macro_rules! nested_tuple {
-    ($a:expr, $b:expr) => {
-        ($a, $b)
-    };
-    ($first:expr, $($rest:expr),+) => {
-        ($first, $crate::nested_tuple!($($rest),+))
-    };
-}
-
-// Same as the above for idents
+// Foldright-like nesting for idents (a, b, c) -> (a, (b, c))
 #[doc(hidden)]
 #[allow(unused_macro_rules)]
 #[macro_export]

--- a/src/spartan/macros.rs
+++ b/src/spartan/macros.rs
@@ -17,27 +17,37 @@
 
 #[macro_export]
 macro_rules! zip_with {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_all!(($e $(, $rest)*))
-            .map($($move)? |$crate::nested_idents!($($i),+)| {
-                $($work)*
-            })
+    // no iterator projection specified: the macro assumes the arguments *are* iterators
+    // ```ignore
+    // zip_with!((iter1, iter2, iter3), |a, b, c| a + b + c) ->
+    //   iter1.zip_eq(iter2.zip_eq(iter3)).map(|(a, (b, c))| a + b + c)
+    // ```
+    //
+    // iterator projection specified: use it on each argument
+    // ```ignore
+    // zip_with!(par_iter, (vec1, vec2, vec3), |a, b, c| a + b + c) ->
+    //   vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).map(|(a, (b, c))| a + b + c)
+    // ````
+    ($($f:ident,)? ($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
+        $crate::zip_with!($($f,)? ($e $(, $rest)*), [map], $($move)? |$($i),+| $($work)*)
     }};
-}
-
-/// General utility macro for `zip_with` variants where iterator-producer and optional post-zip function can be
-/// specified.
-#[macro_export]
-macro_rules! zip_with_fn {
-    ($f:ident, ($e:expr $(, $rest:expr)*), [$worker:ident] $($move:ident)?, |$($i:ident),+ $(,)?|  $($work:tt)*) => {{
-        $crate::zip_all_with_fn!($f, ($e $(, $rest)*))
+    // no iterator projection specified: the macro assumes the arguments *are* iterators
+    // optional zipping function specified as well: use it instead of map
+    // ```ignore
+    // zip_with!((iter1, iter2, iter3), [for_each], |a, b, c| a + b + c) ->
+    //   iter1.zip_eq(iter2.zip_eq(iter3)).for_each(|(a, (b, c))| a + b + c)
+    // ```
+    //
+    //
+    // iterator projection specified: use it on each argument
+    // optional zipping function specified as well: use it instead of map
+    // ```ignore
+    // zip_with!(par_iter, (vec1, vec2, vec3), [for_each], |a, b, c| a + b + c) ->
+    //   vec1.part_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).for_each(|(a, (b, c))| a + b + c)
+    // ```
+    ($($f:ident,)? ($e:expr $(, $rest:expr)*), [$worker:ident], $($move:ident,)? |$($i:ident),+ $(,)?|  $($work:tt)*) => {{
+        $crate::zip_all!($($f,)? ($e $(, $rest)*))
             .$worker($($move)? |$crate::nested_idents!($($i),+)| {
-                $($work)*
-            })
-    }};
-    ($f:ident, ($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_all_with_fn!($f, ($e $(, $rest)*))
-            .map($($move)? |$crate::nested_idents!($($i),+)| {
                 $($work)*
             })
     }};
@@ -46,20 +56,19 @@ macro_rules! zip_with_fn {
 /// Like `zip_with` but use `for_each` instead of `map`.
 #[macro_export]
 macro_rules! zip_with_for_each {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_all!(($e $(, $rest)*))
-            .for_each($($move)? |$crate::nested_idents!($($i),+)| {
-                $($work)*
-            })
-    }};
-}
-
-/// Like `zip_with` but call `par_iter_mut()` on each input to produce the iterators, and apply `for_each` instead of
-/// `map` after zipping.
-#[macro_export]
-macro_rules! zip_with_par_iter_mut_for_each {
-    (($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
-        $crate::zip_with_fn!(par_iter_mut, ($e $(, $rest)*), [for_each], $($move)? |$($i),+| $($work)*)
+    // no iterator projection specified: the macro assumes the arguments *are* iterators
+    // ```ignore
+    // zip_with_for_each!((iter1, iter2, iter3), |a, b, c| a + b + c) ->
+    //   iter1.zip_eq(iter2.zip_eq(iter3)).for_each(|(a, (b, c))| a + b + c)
+    // ```
+    //
+    // iterator projection specified: use it on each argument
+    // ```ignore
+    // zip_with_for_each!(par_iter, (vec1, vec2, vec3), |a, b, c| a + b + c) ->
+    //   vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).for_each(|(a, (b, c))| a + b + c)
+    // ````
+    ($($f:ident,)? ($e:expr $(, $rest:expr)*), $($move:ident)? |$($i:ident),+ $(,)?| $($work:tt)*) => {{
+        $crate::zip_with!($($f,)? ($e $(, $rest)*), [for_each], $($move)? |$($i),+| $($work)*)
     }};
 }
 
@@ -89,25 +98,20 @@ macro_rules! nested_idents {
     };
 }
 
-// Fold-right like zipping
+// Fold-right like zipping, with an optional function `f` to apply to each argument
 #[doc(hidden)]
 #[macro_export]
 macro_rules! zip_all {
     (($e:expr,)) => {
         $e
     };
-    (($first:expr, $second:expr $(, $rest:expr)*)) => {
-        ($first.zip_eq($crate::zip_all!(($second, $( $rest),*))))
-    };
-}
-
-/// Like `zip_all` but with specified function to produce the iterators
-#[macro_export]
-macro_rules! zip_all_with_fn {
     ($f:ident, ($e:expr,)) => {
         $e.$f()
     };
     ($f:ident, ($first:expr, $second:expr $(, $rest:expr)*)) => {
-        ($first.$f().zip_eq($crate::zip_all_with_fn!($f, ($second, $( $rest),*))))
+        ($first.$f().zip_eq($crate::zip_all!($f, ($second, $( $rest),*))))
+    };
+    (($first:expr, $second:expr $(, $rest:expr)*)) => {
+        ($first.zip_eq($crate::zip_all!(($second, $( $rest),*))))
     };
 }

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -101,7 +101,7 @@ impl<E: Engine> PolyEvalWitness<E> {
 
     let powers_of_s = powers::<E>(s, p_vec.len());
 
-    let p = zip_with_fn!(par_iter, (p_vec, powers_of_s), |v, weight| {
+    let p = zip_with!(par_iter, (p_vec, powers_of_s), |v, weight| {
       // compute the weighted sum for each vector
       v.iter().map(|&x| x * *weight).collect::<Vec<E::Scalar>>()
     })
@@ -140,7 +140,7 @@ impl<E: Engine> PolyEvalInstance<E> {
     let powers: Vec<E::Scalar> = powers::<E>(&s, num_instances);
     // Rescale evaluations by the first Lagrange polynomial,
     // so that we can check its evaluation against x
-    let evals_scaled = zip_with_fn!(iter, (e_vec, num_vars), |eval, num_rounds| {
+    let evals_scaled = zip_with!(iter, (e_vec, num_vars), |eval, num_rounds| {
       // x_lo = [ x[0]   , ..., x[n-nᵢ-1] ]
       // x_hi = [ x[n-nᵢ], ..., x[n]      ]
       let (r_lo, _r_hi) = x.split_at(num_vars_max - num_rounds);
@@ -156,7 +156,7 @@ impl<E: Engine> PolyEvalInstance<E> {
     .collect::<Vec<_>>();
 
     // C = ∑ᵢ γⁱ⋅Cᵢ
-    let comm_joint = zip_with_fn!(iter, (c_vec, powers), |c, g_i| *c * *g_i)
+    let comm_joint = zip_with!(iter, (c_vec, powers), |c, g_i| *c * *g_i)
       .fold(Commitment::<E>::default(), |acc, item| acc + item);
 
     // v = ∑ᵢ γⁱ⋅vᵢ
@@ -180,9 +180,9 @@ impl<E: Engine> PolyEvalInstance<E> {
 
     let powers_of_s = powers::<E>(s, num_instances);
     // Weighted sum of evaluations
-    let e = zip_with_fn!(par_iter, (e_vec, powers_of_s), |e, p| *e * p).sum();
+    let e = zip_with!(par_iter, (e_vec, powers_of_s), |e, p| *e * p).sum();
     // Weighted sum of commitments
-    let c = zip_with_fn!(par_iter, (c_vec, powers_of_s), |c, p| *c * *p)
+    let c = zip_with!(par_iter, (c_vec, powers_of_s), |c, p| *c * *p)
       .reduce(Commitment::<E>::default, |acc, item| acc + item);
 
     PolyEvalInstance {

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -101,7 +101,7 @@ impl<E: Engine> PolyEvalWitness<E> {
 
     let powers_of_s = powers::<E>(s, p_vec.len());
 
-    let p = zip_with_par_iter!((p_vec, powers_of_s), |v, weight| {
+    let p = zip_with_fn!(par_iter, (p_vec, powers_of_s), |v, weight| {
       // compute the weighted sum for each vector
       v.iter().map(|&x| x * *weight).collect::<Vec<E::Scalar>>()
     })
@@ -140,7 +140,7 @@ impl<E: Engine> PolyEvalInstance<E> {
     let powers: Vec<E::Scalar> = powers::<E>(&s, num_instances);
     // Rescale evaluations by the first Lagrange polynomial,
     // so that we can check its evaluation against x
-    let evals_scaled = zip_with_iter!((e_vec, num_vars), |eval, num_rounds| {
+    let evals_scaled = zip_with_fn!(iter, (e_vec, num_vars), |eval, num_rounds| {
       // x_lo = [ x[0]   , ..., x[n-nᵢ-1] ]
       // x_hi = [ x[n-nᵢ], ..., x[n]      ]
       let (r_lo, _r_hi) = x.split_at(num_vars_max - num_rounds);
@@ -156,7 +156,7 @@ impl<E: Engine> PolyEvalInstance<E> {
     .collect::<Vec<_>>();
 
     // C = ∑ᵢ γⁱ⋅Cᵢ
-    let comm_joint = zip_with_iter!((c_vec, powers), |c, g_i| *c * *g_i)
+    let comm_joint = zip_with_fn!(iter, (c_vec, powers), |c, g_i| *c * *g_i)
       .fold(Commitment::<E>::default(), |acc, item| acc + item);
 
     // v = ∑ᵢ γⁱ⋅vᵢ
@@ -180,9 +180,9 @@ impl<E: Engine> PolyEvalInstance<E> {
 
     let powers_of_s = powers::<E>(s, num_instances);
     // Weighted sum of evaluations
-    let e = zip_with_par_iter!((e_vec, powers_of_s), |e, p| *e * p).sum();
+    let e = zip_with_fn!(par_iter, (e_vec, powers_of_s), |e, p| *e * p).sum();
     // Weighted sum of commitments
-    let c = zip_with_par_iter!((c_vec, powers_of_s), |c, p| *c * *p)
+    let c = zip_with_fn!(par_iter, (c_vec, powers_of_s), |c, p| *c * *p)
       .reduce(Commitment::<E>::default, |acc, item| acc + item);
 
     PolyEvalInstance {

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -187,7 +187,7 @@ impl<Scalar: PrimeField> Add for MultilinearPolynomial<Scalar> {
       return Err("The two polynomials must have the same number of variables");
     }
 
-    let sum: Vec<Scalar> = zip_with_into_iter!((self.Z, other.Z), |a, b| a + b).collect();
+    let sum: Vec<Scalar> = zip_with_fn!(into_iter, (self.Z, other.Z), |a, b| a + b).collect();
 
     Ok(MultilinearPolynomial::new(sum))
   }

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -187,7 +187,7 @@ impl<Scalar: PrimeField> Add for MultilinearPolynomial<Scalar> {
       return Err("The two polynomials must have the same number of variables");
     }
 
-    let sum: Vec<Scalar> = zip_with_fn!(into_iter, (self.Z, other.Z), |a, b| a + b).collect();
+    let sum: Vec<Scalar> = zip_with!(into_iter, (self.Z, other.Z), |a, b| a + b).collect();
 
     Ok(MultilinearPolynomial::new(sum))
   }

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -200,18 +200,13 @@ impl<E: Engine> SumcheckProof<E> {
       let a = &poly_A_vec[i];
       let b = &poly_B_vec[i];
 
-      assert_eq!(
-        a.len(),
-        expected_size,
-        "Mismatch in size for poly_A_vec at index {}",
-        i
-      );
-      assert_eq!(
-        b.len(),
-        expected_size,
-        "Mismatch in size for poly_B_vec at index {}",
-        i
-      );
+      for (l, polyname) in [(a.len(), "poly_A_vec"), (b.len(), "poly_B_vec")].iter() {
+        assert_eq!(
+          *l, expected_size,
+          "Mismatch in size for {} at index {}",
+          polyname, i
+        );
+      }
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();
@@ -497,30 +492,20 @@ impl<E: Engine> SumcheckProof<E> {
       let c = &poly_C_vec[i];
       let d = &poly_D_vec[i];
 
-      assert_eq!(
-        a.len(),
-        expected_size,
-        "Mismatch in size for poly_A_vec at index {}",
-        i
-      );
-      assert_eq!(
-        b.len(),
-        expected_size,
-        "Mismatch in size for poly_B_vec at index {}",
-        i
-      );
-      assert_eq!(
-        c.len(),
-        expected_size,
-        "Mismatch in size for poly_C_vec at index {}",
-        i
-      );
-      assert_eq!(
-        d.len(),
-        expected_size,
-        "Mismatch in size for poly_D_vec at index {}",
-        i
-      );
+      for (l, polyname) in [
+        (a.len(), "poly_A"),
+        (b.len(), "poly_B"),
+        (c.len(), "poly_C"),
+        (d.len(), "poly_D"),
+      ]
+      .iter()
+      {
+        assert_eq!(
+          *l, expected_size,
+          "Mismatch in size for {} at index {}",
+          polyname, i
+        );
+      }
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -83,7 +83,7 @@ impl<E: Engine> SumcheckProof<E> {
     // claim = ∑ᵢ coeffᵢ⋅2^{n-nᵢ}⋅cᵢ
     let claim = zip_with!(
       (
-        zip_with_fn!(iter, (claims, num_rounds), |claim, num_rounds| {
+        zip_with!(iter, (claims, num_rounds), |claim, num_rounds| {
           let scaling_factor = 1 << (num_rounds_max - num_rounds);
           E::Scalar::from(scaling_factor as u64) * claim
         }),
@@ -215,7 +215,7 @@ impl<E: Engine> SumcheckProof<E> {
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();
-    let mut e = zip_with_fn!(
+    let mut e = zip_with!(
       iter,
       (claims, num_rounds, coeffs),
       |claim, num_rounds, coeff| {
@@ -229,7 +229,7 @@ impl<E: Engine> SumcheckProof<E> {
 
     for current_round in 0..num_rounds_max {
       let remaining_rounds = num_rounds_max - current_round;
-      let evals: Vec<(E::Scalar, E::Scalar)> = zip_with_fn!(
+      let evals: Vec<(E::Scalar, E::Scalar)> = zip_with!(
         par_iter,
         (num_rounds, claims, poly_A_vec, poly_B_vec),
         |num_rounds, claim, poly_A, poly_B| {
@@ -289,7 +289,7 @@ impl<E: Engine> SumcheckProof<E> {
       .map(|poly| poly[0])
       .collect::<Vec<_>>();
 
-    let eval_expected = zip_with_fn!(
+    let eval_expected = zip_with!(
       iter,
       (poly_A_final, poly_B_final, coeffs),
       |eA, eB, coeff| comb_func(eA, eB) * coeff
@@ -527,7 +527,7 @@ impl<E: Engine> SumcheckProof<E> {
 
     let mut r: Vec<E::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::new();
-    let mut claim_per_round = zip_with_fn!(
+    let mut claim_per_round = zip_with!(
       iter,
       (claims, num_rounds, coeffs),
       |claim, num_rounds, coeff| {
@@ -539,7 +539,7 @@ impl<E: Engine> SumcheckProof<E> {
 
     for current_round in 0..num_rounds_max {
       let remaining_rounds = num_rounds_max - current_round;
-      let evals: Vec<(E::Scalar, E::Scalar, E::Scalar)> = zip_with_fn!(
+      let evals: Vec<(E::Scalar, E::Scalar, E::Scalar)> = zip_with!(
         par_iter,
         (num_rounds, claims, poly_A_vec, poly_B_vec, poly_C_vec, poly_D_vec),
         |num_rounds, claim, poly_A, poly_B, poly_C, poly_D| {

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -83,7 +83,7 @@ impl<E: Engine> SumcheckProof<E> {
     // claim = ∑ᵢ coeffᵢ⋅2^{n-nᵢ}⋅cᵢ
     let claim = zip_with!(
       (
-        zip_with_iter!((claims, num_rounds), |claim, num_rounds| {
+        zip_with_fn!(iter, (claims, num_rounds), |claim, num_rounds| {
           let scaling_factor = 1 << (num_rounds_max - num_rounds);
           E::Scalar::from(scaling_factor as u64) * claim
         }),
@@ -215,17 +215,22 @@ impl<E: Engine> SumcheckProof<E> {
     }
 
     let num_rounds_max = *num_rounds.iter().max().unwrap();
-    let mut e = zip_with_iter!((claims, num_rounds, coeffs), |claim, num_rounds, coeff| {
-      let scaled_claim = E::Scalar::from((1 << (num_rounds_max - num_rounds)) as u64) * claim;
-      scaled_claim * coeff
-    })
+    let mut e = zip_with_fn!(
+      iter,
+      (claims, num_rounds, coeffs),
+      |claim, num_rounds, coeff| {
+        let scaled_claim = E::Scalar::from((1 << (num_rounds_max - num_rounds)) as u64) * claim;
+        scaled_claim * coeff
+      }
+    )
     .sum();
     let mut r: Vec<E::Scalar> = Vec::new();
     let mut quad_polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::new();
 
     for current_round in 0..num_rounds_max {
       let remaining_rounds = num_rounds_max - current_round;
-      let evals: Vec<(E::Scalar, E::Scalar)> = zip_with_par_iter!(
+      let evals: Vec<(E::Scalar, E::Scalar)> = zip_with_fn!(
+        par_iter,
         (num_rounds, claims, poly_A_vec, poly_B_vec),
         |num_rounds, claim, poly_A, poly_B| {
           if remaining_rounds <= *num_rounds {
@@ -284,12 +289,12 @@ impl<E: Engine> SumcheckProof<E> {
       .map(|poly| poly[0])
       .collect::<Vec<_>>();
 
-    let eval_expected =
-      zip_with_iter!(
-        (poly_A_final, poly_B_final, coeffs),
-        |eA, eB, coeff| comb_func(eA, eB) * coeff
-      )
-      .sum::<E::Scalar>();
+    let eval_expected = zip_with_fn!(
+      iter,
+      (poly_A_final, poly_B_final, coeffs),
+      |eA, eB, coeff| comb_func(eA, eB) * coeff
+    )
+    .sum::<E::Scalar>();
     assert_eq!(e, eval_expected);
 
     let claims_prod = (poly_A_final, poly_B_final);
@@ -522,16 +527,20 @@ impl<E: Engine> SumcheckProof<E> {
 
     let mut r: Vec<E::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::new();
-    let mut claim_per_round =
-      zip_with_iter!((claims, num_rounds, coeffs), |claim, num_rounds, coeff| {
+    let mut claim_per_round = zip_with_fn!(
+      iter,
+      (claims, num_rounds, coeffs),
+      |claim, num_rounds, coeff| {
         let scaled_claim = E::Scalar::from((1 << (num_rounds_max - num_rounds)) as u64) * claim;
         scaled_claim * *coeff
-      })
-      .sum();
+      }
+    )
+    .sum();
 
     for current_round in 0..num_rounds_max {
       let remaining_rounds = num_rounds_max - current_round;
-      let evals: Vec<(E::Scalar, E::Scalar, E::Scalar)> = zip_with_par_iter!(
+      let evals: Vec<(E::Scalar, E::Scalar, E::Scalar)> = zip_with_fn!(
+        par_iter,
         (num_rounds, claims, poly_A_vec, poly_B_vec, poly_C_vec, poly_D_vec),
         |num_rounds, claim, poly_A, poly_B, poly_C, poly_D| {
           if remaining_rounds <= *num_rounds {

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -385,12 +385,11 @@ where
   }
 
   /// Returns all the primary R1CS Shapes
-  pub fn primary_r1cs_shapes(&self) -> Vec<R1CSShape<E1>> {
+  pub fn primary_r1cs_shapes(&self) -> Vec<&R1CSShape<E1>> {
     self
       .circuit_shapes
-      .clone()
-      .into_iter()
-      .map(|cs| cs.r1cs_shape)
+      .iter()
+      .map(|cs| &cs.r1cs_shape)
       .collect::<Vec<_>>()
   }
 }

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -119,7 +119,7 @@ where
     ),
     SuperNovaError,
   > {
-    let (pk_primary, vk_primary) = S1::setup(&pp.ck_primary, &pp.primary_r1cs_shapes())?;
+    let (pk_primary, vk_primary) = S1::setup(&pp.ck_primary, pp.primary_r1cs_shapes())?;
 
     let (pk_secondary, vk_secondary) =
       S2::setup(&pp.ck_secondary, &pp.circuit_shape_secondary.r1cs_shape)?;
@@ -182,7 +182,7 @@ where
     let r_W_snark_primary = S1::prove(
       &pp.ck_primary,
       &pk.pk_primary,
-      &pp.primary_r1cs_shapes(),
+      pp.primary_r1cs_shapes(),
       &r_U_primary,
       &r_W_primary,
     )?;

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -878,18 +878,7 @@ where
     &z0_secondary,
   )
   .map_err(|err| {
-    print_constraints_name_on_error_index(
-      &err,
-      &pp,
-      circuit_primary,
-      &circuit_secondary,
-      <RootCheckingCircuit<E1::Scalar> as NonUniformCircuit<
-        E1,
-        E2,
-        RootCheckingCircuit<E1::Scalar>,
-        TrivialSecondaryCircuit<E1::Base>,
-      >>::num_circuits(circuit_primary),
-    )
+    print_constraints_name_on_error_index(&err, &pp, circuit_primary, &circuit_secondary, 2)
   })
   .unwrap();
 
@@ -897,18 +886,7 @@ where
     let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
     assert!(res
       .map_err(|err| {
-        print_constraints_name_on_error_index(
-          &err,
-          &pp,
-          circuit_primary,
-          &circuit_secondary,
-          <RootCheckingCircuit<E1::Scalar> as NonUniformCircuit<
-            E1,
-            E2,
-            RootCheckingCircuit<E1::Scalar>,
-            TrivialSecondaryCircuit<E1::Base>,
-          >>::num_circuits(circuit_primary),
-        )
+        print_constraints_name_on_error_index(&err, &pp, circuit_primary, &circuit_secondary, 2)
       })
       .is_ok());
 
@@ -916,18 +894,7 @@ where
     let res = recursive_snark
       .verify(&pp, 0, &z0_primary, &z0_secondary)
       .map_err(|err| {
-        print_constraints_name_on_error_index(
-          &err,
-          &pp,
-          circuit_primary,
-          &circuit_secondary,
-          <RootCheckingCircuit<E1::Scalar> as NonUniformCircuit<
-            E1,
-            E2,
-            RootCheckingCircuit<E1::Scalar>,
-            TrivialSecondaryCircuit<E1::Base>,
-          >>::num_circuits(circuit_primary),
-        )
+        print_constraints_name_on_error_index(&err, &pp, circuit_primary, &circuit_secondary, 2)
       });
     assert!(res.is_ok());
   }

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -87,14 +87,14 @@ pub trait BatchedRelaxedR1CSSNARKTrait<E: Engine>:
   /// Produces the keys for the prover and the verifier
   fn setup(
     ck: &CommitmentKey<E>,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError>;
 
   /// Produces a new SNARK for a batch of relaxed R1CS
   fn prove(
     ck: &CommitmentKey<E>,
     pk: &Self::ProverKey,
-    S: &[R1CSShape<E>],
+    S: Vec<&R1CSShape<E>>,
     U: &[RelaxedR1CSInstance<E>],
     W: &[RelaxedR1CSWitness<E>],
   ) -> Result<Self, NovaError>;


### PR DESCRIPTION
## The Problem

The current macro system requires learning what 7 auxiliary macros do: `zip_with, zip_with_for_each, zip_with_into_par_iter, zip_with_iter, zip_with_par_iter, zip_with_par_iter_mut_for_each, zip_with_into_iter`.

## This PR

Switches us to a mode in which the user has only 2 macros to learn about : `zip_with` and `zip_with_for_each`.
This further documents them as such:
```
// no iterator projection specified: the macro assumes the arguments *are* iterators
// zip_with!((iter1, iter2, iter3), |a, b, c| a + b + c) -> iter1.zip_eq(iter2.zip_eq(iter3)).map(|(a, (b, c))| a + b + c)
//
// iterator projection specified: use it on each argument
// zip_with!(par_iter, (vec1, vec2, vec3), |a, b, c| a + b + c) -> 
// vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).map(|(a, (b, c))| a + b + c)
```
and:
```
// no iterator projection specified: the macro assumes the arguments *are* iterators
// zip_with_for_each!((iter1, iter2, iter3), |a, b, c| a + b + c) -> iter1.zip_eq(iter2.zip_eq(iter3)).for_each(|(a, (b, c))| a + b + c)
//
// iterator projection specified: use it on each argument
// zip_with_for_each!(par_iter, (vec1, vec2, vec3), |a, b, c| a + b + c) ->
//   vec1.par_iter().zip_eq(vec2.par_iter().zip_eq(vec3.par_iter())).for_each(|(a, (b, c))| a + b + c)
```

Everything is refactored to use one of these two macros. While there are more complex forms to these macros, the user doesn't need to import them or know about them. The implementations are also simplified.

## Details
Also contains #170 because stacked PRs in Git are a mess.