### PR TITLE
Removing redundant absorption to the transcript (#201)

### DIFF
--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1215,20 +1215,16 @@ where
     let (comm_L_row, comm_L_col) =
       rayon::join(|| E::CE::commit(ck, &L_row), || E::CE::commit(ck, &L_col));
 
-    // absorb the claimed evaluations into the transcript
-    transcript.absorb(
-      b"e",
-      &[eval_Az_at_tau, eval_Bz_at_tau, eval_Cz_at_tau].as_slice(),
-    );
-    // absorb commitments to L_row and L_col in the transcript
-    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
-
     // since all the three polynomials are opened at tau,
     // we can combine them into a single polynomial opened at tau
     let eval_vec = vec![eval_Az_at_tau, eval_Bz_at_tau, eval_Cz_at_tau];
+
+    // absorb the claimed evaluations into the transcript
+    transcript.absorb(b"e", &eval_vec.as_slice());
+    // absorb commitments to L_row and L_col in the transcript
+    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
     let comm_vec = vec![comm_Az, comm_Bz, comm_Cz];
     let poly_vec = vec![&Az, &Bz, &Cz];
-    transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let w: PolyEvalWitness<E> = PolyEvalWitness::batch(&poly_vec, &c);
     let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
@@ -1496,18 +1492,6 @@ where
     let tau = transcript.squeeze(b"t")?;
     let tau_coords = PowPolynomial::new(&tau, num_rounds_sc).coordinates();
 
-    transcript.absorb(
-      b"e",
-      &[
-        self.eval_Az_at_tau,
-        self.eval_Bz_at_tau,
-        self.eval_Cz_at_tau,
-      ]
-      .as_slice(),
-    );
-
-    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
-
     // add claims about Az, Bz, and Cz to be checked later
     // since all the three polynomials are opened at tau,
     // we can combine them into a single polynomial opened at tau
@@ -1516,8 +1500,11 @@ where
       self.eval_Bz_at_tau,
       self.eval_Cz_at_tau,
     ];
+
+    transcript.absorb(b"e", &eval_vec.as_slice());
+
+    transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
     let comm_vec = vec![comm_Az, comm_Bz, comm_Cz];
-    transcript.absorb(b"e", &eval_vec.as_slice()); // c_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
     let claim = u.e;


### PR DESCRIPTION
This PR fixes https://github.com/lurk-lab/arecibo/issues/201.

It would be nice to apply the patch to [upstream](https://github.com/microsoft/Nova/tree/main) Nova implementation as well.