### PR TITLE
Clean up trait/macro boilerplate in provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ once_cell = "1.18.0"
 itertools = "0.12.0"
 rand = "0.8.5"
 ref-cast = "1.0.20"
+derive_more = "0.99.17"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev", version = "0.1.4" }

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -1,14 +1,13 @@
 //! This module implements the Nova traits for `bn256::Point`, `bn256::Scalar`, `grumpkin::Point`, `grumpkin::Scalar`.
 use crate::{
-  provider::{
-    traits::{CompressedGroup, DlogGroup},
-    util::msm::cpu_best_msm,
-  },
+  impl_traits,
+  provider::{traits::DlogGroup, util::msm::cpu_best_msm},
   traits::{Group, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
+use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
 use num_bigint::BigInt;
 use num_traits::Num;
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves
@@ -17,203 +16,32 @@ use rayon::prelude::*;
 use sha3::Shake256;
 use std::io::Read;
 
-use halo2curves::bn256::{
-  G1Affine as Bn256Affine, G1Compressed as Bn256Compressed, G1 as Bn256Point,
-};
-use halo2curves::grumpkin::{
-  G1Affine as GrumpkinAffine, G1Compressed as GrumpkinCompressed, G1 as GrumpkinPoint,
-};
-
 /// Re-exports that give access to the standard aliases used in the code base, for bn256
 pub mod bn256 {
-  pub use halo2curves::bn256::{Fq as Base, Fr as Scalar, G1Affine as Affine, G1 as Point};
+  pub use halo2curves::bn256::{
+    Fq as Base, Fr as Scalar, G1Affine as Affine, G1Compressed as Compressed, G1 as Point,
+  };
 }
 
 /// Re-exports that give access to the standard aliases used in the code base, for grumpkin
 pub mod grumpkin {
-  pub use halo2curves::grumpkin::{Fq as Base, Fr as Scalar, G1Affine as Affine, G1 as Point};
-}
-
-macro_rules! impl_traits {
-  (
-    $name:ident,
-    $name_compressed:ident,
-    $name_curve:ident,
-    $name_curve_affine:ident,
-    $order_str:literal,
-    $base_str:literal
-  ) => {
-    impl Group for $name::Point {
-      type Base = $name::Base;
-      type Scalar = $name::Scalar;
-
-      fn group_params() -> (Self::Base, Self::Base, BigInt, BigInt) {
-        let A = $name::Point::a();
-        let B = $name::Point::b();
-        let order = BigInt::from_str_radix($order_str, 16).unwrap();
-        let base = BigInt::from_str_radix($base_str, 16).unwrap();
-
-        (A, B, order, base)
-      }
-    }
-
-    impl DlogGroup for $name::Point {
-      type CompressedGroupElement = $name_compressed;
-      type PreprocessedGroupElement = $name::Affine;
-
-      #[tracing::instrument(
-        skip_all,
-        level = "trace",
-        name = "<_ as Group>::vartime_multiscalar_mul"
-      )]
-      fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
-        bases: &[Self::PreprocessedGroupElement],
-      ) -> Self {
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-        if scalars.len() >= 128 {
-          grumpkin_msm::$name(bases, scalars)
-        } else {
-          cpu_best_msm(scalars, bases)
-        }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-        cpu_best_msm(scalars, bases)
-      }
-      fn preprocessed(&self) -> Self::PreprocessedGroupElement {
-        self.to_affine()
-      }
-
-      fn compress(&self) -> Self::CompressedGroupElement {
-        self.to_bytes()
-      }
-
-      fn from_label(label: &'static [u8], n: usize) -> Vec<Self::PreprocessedGroupElement> {
-        let mut shake = Shake256::default();
-        shake.update(label);
-        let mut reader = shake.finalize_xof();
-        let mut uniform_bytes_vec = Vec::new();
-        for _ in 0..n {
-          let mut uniform_bytes = [0u8; 32];
-          reader.read_exact(&mut uniform_bytes).unwrap();
-          uniform_bytes_vec.push(uniform_bytes);
-        }
-        let gens_proj: Vec<$name_curve> = (0..n)
-          .into_par_iter()
-          .map(|i| {
-            let hash = $name_curve::hash_to_curve("from_uniform_bytes");
-            hash(&uniform_bytes_vec[i])
-          })
-          .collect();
-
-        let num_threads = rayon::current_num_threads();
-        if gens_proj.len() > num_threads {
-          let chunk = (gens_proj.len() as f64 / num_threads as f64).ceil() as usize;
-          (0..num_threads)
-            .into_par_iter()
-            .flat_map(|i| {
-              let start = i * chunk;
-              let end = if i == num_threads - 1 {
-                gens_proj.len()
-              } else {
-                core::cmp::min((i + 1) * chunk, gens_proj.len())
-              };
-              if end > start {
-                let mut gens = vec![$name_curve_affine::identity(); end - start];
-                <Self as Curve>::batch_normalize(&gens_proj[start..end], &mut gens);
-                gens
-              } else {
-                vec![]
-              }
-            })
-            .collect()
-        } else {
-          let mut gens = vec![$name_curve_affine::identity(); n];
-          <Self as Curve>::batch_normalize(&gens_proj, &mut gens);
-          gens
-        }
-      }
-
-      fn zero() -> Self {
-        $name::Point::identity()
-      }
-
-      fn to_coordinates(&self) -> (Self::Base, Self::Base, bool) {
-        let coordinates = self.to_affine().coordinates();
-        if coordinates.is_some().unwrap_u8() == 1
-          && ($name_curve_affine::identity() != self.to_affine())
-        {
-          (*coordinates.unwrap().x(), *coordinates.unwrap().y(), false)
-        } else {
-          (Self::Base::zero(), Self::Base::zero(), true)
-        }
-      }
-    }
-
-    impl PrimeFieldExt for $name::Scalar {
-      fn from_uniform(bytes: &[u8]) -> Self {
-        let bytes_arr: [u8; 64] = bytes.try_into().unwrap();
-        $name::Scalar::from_uniform_bytes(&bytes_arr)
-      }
-    }
-
-    impl<G: DlogGroup> TranscriptReprTrait<G> for $name_compressed {
-      fn to_transcript_bytes(&self) -> Vec<u8> {
-        self.as_ref().to_vec()
-      }
-    }
-
-    impl CompressedGroup for $name_compressed {
-      type GroupElement = $name::Point;
-
-      fn decompress(&self) -> Option<$name::Point> {
-        Some($name_curve::from_bytes(&self).unwrap())
-      }
-    }
-
-    impl<G: Group> TranscriptReprTrait<G> for $name::Scalar {
-      fn to_transcript_bytes(&self) -> Vec<u8> {
-        self.to_repr().to_vec()
-      }
-    }
-
-    impl<G: DlogGroup> TranscriptReprTrait<G> for $name::Affine {
-      fn to_transcript_bytes(&self) -> Vec<u8> {
-        let (x, y, is_infinity_byte) = {
-          let coordinates = self.coordinates();
-          if coordinates.is_some().unwrap_u8() == 1 && ($name_curve_affine::identity() != *self) {
-            let c = coordinates.unwrap();
-            (*c.x(), *c.y(), u8::from(false))
-          } else {
-            ($name::Base::zero(), $name::Base::zero(), u8::from(false))
-          }
-        };
-
-        x.to_repr()
-          .into_iter()
-          .chain(y.to_repr().into_iter())
-          .chain(std::iter::once(is_infinity_byte))
-          .collect()
-      }
-    }
+  pub use halo2curves::grumpkin::{
+    Fq as Base, Fr as Scalar, G1Affine as Affine, G1Compressed as Compressed, G1 as Point,
   };
 }
 
 impl_traits!(
   bn256,
-  Bn256Compressed,
-  Bn256Point,
-  Bn256Affine,
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
-  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
+  bn256_msm
 );
 
 impl_traits!(
   grumpkin,
-  GrumpkinCompressed,
-  GrumpkinPoint,
-  GrumpkinAffine,
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
-  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
+  grumpkin_msm
 );
 
 #[cfg(test)]
@@ -237,7 +65,7 @@ mod tests {
       .map(|_| bn256::Scalar::random(&mut rng))
       .collect::<Vec<_>>();
 
-    let cpu_msm = cpu_best_msm(&scalars, &points);
+    let cpu_msm = cpu_best_msm(&points, &scalars);
     let gpu_msm = bn256::Point::vartime_multiscalar_mul(&scalars, &points);
 
     assert_eq!(cpu_msm, gpu_msm);
@@ -253,7 +81,7 @@ mod tests {
       .map(|_| grumpkin::Scalar::random(&mut rng))
       .collect::<Vec<_>>();
 
-    let cpu_msm = cpu_best_msm(&scalars, &points);
+    let cpu_msm = cpu_best_msm(&points, &scalars);
     let gpu_msm = grumpkin::Point::vartime_multiscalar_mul(&scalars, &points);
 
     assert_eq!(cpu_msm, gpu_msm);

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -7,6 +7,7 @@ use crate::{
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
 use num_bigint::BigInt;
 use num_traits::Num;
@@ -30,18 +31,32 @@ pub mod grumpkin {
   };
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 impl_traits!(
   bn256,
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
   bn256_msm
 );
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+impl_traits!(
+  bn256,
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+);
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 impl_traits!(
   grumpkin,
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
   grumpkin_msm
+);
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+impl_traits!(
+  grumpkin,
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
 );
 
 #[cfg(test)]

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -30,7 +30,7 @@ pub struct KZGCommitmentEngine<E: Engine> {
 impl<E: Engine, NE: NovaEngine<GE = E::G1, Scalar = E::Fr>> CommitmentEngineTrait<NE>
   for KZGCommitmentEngine<E>
 where
-  E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+  E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
   E::G1Affine: Serialize + for<'de> Deserialize<'de>,
   E::G2Affine: Serialize + for<'de> Deserialize<'de>,
   E::Fr: PrimeFieldBits, // TODO due to use of gen_srs_for_testing, make optional

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -205,7 +205,7 @@ mod tests {
         acc + *base * coeff
       });
 
-    assert_eq!(naive, cpu_best_msm(&coeffs, &bases))
+    assert_eq!(naive, cpu_best_msm(&bases, &coeffs))
   }
 
   #[test]

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -234,7 +234,7 @@ pub struct UVKZGPCS<E> {
 
 impl<E: MultiMillerLoop> UVKZGPCS<E>
 where
-  E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+  E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
 {
   /// Generate a commitment for a polynomial
   /// Note that the scheme is not hidding
@@ -327,7 +327,7 @@ mod tests {
   fn end_to_end_test_template<E>() -> Result<(), NovaError>
   where
     E: MultiMillerLoop,
-    E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+    E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
     E::Fr: PrimeFieldBits,
   {
     for _ in 0..100 {

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -28,7 +28,7 @@ use rayon::{
   prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
 };
 use ref_cast::RefCast;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, iter, marker::PhantomData};
 
 use crate::provider::kzg_commitment::KZGCommitmentEngine;
@@ -145,7 +145,7 @@ pub struct ZMPCS<E, NE> {
 
 impl<E: MultiMillerLoop, NE: NovaEngine<GE = E::G1, Scalar = E::Fr>> ZMPCS<E, NE>
 where
-  E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+  E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
   // Note: due to the move of the bound TranscriptReprTrait<G> on G::Base from Group to Engine
   <E::G1 as Group>::Base: TranscriptReprTrait<E::G1>,
 {
@@ -463,9 +463,9 @@ fn eval_and_quotient_scalars<F: Field>(y: F, x: F, z: F, point: &[F]) -> (F, (Ve
 impl<E: MultiMillerLoop, NE: NovaEngine<GE = E::G1, Scalar = E::Fr, CE = KZGCommitmentEngine<E>>>
   EvaluationEngineTrait<NE> for ZMPCS<E, NE>
 where
-  E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
-  E::G1Affine: Serialize + DeserializeOwned,
-  E::G2Affine: Serialize + DeserializeOwned,
+  E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
+  E::G1Affine: Serialize + for<'de> Deserialize<'de>,
+  E::G2Affine: Serialize + for<'de> Deserialize<'de>,
   <E::G1 as Group>::Base: TranscriptReprTrait<E::G1>, // Note: due to the move of the bound TranscriptReprTrait<G> on G::Base from Group to Engine
   E::Fr: PrimeFieldBits, // TODO due to use of gen_srs_for_testing, make optional
 {
@@ -542,7 +542,7 @@ mod test {
 
   fn commit_open_verify_with<E: MultiMillerLoop, NE: NovaEngine<GE = E::G1, Scalar = E::Fr>>()
   where
-    E::G1: DlogGroup<PreprocessedGroupElement = E::G1Affine, Scalar = E::Fr>,
+    E::G1: DlogGroup<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
     <E::G1 as Group>::Base: TranscriptReprTrait<E::G1>, // Note: due to the move of the bound TranscriptReprTrait<G> on G::Base from Group to Engine
     E::Fr: PrimeFieldBits,
   {

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,29 +1,23 @@
 //! This module implements the Nova traits for `secp::Point`, `secp::Scalar`, `secq::Point`, `secq::Scalar`.
 use crate::{
   impl_traits,
-  provider::{
-    traits::{CompressedGroup, DlogGroup},
-    util::msm::cpu_best_msm,
-  },
+  provider::{traits::DlogGroup, util::msm::cpu_best_msm},
   traits::{Group, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
 use num_bigint::BigInt;
 use num_traits::Num;
 use pasta_curves::arithmetic::{CurveAffine, CurveExt};
 use rayon::prelude::*;
 use sha3::Shake256;
 use std::io::Read;
-
-use halo2curves::secp256k1::{Secp256k1, Secp256k1Affine, Secp256k1Compressed};
-use halo2curves::secq256k1::{Secq256k1, Secq256k1Affine, Secq256k1Compressed};
-
 /// Re-exports that give access to the standard aliases used in the code base, for secp
 pub mod secp256k1 {
   pub use halo2curves::secp256k1::{
     Fp as Base, Fq as Scalar, Secp256k1 as Point, Secp256k1Affine as Affine,
+    Secp256k1Compressed as Compressed,
   };
 }
 
@@ -31,23 +25,18 @@ pub mod secp256k1 {
 pub mod secq256k1 {
   pub use halo2curves::secq256k1::{
     Fp as Base, Fq as Scalar, Secq256k1 as Point, Secq256k1Affine as Affine,
+    Secq256k1Compressed as Compressed,
   };
 }
 
 impl_traits!(
   secp256k1,
-  Secp256k1Compressed,
-  Secp256k1,
-  Secp256k1Affine,
   "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
   "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
 );
 
 impl_traits!(
   secq256k1,
-  Secq256k1Compressed,
-  Secq256k1,
-  Secq256k1Affine,
   "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
   "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
 );

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -1,8 +1,6 @@
 use crate::traits::{commitment::ScalarMul, Group, TranscriptReprTrait};
-use core::{
-  fmt::Debug,
-  ops::{Add, AddAssign, Sub, SubAssign},
-};
+use core::fmt::Debug;
+use group::{GroupOps, GroupOpsOwned, ScalarMulOwned};
 use serde::{Deserialize, Serialize};
 
 /// Represents a compressed version of a group element
@@ -24,25 +22,6 @@ pub trait CompressedGroup:
   /// Decompresses the compressed group element
   fn decompress(&self) -> Option<Self::GroupElement>;
 }
-
-/// A helper trait for types with a group operation.
-pub trait GroupOps<Rhs = Self, Output = Self>:
-  Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
-
-impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
-  T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
-
-/// A helper trait for references with a group operation.
-pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
-impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
-
-/// A helper trait for references implementing group scalar multiplication.
-pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
-impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
 
 /// A trait that defines extensions to the Group trait
 pub trait DlogGroup:

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -1,69 +1,33 @@
-use crate::traits::{commitment::ScalarMul, Group, TranscriptReprTrait};
-use core::fmt::Debug;
-use group::{GroupOps, GroupOpsOwned, ScalarMulOwned};
+use crate::traits::{Group, TranscriptReprTrait};
+use group::{prime::PrimeCurve, GroupEncoding};
 use serde::{Deserialize, Serialize};
-
-/// Represents a compressed version of a group element
-pub trait CompressedGroup:
-  Clone
-  + Copy
-  + Debug
-  + Eq
-  + Send
-  + Sync
-  + TranscriptReprTrait<Self::GroupElement>
-  + Serialize
-  + for<'de> Deserialize<'de>
-  + 'static
-{
-  /// A type that holds the decompressed version of the compressed group element
-  type GroupElement: DlogGroup;
-
-  /// Decompresses the compressed group element
-  fn decompress(&self) -> Option<Self::GroupElement>;
-}
+use std::fmt::Debug;
 
 /// A trait that defines extensions to the Group trait
 pub trait DlogGroup:
-  Group
+  Group<Scalar = <Self as DlogGroup>::ScalarExt>
   + Serialize
   + for<'de> Deserialize<'de>
-  + GroupOps
-  + GroupOpsOwned
-  + ScalarMul<<Self as Group>::Scalar>
-  + ScalarMulOwned<<Self as Group>::Scalar>
+  + PrimeCurve<Scalar = <Self as DlogGroup>::ScalarExt, Affine = <Self as DlogGroup>::AffineExt>
 {
-  /// A type representing the compressed version of the group element
-  type CompressedGroupElement: CompressedGroup<GroupElement = Self>;
-
-  /// A type representing preprocessed group element
-  type PreprocessedGroupElement: Clone
+  type ScalarExt;
+  type AffineExt: Clone + Debug + Eq + Serialize + for<'de> Deserialize<'de> + Sync + Send;
+  type Compressed: Clone
     + Debug
-    + PartialEq
     + Eq
-    + Send
-    + Sync
+    + From<<Self as GroupEncoding>::Repr>
+    + Into<<Self as GroupEncoding>::Repr>
     + Serialize
     + for<'de> Deserialize<'de>
+    + Sync
+    + Send
     + TranscriptReprTrait<Self>;
 
   /// A method to compute a multiexponentation
-  fn vartime_multiscalar_mul(
-    scalars: &[Self::Scalar],
-    bases: &[Self::PreprocessedGroupElement],
-  ) -> Self;
+  fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::AffineExt]) -> Self;
 
   /// Produce a vector of group elements using a static label
-  fn from_label(label: &'static [u8], n: usize) -> Vec<Self::PreprocessedGroupElement>;
-
-  /// Compresses the group element
-  fn compress(&self) -> Self::CompressedGroupElement;
-
-  /// Produces a preprocessed element
-  fn preprocessed(&self) -> Self::PreprocessedGroupElement;
-
-  /// Returns an element that is the additive identity of the group
-  fn zero() -> Self;
+  fn from_label(label: &'static [u8], n: usize) -> Vec<Self::Affine>;
 
   /// Returns the affine coordinates (x, y, infinty) for the point
   fn to_coordinates(&self) -> (<Self as Group>::Base, <Self as Group>::Base, bool);
@@ -77,11 +41,16 @@ pub trait DlogGroup:
 macro_rules! impl_traits {
   (
     $name:ident,
-    $name_compressed:ident,
-    $name_curve:ident,
-    $name_curve_affine:ident,
     $order_str:literal,
     $base_str:literal
+  ) => {
+    $crate::impl_traits!($name, $order_str, $base_str, cpu_best_msm);
+  };
+  (
+    $name:ident,
+    $order_str:literal,
+    $base_str:literal,
+    $large_msm_method: ident
   ) => {
     impl Group for $name::Point {
       type Base = $name::Base;
@@ -98,25 +67,24 @@ macro_rules! impl_traits {
     }
 
     impl DlogGroup for $name::Point {
-      type CompressedGroupElement = $name_compressed;
-      type PreprocessedGroupElement = $name::Affine;
+      type ScalarExt = $name::Scalar;
+      type AffineExt = $name::Affine;
+      // note: for halo2curves implementations, $name::Compressed == <$name::Point as GroupEncoding>::Repr
+      // so the blanket impl<T> From<T> for T and impl<T> Into<T> apply.
+      type Compressed = $name::Compressed;
 
-      fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
-        bases: &[Self::PreprocessedGroupElement],
-      ) -> Self {
-        cpu_best_msm(scalars, bases)
+      fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::AffineExt]) -> Self {
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        if scalars.len() >= 128 {
+          $large_msm_method(bases, scalars)
+        } else {
+          cpu_best_msm(bases, scalars)
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        cpu_best_msm(bases, scalars)
       }
 
-      fn preprocessed(&self) -> Self::PreprocessedGroupElement {
-        self.to_affine()
-      }
-
-      fn compress(&self) -> Self::CompressedGroupElement {
-        self.to_bytes()
-      }
-
-      fn from_label(label: &'static [u8], n: usize) -> Vec<Self::PreprocessedGroupElement> {
+      fn from_label(label: &'static [u8], n: usize) -> Vec<Self::Affine> {
         let mut shake = Shake256::default();
         shake.update(label);
         let mut reader = shake.finalize_xof();
@@ -126,10 +94,10 @@ macro_rules! impl_traits {
           reader.read_exact(&mut uniform_bytes).unwrap();
           uniform_bytes_vec.push(uniform_bytes);
         }
-        let gens_proj: Vec<$name_curve> = (0..n)
+        let gens_proj: Vec<$name::Point> = (0..n)
           .into_par_iter()
           .map(|i| {
-            let hash = $name_curve::hash_to_curve("from_uniform_bytes");
+            let hash = $name::Point::hash_to_curve("from_uniform_bytes");
             hash(&uniform_bytes_vec[i])
           })
           .collect();
@@ -147,7 +115,7 @@ macro_rules! impl_traits {
                 core::cmp::min((i + 1) * chunk, gens_proj.len())
               };
               if end > start {
-                let mut gens = vec![$name_curve_affine::identity(); end - start];
+                let mut gens = vec![$name::Affine::identity(); end - start];
                 <Self as Curve>::batch_normalize(&gens_proj[start..end], &mut gens);
                 gens
               } else {
@@ -156,21 +124,15 @@ macro_rules! impl_traits {
             })
             .collect()
         } else {
-          let mut gens = vec![$name_curve_affine::identity(); n];
+          let mut gens = vec![$name::Affine::identity(); n];
           <Self as Curve>::batch_normalize(&gens_proj, &mut gens);
           gens
         }
       }
 
-      fn zero() -> Self {
-        $name::Point::identity()
-      }
-
       fn to_coordinates(&self) -> (Self::Base, Self::Base, bool) {
         let coordinates = self.to_affine().coordinates();
-        if coordinates.is_some().unwrap_u8() == 1
-          && ($name_curve_affine::identity() != self.to_affine())
-        {
+        if coordinates.is_some().unwrap_u8() == 1 && ($name::Point::identity() != *self) {
           (*coordinates.unwrap().x(), *coordinates.unwrap().y(), false)
         } else {
           (Self::Base::zero(), Self::Base::zero(), true)
@@ -185,17 +147,9 @@ macro_rules! impl_traits {
       }
     }
 
-    impl<G: DlogGroup> TranscriptReprTrait<G> for $name_compressed {
+    impl<G: DlogGroup> TranscriptReprTrait<G> for $name::Compressed {
       fn to_transcript_bytes(&self) -> Vec<u8> {
         self.as_ref().to_vec()
-      }
-    }
-
-    impl CompressedGroup for $name_compressed {
-      type GroupElement = $name::Point;
-
-      fn decompress(&self) -> Option<$name::Point> {
-        Some($name_curve::from_bytes(&self).unwrap())
       }
     }
 
@@ -209,7 +163,7 @@ macro_rules! impl_traits {
       fn to_transcript_bytes(&self) -> Vec<u8> {
         let (x, y, is_infinity_byte) = {
           let coordinates = self.coordinates();
-          if coordinates.is_some().unwrap_u8() == 1 && ($name_curve_affine::identity() != *self) {
+          if coordinates.is_some().unwrap_u8() == 1 && ($name::Affine::identity() != *self) {
             let c = coordinates.unwrap();
             (*c.x(), *c.y(), u8::from(false))
           } else {

--- a/src/provider/util/msm.rs
+++ b/src/provider/util/msm.rs
@@ -95,7 +95,7 @@ fn cpu_msm_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve
 ///
 /// This will use multithreading if beneficial.
 /// Adapted from zcash/halo2
-pub(crate) fn cpu_best_msm<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
+pub(crate) fn cpu_best_msm<C: CurveAffine>(bases: &[C], coeffs: &[C::Scalar]) -> C::Curve {
   assert_eq!(coeffs.len(), bases.len());
 
   let num_threads = current_num_threads();
@@ -137,7 +137,7 @@ mod tests {
       .fold(A::CurveExt::identity(), |acc, (coeff, base)| {
         acc + *base * coeff
       });
-    let msm = cpu_best_msm(&coeffs, &bases);
+    let msm = cpu_best_msm(&bases, &coeffs);
 
     assert_eq!(naive, msm)
   }


### PR DESCRIPTION
- makes src/provider group-crate aware and cleans corresponding redundancy,
- removes macro boilerplate created for #187 