### PR TITLE
Use `expect_test` in `test_pp_digest`, `test_recursive_circuit`, and `test_supernova_recursive_circuit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ pprof = { version = "0.11" }
 sha2 = "0.10.7"
 tracing-test = "0.2.4"
 proptest = "1.2.0"
+expect-test = "1.4.1"
 
 [[bench]]
 name = "recursive-snark"

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -378,6 +378,7 @@ mod tests {
     },
     traits::{circuit::TrivialCircuit, snark::default_ck_hint},
   };
+  use expect_test::{expect, Expect};
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
   fn test_recursive_circuit_with<E1, E2>(
@@ -385,8 +386,8 @@ mod tests {
     secondary_params: &NovaAugmentedCircuitParams,
     ro_consts1: ROConstantsCircuit<E2>,
     ro_consts2: ROConstantsCircuit<E1>,
-    num_constraints_primary: usize,
-    num_constraints_secondary: usize,
+    expected_num_constraints_primary: &Expect,
+    expected_num_constraints_secondary: &Expect,
   ) where
     E1: Engine<Base = <E2 as Engine>::Scalar>,
     E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -398,7 +399,8 @@ mod tests {
     let mut cs: TestShapeCS<E1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
-    assert_eq!(cs.num_constraints(), num_constraints_primary);
+
+    expected_num_constraints_primary.assert_eq(&cs.num_constraints().to_string());
 
     let tc2 = TrivialCircuit::default();
     // Initialize the shape and ck for the secondary
@@ -407,7 +409,8 @@ mod tests {
     let mut cs: TestShapeCS<E2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
-    assert_eq!(cs.num_constraints(), num_constraints_secondary);
+
+    expected_num_constraints_secondary.assert_eq(&cs.num_constraints().to_string());
 
     // Execute the base case for the primary
     let zero1 = <<E2 as Engine>::Base as Field>::ZERO;
@@ -457,7 +460,12 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<PallasEngine, VestaEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 9825, 10357,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["9825"],
+      &expect!["10357"],
     );
   }
 
@@ -469,7 +477,12 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 9993, 10546,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["9993"],
+      &expect!["10546"],
     );
   }
 
@@ -481,7 +494,12 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
-      &params1, &params2, ro_consts1, ro_consts2, 10272, 10969,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["10272"],
+      &expect!["10969"],
     );
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1007,6 +1007,7 @@ mod tests {
   };
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::{fmt::Write, marker::PhantomData};
+  use expect_test::{expect, Expect};
   use ff::PrimeField;
   use halo2curves::bn256::Bn256;
   use traits::circuit::TrivialCircuit;
@@ -1063,7 +1064,7 @@ mod tests {
     }
   }
 
-  fn test_pp_digest_with<E1, E2, T1, T2, EE1, EE2>(circuit1: &T1, circuit2: &T2, expected: &str)
+  fn test_pp_digest_with<E1, E2, T1, T2, EE1, EE2>(circuit1: &T1, circuit2: &T2, expected: &Expect)
   where
     E1: Engine<Base = <E2 as Engine>::Scalar>,
     E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -1091,7 +1092,8 @@ mod tests {
         let _ = write!(output, "{b:02x}");
         output
       });
-    assert_eq!(digest_str, expected);
+
+    expected.assert_eq(&digest_str);
   }
 
   #[test]
@@ -1103,13 +1105,13 @@ mod tests {
     test_pp_digest_with::<PallasEngine, VestaEngine, _, _, EE<_>, EE<_>>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "f4a04841515b4721519e2671b7ee11e58e2d4a30bb183ded963b71ad2ec80d00",
+      &expect!["f4a04841515b4721519e2671b7ee11e58e2d4a30bb183ded963b71ad2ec80d00"],
     );
 
     test_pp_digest_with::<PallasEngine, VestaEngine, _, _, EE<_>, EE<_>>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "dc1b7c40ab50c5c6877ad027769452870cc28f1d13f140de7ca3a00138c58502",
+      &expect!["dc1b7c40ab50c5c6877ad027769452870cc28f1d13f140de7ca3a00138c58502"],
     );
 
     let trivial_circuit1_grumpkin = TrivialCircuit::<<Bn256Engine as Engine>::Scalar>::default();
@@ -1122,22 +1124,22 @@ mod tests {
     test_pp_digest_with::<Bn256Engine, GrumpkinEngine, _, _, EE<_>, EE<_>>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "2af2a80ea8a0c21cfc4096e9b2d4822344a29174d88cd86239a99a363efe8702",
+      &expect!["2af2a80ea8a0c21cfc4096e9b2d4822344a29174d88cd86239a99a363efe8702"],
     );
     test_pp_digest_with::<Bn256Engine, GrumpkinEngine, _, _, EE<_>, EE<_>>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "9273fd39ed6220ea28e60abca8bdb3180f90e37e6aaf3031e6d670d073e8a002",
+      &expect!["9273fd39ed6220ea28e60abca8bdb3180f90e37e6aaf3031e6d670d073e8a002"],
     );
     test_pp_digest_with::<Bn256EngineZM, GrumpkinEngine, _, _, ZMPCS<Bn256, _>, EE<_>>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "eac63861dcbaa924a1bd9721f01528271385dd6ff182c77bc62e03448adc1902",
+      &expect!["eac63861dcbaa924a1bd9721f01528271385dd6ff182c77bc62e03448adc1902"],
     );
     test_pp_digest_with::<Bn256EngineZM, GrumpkinEngine, _, _, ZMPCS<Bn256, _>, EE<_>>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "21bd7e07175b23e3bd2bbc6a0c3b9efd8603815609dbe93f8df9c174e132de03",
+      &expect!["21bd7e07175b23e3bd2bbc6a0c3b9efd8603815609dbe93f8df9c174e132de03"],
     );
 
     let trivial_circuit1_secp = TrivialCircuit::<<Secp256k1Engine as Engine>::Scalar>::default();
@@ -1147,12 +1149,12 @@ mod tests {
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, EE<_>, EE<_>>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "7652ef8326b01e784eaac7b44bd0bc2f27af3904c96ef2bf7ab1b923b8aae701",
+      &expect!["7652ef8326b01e784eaac7b44bd0bc2f27af3904c96ef2bf7ab1b923b8aae701"],
     );
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, EE<_>, EE<_>>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "da51e6bac881c054c4ed08320ce42d8a0e61a22fbd70bbbbf05384ec4adeb201",
+      &expect!["da51e6bac881c054c4ed08320ce42d8a0e61a22fbd70bbbbf05384ec4adeb201"],
     );
   }
 

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -607,6 +607,7 @@ mod tests {
     },
     traits::{circuit_supernova::TrivialTestCircuit, snark::default_ck_hint},
   };
+  use expect_test::{expect, Expect};
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
   fn test_supernova_recursive_circuit_with<E1, E2>(
@@ -614,8 +615,8 @@ mod tests {
     secondary_params: &SuperNovaAugmentedCircuitParams,
     ro_consts1: ROConstantsCircuit<E2>,
     ro_consts2: ROConstantsCircuit<E1>,
-    num_constraints_primary: usize,
-    num_constraints_secondary: usize,
+    num_constraints_primary: &Expect,
+    num_constraints_secondary: &Expect,
     num_augmented_circuits: usize,
   ) where
     E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -634,7 +635,8 @@ mod tests {
     let mut cs: TestShapeCS<E1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
-    assert_eq!(cs.num_constraints(), num_constraints_primary);
+
+    num_constraints_primary.assert_eq(&cs.num_constraints().to_string());
 
     let tc2 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the secondary
@@ -649,7 +651,8 @@ mod tests {
     let mut cs: TestShapeCS<E2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
-    assert_eq!(cs.num_constraints(), num_constraints_secondary);
+
+    num_constraints_secondary.assert_eq(&cs.num_constraints().to_string());
 
     // Execute the base case for the primary
     let zero1 = <<E2 as Engine>::Base as Field>::ZERO;
@@ -717,7 +720,13 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
 
     test_supernova_recursive_circuit_with::<PallasEngine, VestaEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 9844, 10392, 1,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["9844"],
+      &expect!["10392"],
+      1,
     );
     // TODO: extend to num_augmented_circuits >= 2
   }
@@ -730,7 +739,13 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
 
     test_supernova_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 10012, 10581, 1,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["10012"],
+      &expect!["10581"],
+      1,
     );
     // TODO: extend to num_augmented_circuits >= 2
   }
@@ -743,7 +758,13 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
 
     test_supernova_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
-      &params1, &params2, ro_consts1, ro_consts2, 10291, 11004, 1,
+      &params1,
+      &params2,
+      ro_consts1,
+      ro_consts2,
+      &expect!["10291"],
+      &expect!["11004"],
+      1,
     );
     // TODO: extend to num_augmented_circuits >= 2
   }


### PR DESCRIPTION
This closes #132. 

There may be other tests that would benefit from this (maybe the ecc op circuit tests for constraint numbers?)