### PR TITLE
Add upstream to author/license for clarity.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arecibo"
 version = "0.2.0"
-authors = ["Lurk Engineering <engineering@lurk-lab.com>"]
+authors = ["Srinath Setty <srinath@microsoft.com>", "Lurk Engineering <engineering@lurk-lab.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"
 documentation = "https://docs.rs/arecibo/"

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
     MIT License
 
+    Copyright (c) Microsoft Corporation.
     Copyright (c) 2023 Lurk Lab
 
     Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR is the same change as in the patch release #188 — duplicated here for visibility on the default branch.