### PR TITLE
chore: Remove redundant absorptions in MLKZG implementation

### DIFF
--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -53,9 +53,7 @@ where
   E::Fr: TranscriptReprTrait<E::G1>,
   E::G1Affine: TranscriptReprTrait<E::G1>, // TODO: this bound on DlogGroup is really unusable!
 {
-  fn compute_challenge(
-    transcript: &mut impl TranscriptEngineTrait<NE>,
-  ) -> E::Fr {
+  fn compute_challenge(transcript: &mut impl TranscriptEngineTrait<NE>) -> E::Fr {
     transcript.squeeze(b"c").unwrap()
   }
 

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -93,11 +93,9 @@ where
   }
 
   fn verifier_second_challenge(
-    C_B: &E::G1Affine,
     W: &[E::G1Affine],
     transcript: &mut impl TranscriptEngineTrait<NE>,
   ) -> E::Fr {
-    transcript.absorb(b"C_b", C_B);
     transcript.absorb(b"W", &W.to_vec().as_slice());
 
     transcript.squeeze(b"d").unwrap()
@@ -220,14 +218,9 @@ where
       // Now open B at u0, ..., u_{t-1}
       let w = u.par_iter().map(|ui| kzg_open(&B, *ui)).collect::<Vec<_>>();
 
-      // Compute the commitment to the batched polynomial B(X)
-      let q_powers = Self::batch_challenge_powers(q, k);
-      let c_0: E::G1 = C[0].into();
-      let C_B = (c_0 + NE::GE::vartime_multiscalar_mul(&q_powers[1..k], &C[1..k])).preprocessed();
-
       // The prover computes the challenge to keep the transcript in the same
       // state as that of the verifier
-      let _d_0 = Self::verifier_second_challenge(&C_B, &w, transcript);
+      let _d_0 = Self::verifier_second_challenge(&w, transcript);
 
       (w, v)
     };
@@ -325,7 +318,7 @@ where
         .map(|v_i| zip_with!(iter, (q_powers, v_i), |a, b| *a * *b).sum())
         .collect::<Vec<E::Fr>>();
 
-      let d_0 = Self::verifier_second_challenge(&C_B, W, transcript);
+      let d_0 = Self::verifier_second_challenge(W, transcript);
       let d = [d_0, d_0 * d_0];
 
       assert!(t == 3);

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -54,15 +54,8 @@ where
   E::G1Affine: TranscriptReprTrait<E::G1>, // TODO: this bound on DlogGroup is really unusable!
 {
   fn compute_challenge(
-    C: &E::G1Affine,
-    y: &E::Fr,
-    com: &[E::G1Affine],
     transcript: &mut impl TranscriptEngineTrait<NE>,
   ) -> E::Fr {
-    transcript.absorb(b"C", C);
-    transcript.absorb(b"y", y);
-    transcript.absorb(b"c", &com.to_vec().as_slice());
-
     transcript.squeeze(b"c").unwrap()
   }
 
@@ -265,7 +258,7 @@ where
     // Phase 2
     // We do not need to add x to the transcript, because in our context x was
     // obtained from the transcript.
-    let r = Self::compute_challenge(&C.comm.preprocessed(), eval, &com, transcript);
+    let r = Self::compute_challenge(transcript);
     let u = vec![r, -r, r * r];
 
     // Phase 3 -- create response
@@ -363,7 +356,7 @@ where
 
     // we do not need to add x to the transcript, because in our context x was
     // obtained from the transcript
-    let r = Self::compute_challenge(&C.comm.preprocessed(), y, &com, transcript);
+    let r = Self::compute_challenge(transcript);
 
     if r == E::Fr::ZERO || C.comm == E::G1::zero() {
       return Err(NovaError::ProofVerifyError);

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -68,14 +68,11 @@ where
 
   // Compute challenge q = Hash(vk, C0, ..., C_{k-1}, u0, ...., u_{t-1},
   // (f_i(u_j))_{i=0..k-1,j=0..t-1})
+  // It is assumed that both 'C' and 'u' are already absorbed by the transcript
   fn get_batch_challenge(
-    C: &[E::G1Affine],
-    u: &[E::Fr],
     v: &[Vec<E::Fr>],
     transcript: &mut impl TranscriptEngineTrait<NE>,
   ) -> E::Fr {
-    transcript.absorb(b"C", &C.to_vec().as_slice());
-    transcript.absorb(b"u", &u.to_vec().as_slice());
     transcript.absorb(
       b"v",
       &v.iter()
@@ -217,7 +214,7 @@ where
         });
       });
 
-      let q = Self::get_batch_challenge(C, u, &v, transcript);
+      let q = Self::get_batch_challenge(&v, transcript);
       let B = kzg_compute_batch_polynomial(f, q);
 
       // Now open B at u0, ..., u_{t-1}
@@ -314,7 +311,7 @@ where
       let k = C.len();
       let t = u.len();
 
-      let q = Self::get_batch_challenge(C, u, v, transcript);
+      let q = Self::get_batch_challenge(v, transcript);
       let q_powers = Self::batch_challenge_powers(q, k); // 1, q, q^2, ..., q^(k-1)
 
       // Compute the commitment to the batched polynomial B(X)

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -53,7 +53,11 @@ where
   E::Fr: TranscriptReprTrait<E::G1>,
   E::G1Affine: TranscriptReprTrait<E::G1>, // TODO: this bound on DlogGroup is really unusable!
 {
-  fn compute_challenge(transcript: &mut impl TranscriptEngineTrait<NE>) -> E::Fr {
+  fn compute_challenge(
+    com: &[E::G1Affine],
+    transcript: &mut impl TranscriptEngineTrait<NE>,
+  ) -> E::Fr {
+    transcript.absorb(b"c", &com.to_vec().as_slice());
     transcript.squeeze(b"c").unwrap()
   }
 
@@ -256,7 +260,7 @@ where
     // Phase 2
     // We do not need to add x to the transcript, because in our context x was
     // obtained from the transcript.
-    let r = Self::compute_challenge(transcript);
+    let r = Self::compute_challenge(&com, transcript);
     let u = vec![r, -r, r * r];
 
     // Phase 3 -- create response
@@ -354,7 +358,7 @@ where
 
     // we do not need to add x to the transcript, because in our context x was
     // obtained from the transcript
-    let r = Self::compute_challenge(transcript);
+    let r = Self::compute_challenge(&com, transcript);
 
     if r == E::Fr::ZERO || C.comm == E::G1::zero() {
       return Err(NovaError::ProofVerifyError);


### PR DESCRIPTION
This PR attempts to address @adr1anh 's comments from https://github.com/lurk-lab/arecibo/pull/172 , related to transcript absorptions. 

Fixes https://github.com/lurk-lab/arecibo/issues/202