### PR TITLE
ci: Update Rust version and correct package name in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
       working-directory: ${{ github.workspace }}/lurk
       run: |
         echo "[patch.'https://github.com/lurk-lab/arecibo']" >> Cargo.toml
-        echo "nova = { path='../arecibo', package='nova-snark' }" >> Cargo.toml
+        echo "nova = { path='../arecibo', package='arecibo' }" >> Cargo.toml
     - name: Check Lurk-rs types don't break spectacularly
       working-directory: ${{ github.workspace }}/lurk
       run: cargo check --all --tests --benches --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/lurk-lab/arecibo"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
-rust-version="1.67.1"
+rust-version="1.70.0"
 
 [dependencies]
 bellpepper-core = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }


### PR DESCRIPTION
- Update the package name in the Lurk compilation check workflow.
- Upgrade to a newer Rust MSRV