### PR TITLE
Remove circuit_index dependence of `supernova::RecursiveSNARK::verify`

### DIFF
--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -140,7 +140,7 @@ fn bench_one_augmented_circuit_compressed_snark(c: &mut Criterion) {
         println!("res failed {:?}", e);
       }
       assert!(res.is_ok());
-      let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+      let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
       if let Err(e) = &res {
         println!("res failed {:?}", e);
       }
@@ -232,7 +232,7 @@ fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -244,7 +244,7 @@ fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -340,7 +340,7 @@ fn bench_two_augmented_circuit_compressed_snark_with_computational_commitments(c
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -352,7 +352,7 @@ fn bench_two_augmented_circuit_compressed_snark_with_computational_commitments(c
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -136,7 +136,7 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         println!("res failed {:?}", e);
       }
       assert!(res.is_ok());
-      let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+      let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
       if let Err(e) = &res {
         println!("res failed {:?}", e);
       }
@@ -167,7 +167,6 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
         assert!(black_box(&mut recursive_snark.clone())
           .verify(
             black_box(&pp),
-            black_box(0),
             black_box(&[<PallasEngine as Engine>::Scalar::from(2u64)]),
             black_box(&[<VestaEngine as Engine>::Scalar::from(2u64)]),
           )
@@ -229,7 +228,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -241,7 +240,7 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
           println!("res failed {:?}", e);
         }
         assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, 0, &z0_primary, &z0_secondary);
+        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
         if let Err(e) = &res {
           println!("res failed {:?}", e);
         }
@@ -276,7 +275,6 @@ fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
         assert!(black_box(&mut recursive_snark.clone())
           .verify(
             black_box(&pp),
-            black_box(0),
             black_box(&[<PallasEngine as Engine>::Scalar::from(2u64)]),
             black_box(&[<VestaEngine as Engine>::Scalar::from(2u64)]),
           )

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -412,6 +412,9 @@ where
   // Inputs and outputs of the primary circuits
   z0_primary: Vec<E1::Scalar>,
   zi_primary: Vec<E1::Scalar>,
+
+  // Proven circuit index, and current program counter
+  proven_circuit_index: usize,
   program_counter: E1::Scalar,
 
   // Relaxed instances for the primary circuits
@@ -582,6 +585,8 @@ where
       i: 0_usize, // after base case, next iteration start from 1
       z0_primary: z0_primary.to_vec(),
       zi_primary,
+
+      proven_circuit_index: circuit_index,
       program_counter: zi_primary_pc_next,
 
       r_W_primary: r_W_primary_initial_list,
@@ -774,6 +779,7 @@ where
     self.i += 1;
     self.zi_primary = zi_primary;
     self.zi_secondary = zi_secondary;
+    self.proven_circuit_index = circuit_index;
     self.program_counter = zi_primary_pc_next;
     Ok(())
   }
@@ -782,7 +788,6 @@ where
   pub fn verify<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<E2::Scalar>>(
     &self,
     pp: &PublicParams<E1, E2, C1, C2>,
-    circuit_index: usize,
     z0_primary: &[E1::Scalar],
     z0_secondary: &[E2::Scalar],
   ) -> Result<(Vec<E1::Scalar>, Vec<E2::Scalar>), SuperNovaError> {
@@ -813,6 +818,8 @@ where
           Err(SuperNovaError::NovaError(NovaError::ProofVerifyError))
         }
       })?;
+
+    let circuit_index = self.proven_circuit_index;
 
     // check we have an instance/witness pair for the circuit_index
     if self.r_U_primary[circuit_index].is_none() {

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -455,13 +455,22 @@ where
     let num_augmented_circuits = non_uniform_circuit.num_circuits();
     let circuit_index = non_uniform_circuit.initial_circuit_index();
 
-    if z0_primary.len() != pp[circuit_index].F_arity
-      || z0_secondary.len() != pp.circuit_shape_secondary.F_arity
-    {
+    // check the length of the secondary initial input
+    if z0_secondary.len() != pp.circuit_shape_secondary.F_arity {
       return Err(SuperNovaError::NovaError(
         NovaError::InvalidStepOutputLength,
       ));
     }
+
+    // check the arity of all the primary circuits match the initial input length
+    pp.circuit_shapes.iter().try_for_each(|circuit| {
+      if circuit.F_arity != z0_primary.len() {
+        return Err(SuperNovaError::NovaError(
+          NovaError::InvalidStepOutputLength,
+        ));
+      }
+      Ok(())
+    })?;
 
     // base case for the primary
     let mut cs_primary = SatisfyingAssignment::<E1>::new();

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -528,9 +528,6 @@ mod test {
 
     let pp = PublicParams::setup(&test_circuits[0], &*S1::ck_floor(), &*S2::ck_floor());
 
-    let initial_pc = E1::Scalar::ZERO;
-    let augmented_circuit_index = field_as_usize(initial_pc);
-
     let z0_primary = vec![E1::Scalar::from(17u64)];
     let z0_secondary = vec![<E2 as Engine>::Scalar::ZERO];
 
@@ -547,8 +544,7 @@ mod test {
     for circuit in test_circuits.iter().take(NUM_STEPS) {
       let prove_res = recursive_snark.prove_step(&pp, circuit, &secondary_circuit);
 
-      let verify_res =
-        recursive_snark.verify(&pp, augmented_circuit_index, &z0_primary, &z0_secondary);
+      let verify_res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
 
       assert!(prove_res.is_ok());
       assert!(verify_res.is_ok());
@@ -718,9 +714,6 @@ mod test {
 
     let pp = PublicParams::setup(&test_circuits[0], &*S1::ck_floor(), &*S2::ck_floor());
 
-    let initial_pc = E1::Scalar::ZERO;
-    let augmented_circuit_index = field_as_usize(initial_pc);
-
     let z0_primary = vec![E1::Scalar::from(17u64)];
     let z0_secondary = vec![<E2 as Engine>::Scalar::ZERO];
 
@@ -737,8 +730,7 @@ mod test {
     for circuit in test_circuits.iter().take(NUM_STEPS) {
       let prove_res = recursive_snark.prove_step(&pp, circuit, &secondary_circuit);
 
-      let verify_res =
-        recursive_snark.verify(&pp, augmented_circuit_index, &z0_primary, &z0_secondary);
+      let verify_res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
 
       assert!(prove_res.is_ok());
       assert!(verify_res.is_ok());

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -425,7 +425,7 @@ where
       .prove_step(&pp, &circuit_primary, &circuit_secondary)
       .unwrap();
     recursive_snark
-      .verify(&pp, op_code, &z0_primary, &z0_secondary)
+      .verify(&pp, &z0_primary, &z0_secondary)
       .map_err(|err| {
         print_constraints_name_on_error_index(
           &err,
@@ -892,7 +892,7 @@ where
 
     // verify the recursive SNARK
     let res = recursive_snark
-      .verify(&pp, 0, &z0_primary, &z0_secondary)
+      .verify(&pp, &z0_primary, &z0_secondary)
       .map_err(|err| {
         print_constraints_name_on_error_index(&err, &pp, circuit_primary, &circuit_secondary, 2)
       });


### PR DESCRIPTION
This PR removes the `circuit_index` dependence of `RecursiveSNARK::verify` that was being mis-used in the tests. Instead, we add a `proven_circuit_index` field in `RecursiveSNARK` itself which plays the role of `circuit_index` in the `verify` method.

The `proven_circuit_index` name was a random name I chose that seemed evocative, I'm open to changing it.

TODO before merge: 
~* Add a check that all the NIVC circuits for a particular instance have the same arity.~
~* Open a companion PR to `lurk-rs`~ Opened PR [lurk#951](https://github.com/lurk-lab/lurk-rs/pull/951)

Closes #64 
Closes #90 