### PR TITLE
fix: Improve benchmarks quality and code duplication 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,8 @@ jobs:
           args: --all -- --check
       - name: Check clippy warnings
         run: cargo xclippy -D warnings
+      - name: Check benches compile under the flamegraph feature
+        run: cargo check --profile dev-ci --features "flamegraph" --benches
       - name: Doctests
         run: cargo test --doc --workspace
 

--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -49,8 +49,9 @@ cfg_if::cfg_if! {
 
 criterion_main!(compressed_snark_supernova);
 
-// This should be accurate, but how?
-const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+// This should match the value in test_supernova_recursive_circuit_pasta
+// TODO: This should also be a table matching the num_augmented_circuits in the below
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9844;
 const NUM_SAMPLES: usize = 10;
 
 struct NonUniformBench<E1, E2, S>

--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -9,8 +9,8 @@ use nova_snark::{
   supernova::{snark::CompressedSNARK, PublicParams, RecursiveSNARK},
   traits::{
     circuit_supernova::{StepCircuit, TrivialTestCircuit},
+    snark::BatchedRelaxedR1CSSNARKTrait,
     snark::RelaxedR1CSSNARKTrait,
-    snark::{default_ck_hint, BatchedRelaxedR1CSSNARKTrait},
     Engine,
   },
 };
@@ -123,7 +123,7 @@ fn bench_compressed_snark_internal_with_arity<
 ) {
   let bench: NonUniformBench<E1, E2, TrivialTestCircuit<<E2 as Engine>::Scalar>> =
     NonUniformBench::new(num_augmented_circuits, num_cons);
-  let pp = PublicParams::setup(&bench, &*default_ck_hint(), &*default_ck_hint());
+  let pp = PublicParams::setup(&bench, &*S1::ck_floor(), &*S2::ck_floor());
 
   let num_steps = 3;
   let z0_primary = vec![<E1 as Engine>::Scalar::from(2u64)];

--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -34,7 +34,7 @@ type SS2 = nova_snark::spartan::ppsnark::RelaxedR1CSSNARK<E2, EE2>;
 cfg_if::cfg_if! {
   if #[cfg(feature = "flamegraph")] {
     criterion_group! {
-      name = compressed_snark_suipernova;
+      name = compressed_snark_supernova;
       config = Criterion::default().warm_up_time(Duration::from_millis(3000)).with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
       targets = bench_one_augmented_circuit_compressed_snark, bench_two_augmented_circuit_compressed_snark, bench_two_augmented_circuit_compressed_snark_with_computational_commitments
     }

--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -201,8 +201,17 @@ fn bench_compressed_snark_internal_with_arity<
 
 fn bench_one_augmented_circuit_compressed_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
@@ -220,8 +229,17 @@ fn bench_one_augmented_circuit_compressed_snark(c: &mut Criterion) {
 
 fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
@@ -239,8 +257,17 @@ fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
 
 fn bench_two_augmented_circuit_compressed_snark_with_computational_commitments(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -2,7 +2,7 @@
 
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
-use criterion::*;
+use criterion::{measurement::WallTime, *};
 use ff::PrimeField;
 use nova_snark::{
   provider::{PallasEngine, VestaEngine},
@@ -50,172 +50,119 @@ cfg_if::cfg_if! {
 
 criterion_main!(compressed_snark);
 
+// This should be accurate, but how?
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+const NUM_SAMPLES: usize = 10;
+
+/// Benchmarks the compressed SNARK at a provided number of constraints
+///
+/// Parameters
+/// - `group``: the criterion benchmark group
+/// - `num_cons`: the number of constraints in the step circuit
+fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1CSSNARKTrait<E2>>(
+  group: &mut BenchmarkGroup<'_, WallTime>,
+  num_cons: usize,
+) {
+  let c_primary = NonTrivialCircuit::new(num_cons);
+  let c_secondary = TrivialCircuit::default();
+
+  // Produce public parameters
+  let pp = PublicParams::<E1, E2, C1, C2>::setup(
+    &c_primary,
+    &c_secondary,
+    &*S1::ck_floor(),
+    &*S2::ck_floor(),
+  );
+
+  // Produce prover and verifier keys for CompressedSNARK
+  let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+
+  // produce a recursive SNARK
+  let num_steps = 3;
+  let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> = RecursiveSNARK::new(
+    &pp,
+    &c_primary,
+    &c_secondary,
+    &[<E1 as Engine>::Scalar::from(2u64)],
+    &[<E2 as Engine>::Scalar::from(2u64)],
+  )
+  .unwrap();
+
+  for i in 0..num_steps {
+    let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
+    assert!(res.is_ok());
+
+    // verify the recursive snark at each step of recursion
+    let res = recursive_snark.verify(
+      &pp,
+      i + 1,
+      &[<E1 as Engine>::Scalar::from(2u64)],
+      &[<E2 as Engine>::Scalar::from(2u64)],
+    );
+    assert!(res.is_ok());
+  }
+
+  // Bench time to produce a compressed SNARK
+  group.bench_function("Prove", |b| {
+    b.iter(|| {
+      assert!(CompressedSNARK::<_, _, _, _, S1, S2>::prove(
+        black_box(&pp),
+        black_box(&pk),
+        black_box(&recursive_snark)
+      )
+      .is_ok());
+    })
+  });
+  let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
+  assert!(res.is_ok());
+  let compressed_snark = res.unwrap();
+
+  // Benchmark the verification time
+  group.bench_function("Verify", |b| {
+    b.iter(|| {
+      assert!(black_box(&compressed_snark)
+        .verify(
+          black_box(&vk),
+          black_box(num_steps),
+          black_box(&[<E1 as Engine>::Scalar::from(2u64)]),
+          black_box(&[<E2 as Engine>::Scalar::from(2u64)]),
+        )
+        .is_ok());
+    })
+  });
+}
+
 fn bench_compressed_snark(c: &mut Criterion) {
-  let num_samples = 10;
-  let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
   for &num_cons_in_augmented_circuit in
     [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
   {
     // number of constraints in the step circuit
-    let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 
     let mut group = c.benchmark_group(format!("CompressedSNARK-StepCircuitSize-{num_cons}"));
-    group.sample_size(num_samples);
+    group.sample_size(NUM_SAMPLES);
 
-    let c_primary = NonTrivialCircuit::new(num_cons);
-    let c_secondary = TrivialCircuit::default();
-
-    // Produce public parameters
-    let pp = PublicParams::<E1, E2, C1, C2>::setup(
-      &c_primary,
-      &c_secondary,
-      &*S1::ck_floor(),
-      &*S2::ck_floor(),
-    );
-
-    // Produce prover and verifier keys for CompressedSNARK
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
-
-    // produce a recursive SNARK
-    let num_steps = 3;
-    let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> = RecursiveSNARK::new(
-      &pp,
-      &c_primary,
-      &c_secondary,
-      &[<E1 as Engine>::Scalar::from(2u64)],
-      &[<E2 as Engine>::Scalar::from(2u64)],
-    )
-    .unwrap();
-
-    for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
-      assert!(res.is_ok());
-
-      // verify the recursive snark at each step of recursion
-      let res = recursive_snark.verify(
-        &pp,
-        i + 1,
-        &[<E1 as Engine>::Scalar::from(2u64)],
-        &[<E2 as Engine>::Scalar::from(2u64)],
-      );
-      assert!(res.is_ok());
-    }
-
-    // Bench time to produce a compressed SNARK
-    group.bench_function("Prove", |b| {
-      b.iter(|| {
-        assert!(CompressedSNARK::<_, _, _, _, S1, S2>::prove(
-          black_box(&pp),
-          black_box(&pk),
-          black_box(&recursive_snark)
-        )
-        .is_ok());
-      })
-    });
-    let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
-    assert!(res.is_ok());
-    let compressed_snark = res.unwrap();
-
-    // Benchmark the verification time
-    group.bench_function("Verify", |b| {
-      b.iter(|| {
-        assert!(black_box(&compressed_snark)
-          .verify(
-            black_box(&vk),
-            black_box(num_steps),
-            black_box(&[<E1 as Engine>::Scalar::from(2u64)]),
-            black_box(&[<E2 as Engine>::Scalar::from(2u64)]),
-          )
-          .is_ok());
-      })
-    });
+    bench_compressed_snark_internal::<S1, S2>(&mut group, num_cons);
 
     group.finish();
   }
 }
 
 fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
-  let num_samples = 10;
-  let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
   for &num_cons_in_augmented_circuit in [9819, 16384, 32768, 65536, 131072, 262144].iter() {
     // number of constraints in the step circuit
-    let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 
     let mut group = c.benchmark_group(format!(
       "CompressedSNARK-Commitments-StepCircuitSize-{num_cons}"
     ));
     group
       .sampling_mode(SamplingMode::Flat)
-      .sample_size(num_samples);
+      .sample_size(NUM_SAMPLES);
 
-    let c_primary = NonTrivialCircuit::new(num_cons);
-    let c_secondary = TrivialCircuit::default();
-
-    // Produce public parameters
-    let pp = PublicParams::<E1, E2, C1, C2>::setup(
-      &c_primary,
-      &c_secondary,
-      &*SS1::ck_floor(),
-      &*SS2::ck_floor(),
-    );
-    // Produce prover and verifier keys for CompressedSNARK
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
-
-    // produce a recursive SNARK
-    let num_steps = 3;
-    let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> = RecursiveSNARK::new(
-      &pp,
-      &c_primary,
-      &c_secondary,
-      &[<E1 as Engine>::Scalar::from(2u64)],
-      &[<E2 as Engine>::Scalar::from(2u64)],
-    )
-    .unwrap();
-
-    for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
-      assert!(res.is_ok());
-
-      // verify the recursive snark at each step of recursion
-      let res = recursive_snark.verify(
-        &pp,
-        i + 1,
-        &[<E1 as Engine>::Scalar::from(2u64)],
-        &[<E2 as Engine>::Scalar::from(2u64)],
-      );
-      assert!(res.is_ok());
-    }
-
-    // Bench time to produce a compressed SNARK
-    group.bench_function("Prove", |b| {
-      b.iter(|| {
-        assert!(CompressedSNARK::<_, _, _, _, SS1, SS2>::prove(
-          black_box(&pp),
-          black_box(&pk),
-          black_box(&recursive_snark)
-        )
-        .is_ok());
-      })
-    });
-    let res = CompressedSNARK::<_, _, _, _, SS1, SS2>::prove(&pp, &pk, &recursive_snark);
-    assert!(res.is_ok());
-    let compressed_snark = res.unwrap();
-
-    // Benchmark the verification time
-    group.bench_function("Verify", |b| {
-      b.iter(|| {
-        assert!(black_box(&compressed_snark)
-          .verify(
-            black_box(&vk),
-            black_box(num_steps),
-            black_box(&[<E1 as Engine>::Scalar::from(2u64)]),
-            black_box(&[<E2 as Engine>::Scalar::from(2u64)]),
-          )
-          .is_ok());
-      })
-    });
+    bench_compressed_snark_internal::<SS1, SS2>(&mut group, num_cons);
 
     group.finish();
   }

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -50,8 +50,8 @@ cfg_if::cfg_if! {
 
 criterion_main!(compressed_snark);
 
-// This should be accurate, but how?
-const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+// This should match the value for the primary in test_recursive_circuit_pasta
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9825;
 const NUM_SAMPLES: usize = 10;
 
 /// Benchmarks the compressed SNARK at a provided number of constraints

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -134,8 +134,17 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
 
 fn bench_compressed_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
@@ -151,7 +160,16 @@ fn bench_compressed_snark(c: &mut Criterion) {
 
 fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in [9819, 16384, 32768, 65536, 131072, 262144].iter() {
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+  ]
+  .iter()
+  {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -38,8 +38,9 @@ cfg_if::cfg_if! {
 
 criterion_main!(recursive_snark_supernova);
 
-// This should be accurate, but how?
-const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+// This should match the value in test_supernova_recursive_circuit_pasta
+// TODO: This should also be a table matching the num_augmented_circuits in the below
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9844;
 const NUM_SAMPLES: usize = 10;
 
 struct NonUniformBench<E1, E2, S>

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -186,8 +186,17 @@ fn bench_recursive_snark_internal_with_arity(
 
 fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
@@ -204,8 +213,17 @@ fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
 
 fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -2,7 +2,7 @@
 
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
-use criterion::*;
+use criterion::{measurement::WallTime, *};
 use ff::PrimeField;
 use nova_snark::{
   provider::{PallasEngine, VestaEngine},
@@ -37,6 +37,10 @@ cfg_if::cfg_if! {
 }
 
 criterion_main!(recursive_snark_supernova);
+
+// This should be accurate, but how?
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+const NUM_SAMPLES: usize = 10;
 
 struct NonUniformBench<E1, E2, S>
 where
@@ -87,200 +91,130 @@ where
   }
 }
 
+/// Benchmarks the compressed SNARK at a provided number of constraints
+///
+/// Parameters
+/// - `num_augmented_circuits`: the number of augmented circuits in this configuration
+/// - `group`: the criterion benchmark group
+/// - `num_cons`: the number of constraints in the step circuit
+fn bench_recursive_snark_internal_with_arity(
+  group: &mut BenchmarkGroup<'_, WallTime>,
+  num_augmented_circuits: usize,
+  num_cons: usize,
+) {
+  let bench: NonUniformBench<
+    PallasEngine,
+    VestaEngine,
+    TrivialTestCircuit<<VestaEngine as Engine>::Scalar>,
+  > = NonUniformBench::new(2, num_cons);
+  let pp = PublicParams::setup(&bench, &*default_ck_hint(), &*default_ck_hint());
+
+  // Bench time to produce a recursive SNARK;
+  // we execute a certain number of warm-up steps since executing
+  // the first step is cheaper than other steps owing to the presence of
+  // a lot of zeros in the satisfying assignment
+  let num_warmup_steps = 10;
+  let z0_primary = vec![<PallasEngine as Engine>::Scalar::from(2u64)];
+  let z0_secondary = vec![<VestaEngine as Engine>::Scalar::from(2u64)];
+  let mut recursive_snark_option: Option<RecursiveSNARK<PallasEngine, VestaEngine>> = None;
+  let mut selected_augmented_circuit = 0;
+
+  for _ in 0..num_warmup_steps {
+    let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
+      RecursiveSNARK::new(
+        &pp,
+        &bench,
+        &bench.primary_circuit(0),
+        &bench.secondary_circuit(),
+        &z0_primary,
+        &z0_secondary,
+      )
+      .unwrap()
+    });
+
+    if selected_augmented_circuit == 0 || selected_augmented_circuit == 1 {
+      recursive_snark
+        .prove_step(
+          &pp,
+          &bench.primary_circuit(selected_augmented_circuit),
+          &bench.secondary_circuit(),
+        )
+        .expect("Prove step failed");
+
+      recursive_snark
+        .verify(&pp, &z0_primary, &z0_secondary)
+        .expect("Verify failed");
+    } else {
+      unimplemented!()
+    }
+
+    selected_augmented_circuit = (selected_augmented_circuit + 1) % num_augmented_circuits;
+    recursive_snark_option = Some(recursive_snark)
+  }
+
+  assert!(recursive_snark_option.is_some());
+  let recursive_snark = recursive_snark_option.unwrap();
+
+  // Benchmark the prove time
+  group.bench_function("Prove", |b| {
+    b.iter(|| {
+      // produce a recursive SNARK for a step of the recursion
+      assert!(black_box(&mut recursive_snark.clone())
+        .prove_step(
+          black_box(&pp),
+          &bench.primary_circuit(0),
+          &bench.secondary_circuit(),
+        )
+        .is_ok());
+    })
+  });
+
+  // Benchmark the verification time
+  group.bench_function("Verify", |b| {
+    b.iter(|| {
+      assert!(black_box(&mut recursive_snark.clone())
+        .verify(
+          black_box(&pp),
+          black_box(&[<PallasEngine as Engine>::Scalar::from(2u64)]),
+          black_box(&[<VestaEngine as Engine>::Scalar::from(2u64)]),
+        )
+        .is_ok());
+    });
+  });
+}
+
 fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
-  let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
   for &num_cons_in_augmented_circuit in
     [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
   {
     // number of constraints in the step circuit
-    let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 
     let mut group = c.benchmark_group(format!(
       "RecursiveSNARKSuperNova-1circuit-StepCircuitSize-{num_cons}"
     ));
-    group.sample_size(10);
+    group.sample_size(NUM_SAMPLES);
 
-    let bench = NonUniformBench::<
-      PallasEngine,
-      VestaEngine,
-      TrivialTestCircuit<<VestaEngine as Engine>::Scalar>,
-    >::new(1, num_cons);
-    let pp = PublicParams::setup(&bench, &*default_ck_hint(), &*default_ck_hint());
-
-    // Bench time to produce a recursive SNARK;
-    // we execute a certain number of warm-up steps since executing
-    // the first step is cheaper than other steps owing to the presence of
-    // a lot of zeros in the satisfying assignment
-    let num_warmup_steps = 10;
-    let z0_primary = vec![<PallasEngine as Engine>::Scalar::from(2u64)];
-    let z0_secondary = vec![<VestaEngine as Engine>::Scalar::from(2u64)];
-    let mut recursive_snark_option: Option<RecursiveSNARK<PallasEngine, VestaEngine>> = None;
-
-    for _ in 0..num_warmup_steps {
-      let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
-        RecursiveSNARK::new(
-          &pp,
-          &bench,
-          &bench.primary_circuit(0),
-          &bench.secondary_circuit(),
-          &z0_primary,
-          &z0_secondary,
-        )
-        .unwrap()
-      });
-
-      let res =
-        recursive_snark.prove_step(&pp, &bench.primary_circuit(0), &bench.secondary_circuit());
-      if let Err(e) = &res {
-        println!("res failed {:?}", e);
-      }
-      assert!(res.is_ok());
-      let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
-      if let Err(e) = &res {
-        println!("res failed {:?}", e);
-      }
-      assert!(res.is_ok());
-      recursive_snark_option = Some(recursive_snark)
-    }
-
-    assert!(recursive_snark_option.is_some());
-    let recursive_snark = recursive_snark_option.unwrap();
-
-    // Benchmark the prove time
-    group.bench_function("Prove", |b| {
-      b.iter(|| {
-        // produce a recursive SNARK for a step of the recursion
-        assert!(black_box(&mut recursive_snark.clone())
-          .prove_step(
-            black_box(&pp),
-            &bench.primary_circuit(0),
-            &bench.secondary_circuit(),
-          )
-          .is_ok());
-      })
-    });
-
-    // Benchmark the verification time
-    group.bench_function("Verify", |b| {
-      b.iter(|| {
-        assert!(black_box(&mut recursive_snark.clone())
-          .verify(
-            black_box(&pp),
-            black_box(&[<PallasEngine as Engine>::Scalar::from(2u64)]),
-            black_box(&[<VestaEngine as Engine>::Scalar::from(2u64)]),
-          )
-          .is_ok());
-      });
-    });
+    bench_recursive_snark_internal_with_arity(&mut group, 1, num_cons);
     group.finish();
   }
 }
 
 fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
-  let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
   for &num_cons_in_augmented_circuit in
     [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
   {
     // number of constraints in the step circuit
-    let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 
     let mut group = c.benchmark_group(format!(
       "RecursiveSNARKSuperNova-2circuit-StepCircuitSize-{num_cons}"
     ));
-    group.sample_size(10);
+    group.sample_size(NUM_SAMPLES);
 
-    let bench: NonUniformBench<
-      PallasEngine,
-      VestaEngine,
-      TrivialTestCircuit<<VestaEngine as Engine>::Scalar>,
-    > = NonUniformBench::new(2, num_cons);
-    let pp = PublicParams::setup(&bench, &*default_ck_hint(), &*default_ck_hint());
-
-    // Bench time to produce a recursive SNARK;
-    // we execute a certain number of warm-up steps since executing
-    // the first step is cheaper than other steps owing to the presence of
-    // a lot of zeros in the satisfying assignment
-    let num_warmup_steps = 10;
-    let z0_primary = vec![<PallasEngine as Engine>::Scalar::from(2u64)];
-    let z0_secondary = vec![<VestaEngine as Engine>::Scalar::from(2u64)];
-    let mut recursive_snark_option: Option<RecursiveSNARK<PallasEngine, VestaEngine>> = None;
-    let mut selected_augmented_circuit = 0;
-
-    for _ in 0..num_warmup_steps {
-      let mut recursive_snark = recursive_snark_option.unwrap_or_else(|| {
-        RecursiveSNARK::new(
-          &pp,
-          &bench,
-          &bench.primary_circuit(0),
-          &bench.secondary_circuit(),
-          &z0_primary,
-          &z0_secondary,
-        )
-        .unwrap()
-      });
-
-      if selected_augmented_circuit == 0 {
-        let res =
-          recursive_snark.prove_step(&pp, &bench.primary_circuit(0), &bench.secondary_circuit());
-        if let Err(e) = &res {
-          println!("res failed {:?}", e);
-        }
-        assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
-        if let Err(e) = &res {
-          println!("res failed {:?}", e);
-        }
-        assert!(res.is_ok());
-      } else if selected_augmented_circuit == 1 {
-        let res =
-          recursive_snark.prove_step(&pp, &bench.primary_circuit(1), &bench.secondary_circuit());
-        if let Err(e) = &res {
-          println!("res failed {:?}", e);
-        }
-        assert!(res.is_ok());
-        let res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
-        if let Err(e) = &res {
-          println!("res failed {:?}", e);
-        }
-        assert!(res.is_ok());
-      } else {
-        unimplemented!()
-      }
-      selected_augmented_circuit = (selected_augmented_circuit + 1) % 2;
-      recursive_snark_option = Some(recursive_snark)
-    }
-
-    assert!(recursive_snark_option.is_some());
-    let recursive_snark = recursive_snark_option.unwrap();
-
-    // Benchmark the prove time
-    group.bench_function("Prove", |b| {
-      b.iter(|| {
-        // produce a recursive SNARK for a step of the recursion
-        assert!(black_box(&mut recursive_snark.clone())
-          .prove_step(
-            black_box(&pp),
-            &bench.primary_circuit(0),
-            &bench.secondary_circuit(),
-          )
-          .is_ok());
-      })
-    });
-
-    // Benchmark the verification time
-    group.bench_function("Verify", |b| {
-      b.iter(|| {
-        assert!(black_box(&mut recursive_snark.clone())
-          .verify(
-            black_box(&pp),
-            black_box(&[<PallasEngine as Engine>::Scalar::from(2u64)]),
-            black_box(&[<VestaEngine as Engine>::Scalar::from(2u64)]),
-          )
-          .is_ok());
-      });
-    });
+    bench_recursive_snark_internal_with_arity(&mut group, 2, num_cons);
     group.finish();
   }
 }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -42,17 +42,20 @@ cfg_if::cfg_if! {
 
 criterion_main!(recursive_snark);
 
+// This should be accurate, but how?
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+const NUM_SAMPLES: usize = 10;
+
 fn bench_recursive_snark(c: &mut Criterion) {
-  let num_cons_verifier_circuit_primary = 9819;
   // we vary the number of constraints in the step circuit
   for &num_cons_in_augmented_circuit in
     [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
   {
     // number of constraints in the step circuit
-    let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
 
     let mut group = c.benchmark_group(format!("RecursiveSNARK-StepCircuitSize-{num_cons}"));
-    group.sample_size(10);
+    group.sample_size(NUM_SAMPLES);
 
     let c_primary = NonTrivialCircuit::new(num_cons);
     let c_secondary = TrivialCircuit::default();

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -48,8 +48,17 @@ const NUM_SAMPLES: usize = 10;
 
 fn bench_recursive_snark(c: &mut Criterion) {
   // we vary the number of constraints in the step circuit
-  for &num_cons_in_augmented_circuit in
-    [9819, 16384, 32768, 65536, 131072, 262144, 524288, 1048576].iter()
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+  ]
+  .iter()
   {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -42,8 +42,8 @@ cfg_if::cfg_if! {
 
 criterion_main!(recursive_snark);
 
-// This should be accurate, but how?
-const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9819;
+// This should match the value for the primary in test_recursive_circuit_pasta
+const NUM_CONS_VERIFIER_CIRCUIT_PRIMARY: usize = 9825;
 const NUM_SAMPLES: usize = 10;
 
 fn bench_recursive_snark(c: &mut Criterion) {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -450,6 +450,7 @@ mod tests {
 
   #[test]
   fn test_recursive_circuit_pasta() {
+    // this test checks against values that must be replicated in benchmarks if changed here
     let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
     let ro_consts1: ROConstantsCircuit<VestaEngine> = PoseidonConstantsCircuit::default();

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -588,3 +588,163 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
     Ok((program_counter_new, z_next))
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{
+    bellpepper::{
+      r1cs::{NovaShape, NovaWitness},
+      solver::SatisfyingAssignment,
+      test_shape_cs::TestShapeCS,
+    },
+    constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
+    gadgets::utils::scalar_as_base,
+    provider::{
+      poseidon::PoseidonConstantsCircuit,
+      {Bn256Engine, GrumpkinEngine}, {PallasEngine, VestaEngine},
+      {Secp256k1Engine, Secq256k1Engine},
+    },
+    traits::{circuit_supernova::TrivialTestCircuit, snark::default_ck_hint},
+  };
+
+  // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
+  fn test_supernova_recursive_circuit_with<E1, E2>(
+    primary_params: &SuperNovaAugmentedCircuitParams,
+    secondary_params: &SuperNovaAugmentedCircuitParams,
+    ro_consts1: ROConstantsCircuit<E2>,
+    ro_consts2: ROConstantsCircuit<E1>,
+    num_constraints_primary: usize,
+    num_constraints_secondary: usize,
+    num_augmented_circuits: usize,
+  ) where
+    E1: Engine<Base = <E2 as Engine>::Scalar>,
+    E2: Engine<Base = <E1 as Engine>::Scalar>,
+  {
+    let tc1 = TrivialTestCircuit::default();
+    // Initialize the shape and ck for the primary
+    let circuit1: SuperNovaAugmentedCircuit<'_, E2, TrivialTestCircuit<<E2 as Engine>::Base>> =
+      SuperNovaAugmentedCircuit::new(
+        primary_params,
+        None,
+        &tc1,
+        ro_consts1.clone(),
+        num_augmented_circuits,
+      );
+    let mut cs: TestShapeCS<E1> = TestShapeCS::new();
+    let _ = circuit1.synthesize(&mut cs);
+    let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
+    assert_eq!(cs.num_constraints(), num_constraints_primary);
+
+    let tc2 = TrivialTestCircuit::default();
+    // Initialize the shape and ck for the secondary
+    let circuit2: SuperNovaAugmentedCircuit<'_, E1, TrivialTestCircuit<<E1 as Engine>::Base>> =
+      SuperNovaAugmentedCircuit::new(
+        secondary_params,
+        None,
+        &tc2,
+        ro_consts2.clone(),
+        num_augmented_circuits,
+      );
+    let mut cs: TestShapeCS<E2> = TestShapeCS::new();
+    let _ = circuit2.synthesize(&mut cs);
+    let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
+    assert_eq!(cs.num_constraints(), num_constraints_secondary);
+
+    // Execute the base case for the primary
+    let zero1 = <<E2 as Engine>::Base as Field>::ZERO;
+    let mut cs1 = SatisfyingAssignment::<E1>::new();
+    let vzero1 = vec![zero1];
+    let inputs1: SuperNovaAugmentedCircuitInputs<'_, E2> = SuperNovaAugmentedCircuitInputs::new(
+      scalar_as_base::<E1>(zero1), // pass zero for testing
+      zero1,
+      &vzero1,
+      None,
+      None,
+      None,
+      None,
+      Some(zero1),
+      zero1,
+    );
+    let circuit1: SuperNovaAugmentedCircuit<'_, E2, TrivialTestCircuit<<E2 as Engine>::Base>> =
+      SuperNovaAugmentedCircuit::new(
+        primary_params,
+        Some(inputs1),
+        &tc1,
+        ro_consts1,
+        num_augmented_circuits,
+      );
+    let _ = circuit1.synthesize(&mut cs1);
+    let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
+    // Make sure that this is satisfiable
+    assert!(shape1.is_sat(&ck1, &inst1, &witness1).is_ok());
+
+    // Execute the base case for the secondary
+    let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
+    let mut cs2 = SatisfyingAssignment::<E2>::new();
+    let vzero2 = vec![zero2];
+    let inputs2: SuperNovaAugmentedCircuitInputs<'_, E1> = SuperNovaAugmentedCircuitInputs::new(
+      scalar_as_base::<E2>(zero2), // pass zero for testing
+      zero2,
+      &vzero2,
+      None,
+      None,
+      Some(&inst1),
+      None,
+      Some(zero2),
+      zero2,
+    );
+    let circuit2: SuperNovaAugmentedCircuit<'_, E1, TrivialTestCircuit<<E1 as Engine>::Base>> =
+      SuperNovaAugmentedCircuit::new(
+        secondary_params,
+        Some(inputs2),
+        &tc2,
+        ro_consts2,
+        num_augmented_circuits,
+      );
+    let _ = circuit2.synthesize(&mut cs2);
+    let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();
+    // Make sure that it is satisfiable
+    assert!(shape2.is_sat(&ck2, &inst2, &witness2).is_ok());
+  }
+
+  #[test]
+  fn test_supernova_recursive_circuit_pasta() {
+    // this test checks against values that must be replicated in benchmarks if changed here
+    let params1 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
+    let params2 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
+    let ro_consts1: ROConstantsCircuit<VestaEngine> = PoseidonConstantsCircuit::default();
+    let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
+
+    test_supernova_recursive_circuit_with::<PallasEngine, VestaEngine>(
+      &params1, &params2, ro_consts1, ro_consts2, 9844, 10392, 1,
+    );
+    // TODO: extend to num_augmented_circuits >= 2
+  }
+
+  #[test]
+  fn test_supernova_recursive_circuit_grumpkin() {
+    let params1 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
+    let params2 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
+    let ro_consts1: ROConstantsCircuit<GrumpkinEngine> = PoseidonConstantsCircuit::default();
+    let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
+
+    test_supernova_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
+      &params1, &params2, ro_consts1, ro_consts2, 10012, 10581, 1,
+    );
+    // TODO: extend to num_augmented_circuits >= 2
+  }
+
+  #[test]
+  fn test_supernova_recursive_circuit_secp() {
+    let params1 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
+    let params2 = SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
+    let ro_consts1: ROConstantsCircuit<Secq256k1Engine> = PoseidonConstantsCircuit::default();
+    let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
+
+    test_supernova_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
+      &params1, &params2, ro_consts1, ro_consts2, 10291, 11004, 1,
+    );
+    // TODO: extend to num_augmented_circuits >= 2
+  }
+}


### PR DESCRIPTION
- avoids uneeded code duplication in benchmarks with auxiliary functions,
- update the circuit sizes used in Nova benchmarks to up-to-date values,
- creates very basic circuit sizing tests for Supernova and uses them in benchmarks,

Elements to be addressed after this PR:
- the Supernova circuit test only works for a num_augmented_circuit equal to 1, we'd like to test (at least) with 2 circuits ( https://github.com/lurk-lab/arecibo/issues/179 )
- we will probably need CI to track the values of this benchmark and publish fresh runs on gh-pages, similarly to https://github.com/lurk-lab/lurk-rs/blob/ab427f23a709e95edb656e6b29bd55f1e22424bc/.github/workflows/merge-tests.yml#L69-L205 ( https://github.com/lurk-lab/arecibo/issues/180)