### PR TITLE
Test vectors & benchmark for PCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # Configurations for VSCode
 .vscode/
+
+# Configuration for Jetbrains
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ harness = false
 default = []
 abomonate = []
 asm = ["halo2curves/asm"]
-bench = []
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,10 +96,15 @@ harness = false
 name = "compressed-snark-supernova"
 harness = false
 
+[[bench]]
+name = "pcs"
+harness = false
+
 [features]
 default = []
 abomonate = []
 asm = ["halo2curves/asm"]
+bench = []
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -27,7 +27,7 @@ type SS2 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E2, EE2>;
 type C1 = NonTrivialCircuit<<E1 as Engine>::Scalar>;
 type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
 
-// To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
+// To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
 // Then `cargo criterion --bench compressed-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
 // For flamegraphs, run `cargo criterion --bench compressed-snark --features flamegraph -- --profile-time <secs>`.
 // The results are located in `target/criterion/profile/<name-of-benchmark>`.

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -98,7 +98,7 @@ macro_rules! benchmark_all_engines {
             // Proving group
             let mut proving_group = $criterion.benchmark_group(format!("PCS-Proving {}", num_vars));
             proving_group
-                .sampling_mode(SamplingMode::Flat)
+                .sampling_mode(SamplingMode::Auto)
                 .sample_size(10);
 
             $(
@@ -112,7 +112,7 @@ macro_rules! benchmark_all_engines {
             // Verifying group
             let mut verifying_group = $criterion.benchmark_group(format!("PCS-Verifying {}", num_vars));
             verifying_group
-                .sampling_mode(SamplingMode::Flat)
+                .sampling_mode(SamplingMode::Auto)
                 .sample_size(10);
 
             $(

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
 
 criterion_main!(pcs);
 
-const TEST_ELL: [usize; 2] = [10, 11];
+const TEST_ELL: [usize; 11] = [10, 11, 12, 23, 14, 15, 16, 17, 18, 19, 20];
 
 struct BenchAssests<E: Engine, EE: EvaluationEngineTrait<E>> {
   poly: MultilinearPolynomial<<E as Engine>::Scalar>,

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -1,0 +1,112 @@
+use arecibo::provider::ipa_pc::EvaluationEngine as IPAEvaluationEngine;
+use arecibo::provider::mlkzg::EvaluationEngine as MLEvaluationEngine;
+use arecibo::provider::non_hiding_zeromorph::ZMPCS;
+use arecibo::provider::util::test_utils::{commitment_setup, gen_poly_point_eval};
+use arecibo::provider::{Bn256EngineKZG, Bn256EngineZM, GrumpkinEngine};
+use arecibo::traits::evaluation::EvaluationEngineTrait;
+use arecibo::traits::{Engine, TranscriptEngineTrait};
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion, SamplingMode};
+use halo2curves::bn256::Bn256;
+use std::time::Duration;
+// To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
+// Then `cargo criterion --bench pcs --features bench`. The results are located in `target/criterion/data/<name-of-benchmark>`.
+criterion_group! {
+      name = pcs;
+      config = Criterion::default().warm_up_time(Duration::from_millis(3000));
+      targets = bench_proving
+}
+
+criterion_main!(pcs);
+
+const SEEDS: [usize; 3] = [4, 5, 6];
+fn bench_proving(c: &mut Criterion) {
+  for seed in SEEDS.iter() {
+    let mut group = c.benchmark_group(format!("PCS-Seed-{seed}"));
+    group.sampling_mode(SamplingMode::Flat);
+
+    bench_proving_internal::<GrumpkinEngine, IPAEvaluationEngine<GrumpkinEngine>>(
+      &mut group,
+      "IPA-Grumpkin",
+      *seed,
+    );
+
+    bench_proving_internal::<Bn256EngineKZG, MLEvaluationEngine<Bn256, Bn256EngineKZG>>(
+      &mut group, "MLKZG-Bn", *seed,
+    );
+
+    bench_proving_internal::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(
+      &mut group, "ZM-Bn", *seed,
+    );
+
+    group.finish();
+  }
+}
+
+fn bench_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
+  group: &mut BenchmarkGroup<'_, WallTime>,
+  id: &str,
+  seed: usize,
+) {
+  let (poly, point, eval) = gen_poly_point_eval::<E>(seed);
+
+  let (ck, commitment, prover_key, verifier_key) = commitment_setup::<E, EE>(seed, &poly);
+
+  // Generate proof.
+  group.bench_function(format!("Prove-{}", id), |b| {
+    b.iter(|| {
+      assert!(EE::prove(
+        &ck,
+        &prover_key,
+        &mut E::TE::new(b"TestEval"),
+        &commitment,
+        poly.evaluations(),
+        &point,
+        &eval,
+      )
+      .is_ok());
+    })
+  });
+  let mut prover_transcript = E::TE::new(b"TestEval");
+  let proof = EE::prove(
+    &ck,
+    &prover_key,
+    &mut prover_transcript,
+    &commitment,
+    poly.evaluations(),
+    &point,
+    &eval,
+  )
+  .unwrap();
+  let pcp = prover_transcript.squeeze(b"c").unwrap();
+
+  // Verify proof.
+  group.bench_function(format!("Verify-{}", id), |b| {
+    b.iter(|| {
+      assert!(EE::prove(
+        &ck,
+        &prover_key,
+        &mut E::TE::new(b"TestEval"),
+        &commitment,
+        poly.evaluations(),
+        &point,
+        &eval,
+      )
+      .is_ok());
+    })
+  });
+  let mut verifier_transcript = E::TE::new(b"TestEval");
+  EE::verify(
+    &verifier_key,
+    &mut verifier_transcript,
+    &commitment,
+    &point,
+    &eval,
+    &proof,
+  )
+  .unwrap();
+  let pcv = verifier_transcript.squeeze(b"c").unwrap();
+
+  // Check if the prover transcript and verifier transcript are kept in the same state.
+  assert_eq!(pcp, pcv);
+}

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -72,8 +72,8 @@ pub fn random_poly_with_eval<E: Engine, R: RngCore + CryptoRng>(
 }
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> BenchAssests<E, EE> {
-  pub(crate) fn from_num_vars<R: CryptoRng + RngCore>(num_vars: usize, mut rng: &mut R) -> Self {
-    let (poly, point, eval) = random_poly_with_eval::<E, R>(num_vars, &mut rng);
+  pub(crate) fn from_num_vars<R: CryptoRng + RngCore>(num_vars: usize, rng: &mut R) -> Self {
+    let (poly, point, eval) = random_poly_with_eval::<E, R>(num_vars, rng);
 
     // Mock commitment key.
     let ck = E::CE::setup(b"test", 1 << num_vars);

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -1,61 +1,74 @@
-use arecibo::provider::ipa_pc::EvaluationEngine as IPAEvaluationEngine;
-use arecibo::provider::mlkzg::EvaluationEngine as MLEvaluationEngine;
-use arecibo::provider::non_hiding_zeromorph::ZMPCS;
-use arecibo::provider::util::test_utils::{commitment_setup, gen_poly_point_eval};
-use arecibo::provider::{Bn256EngineKZG, Bn256EngineZM, GrumpkinEngine};
-use arecibo::traits::evaluation::EvaluationEngineTrait;
-use arecibo::traits::{Engine, TranscriptEngineTrait};
+use arecibo::provider::{
+  ipa_pc::EvaluationEngine as IPAEvaluationEngine, mlkzg::EvaluationEngine as MLEvaluationEngine,
+  non_hiding_zeromorph::ZMPCS, Bn256EngineKZG, Bn256EngineZM, GrumpkinEngine,
+};
+use arecibo::spartan::polys::multilinear::MultilinearPolynomial;
+use arecibo::traits::{
+  commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, Engine,
+  TranscriptEngineTrait,
+};
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion, SamplingMode};
 use halo2curves::bn256::Bn256;
+use rand::rngs::StdRng;
+use rand_core::{CryptoRng, RngCore, SeedableRng};
 use std::time::Duration;
 // To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
-// Then `cargo criterion --bench pcs --features bench`. The results are located in `target/criterion/data/<name-of-benchmark>`.
+// Then `cargo criterion --bench pcs`. The results are located in `target/criterion/data/<name-of-benchmark>`.
 criterion_group! {
       name = pcs;
       config = Criterion::default().warm_up_time(Duration::from_millis(3000));
-      targets = bench_proving
+      targets = bench_pcs
 }
 
 criterion_main!(pcs);
 
-const SEEDS: [usize; 3] = [4, 5, 6];
-fn bench_proving(c: &mut Criterion) {
-  for seed in SEEDS.iter() {
-    let mut group = c.benchmark_group(format!("PCS-Seed-{seed}"));
+const TEST_ELL: [usize; 3] = [4, 5, 6];
+fn bench_pcs(c: &mut Criterion) {
+  for ell in TEST_ELL.iter() {
+    let mut group = c.benchmark_group(format!("PCS-Seed-{ell}"));
     group.sampling_mode(SamplingMode::Flat);
 
-    bench_proving_internal::<GrumpkinEngine, IPAEvaluationEngine<GrumpkinEngine>>(
+    let mut rng = rand::rngs::StdRng::seed_from_u64(*ell as u64);
+
+    bench_pcs_internal::<GrumpkinEngine, IPAEvaluationEngine<GrumpkinEngine>, StdRng>(
       &mut group,
       "IPA-Grumpkin",
-      *seed,
+      *ell,
+      &mut rng,
     );
 
-    bench_proving_internal::<Bn256EngineKZG, MLEvaluationEngine<Bn256, Bn256EngineKZG>>(
-      &mut group, "MLKZG-Bn", *seed,
+    bench_pcs_internal::<Bn256EngineKZG, MLEvaluationEngine<Bn256, Bn256EngineKZG>, StdRng>(
+      &mut group, "MLKZG-Bn", *ell, &mut rng,
     );
 
-    bench_proving_internal::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(
-      &mut group, "ZM-Bn", *seed,
+    bench_pcs_internal::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>, StdRng>(
+      &mut group, "ZM-Bn", *ell, &mut rng,
     );
 
     group.finish();
   }
 }
 
-fn bench_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
+fn bench_pcs_internal<E: Engine, EE: EvaluationEngineTrait<E>, R: CryptoRng + RngCore>(
   group: &mut BenchmarkGroup<'_, WallTime>,
   id: &str,
-  seed: usize,
+  ell: usize,
+  mut rng: &mut R,
 ) {
-  let (poly, point, eval) = gen_poly_point_eval::<E>(seed);
+  let (poly, point, eval) = MultilinearPolynomial::random_with_eval(ell, &mut rng);
 
-  let (ck, commitment, prover_key, verifier_key) = commitment_setup::<E, EE>(seed, &poly);
+  // Mock commitment key.
+  let ck = E::CE::setup(b"test", 1 << ell);
+  // Commits to the provided vector using the provided generators.
+  let commitment = E::CE::commit(&ck, poly.evaluations());
 
-  // Generate proof.
+  let (prover_key, verifier_key) = EE::setup(&ck);
+
+  // Bench generate proof.
   group.bench_function(format!("Prove-{}", id), |b| {
     b.iter(|| {
-      assert!(EE::prove(
+      EE::prove(
         &ck,
         &prover_key,
         &mut E::TE::new(b"TestEval"),
@@ -64,9 +77,11 @@ fn bench_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
         &point,
         &eval,
       )
-      .is_ok());
+      .unwrap();
     })
   });
+
+  // Generate proof so that we can bench verification.
   let mut prover_transcript = E::TE::new(b"TestEval");
   let proof = EE::prove(
     &ck,
@@ -80,21 +95,22 @@ fn bench_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
   .unwrap();
   let pcp = prover_transcript.squeeze(b"c").unwrap();
 
-  // Verify proof.
+  // Bench verify proof.
   group.bench_function(format!("Verify-{}", id), |b| {
     b.iter(|| {
-      assert!(EE::prove(
-        &ck,
-        &prover_key,
+      EE::verify(
+        &verifier_key,
         &mut E::TE::new(b"TestEval"),
         &commitment,
-        poly.evaluations(),
         &point,
         &eval,
+        &proof,
       )
-      .is_ok());
+      .unwrap();
     })
   });
+
+  // Assert that verification goes well and that challenge passes.
   let mut verifier_transcript = E::TE::new(b"TestEval");
   EE::verify(
     &verifier_key,

--- a/benches/pcs.rs
+++ b/benches/pcs.rs
@@ -7,11 +7,7 @@ use arecibo::traits::{
   commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, Engine,
   TranscriptEngineTrait,
 };
-use criterion::measurement::WallTime;
-use criterion::{
-  black_box, criterion_group, criterion_main, Bencher, BenchmarkGroup, BenchmarkId, Criterion,
-  SamplingMode, Throughput,
-};
+use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, SamplingMode};
 use halo2curves::bn256::Bn256;
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, RngCore, SeedableRng};
@@ -70,7 +66,7 @@ fn bench_pcs(c: &mut Criterion) {
 
     // Proving group
     {
-      let mut proving_group = c.benchmark_group(format!("PCS-Proving"));
+      let mut proving_group = c.benchmark_group("PCS-Proving");
       proving_group
         .sampling_mode(SamplingMode::Flat)
         .sample_size(10);
@@ -90,7 +86,7 @@ fn bench_pcs(c: &mut Criterion) {
 
     // Verifying group
     {
-      let mut verifying_group = c.benchmark_group(format!("PCS-Verifying"));
+      let mut verifying_group = c.benchmark_group("PCS-Verifying");
       verifying_group
         .sampling_mode(SamplingMode::Flat)
         .sample_size(10);
@@ -148,8 +144,8 @@ fn deterministic_assets<E: Engine, EE: EvaluationEngineTrait<E>, R: CryptoRng + 
 }
 
 fn bench_pcs_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
-  b: &mut Bencher,
-  mut bench_assets: &mut BenchAssests<E, EE>,
+  b: &mut Bencher<'_>,
+  bench_assets: &BenchAssests<E, EE>,
 ) {
   // Bench generate proof.
   b.iter(|| {
@@ -167,7 +163,7 @@ fn bench_pcs_proving_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
 }
 
 fn bench_pcs_verifying_internal<E: Engine, EE: EvaluationEngineTrait<E>>(
-  b: &mut Bencher,
+  b: &mut Bencher<'_>,
   bench_assets: &BenchAssests<E, EE>,
 ) {
   // Bench verify proof.

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -19,7 +19,7 @@ type E2 = VestaEngine;
 type C1 = NonTrivialCircuit<<E1 as Engine>::Scalar>;
 type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
 
-// To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
+// To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
 // Then `cargo criterion --bench recursive-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
 // For flamegraphs, run `cargo criterion --bench recursive-snark --features flamegraph -- --profile-time <secs>`.
 // The results are located in `target/criterion/profile/<name-of-benchmark>`.

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -414,14 +414,13 @@ where
 #[cfg(test)]
 mod test {
   use crate::provider::ipa_pc::EvaluationEngine;
-  use crate::provider::util::test_utils::{test_fail_bad_proof, test_from_seed};
+  use crate::provider::util::test_utils::test_from_ell;
   use crate::provider::GrumpkinEngine;
 
   #[test]
   fn test_multiple_seeds() {
     for ell in [4, 5, 6] {
-      test_from_seed::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
-      test_fail_bad_proof::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
+      test_from_ell::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
     }
   }
 }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -414,13 +414,13 @@ where
 #[cfg(test)]
 mod test {
   use crate::provider::ipa_pc::EvaluationEngine;
-  use crate::provider::util::test_utils::prove_verify_from_ell;
+  use crate::provider::util::test_utils::prove_verify_from_num_vars;
   use crate::provider::GrumpkinEngine;
 
   #[test]
   fn test_multiple_polynomial_size() {
-    for ell in [4, 5, 6] {
-      prove_verify_from_ell::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
+    for num_vars in [4, 5, 6] {
+      prove_verify_from_num_vars::<_, EvaluationEngine<GrumpkinEngine>>(num_vars);
     }
   }
 }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -418,7 +418,7 @@ mod test {
   use crate::provider::GrumpkinEngine;
 
   #[test]
-  fn test_multiple_seeds() {
+  fn test_multiple_polynomial_size() {
     for ell in [4, 5, 6] {
       prove_verify_from_ell::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
     }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -413,69 +413,15 @@ where
 
 #[cfg(test)]
 mod test {
-  use ff::Field;
-  use rand_core::SeedableRng;
-  /*  use rand_chacha::ChaCha20Rng;
-  use rand_core::SeedableRng;*/
   use crate::provider::ipa_pc::EvaluationEngine;
+  use crate::provider::util::test_utils::{test_fail_bad_proof, test_from_seed};
   use crate::provider::GrumpkinEngine;
-  use crate::spartan::polys::multilinear::MultilinearPolynomial;
-  use crate::traits::evaluation::EvaluationEngineTrait;
-  use crate::traits::{commitment::CommitmentEngineTrait, Engine, TranscriptEngineTrait};
-
-  type GrumpkinIPA = EvaluationEngine<GrumpkinEngine>;
-  type GrumpkinScalar = <GrumpkinEngine as Engine>::Scalar;
-  type GrumpkinCommitmentEngine = <GrumpkinEngine as Engine>::CE;
-  type GrumpkinTranscript = <GrumpkinEngine as Engine>::TE;
 
   #[test]
-  fn trying() {
-    /*    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-     */
+  fn test_multiple_seeds() {
     for ell in [4, 5, 6] {
-      let mut rng = rand::rngs::StdRng::seed_from_u64(ell as u64);
-
-      let n = 1 << ell; // n = 2^ell
-
-      let poly = (0..n)
-        .map(|_| GrumpkinScalar::random(&mut rng))
-        .collect::<Vec<_>>();
-      let point = (0..ell)
-        .map(|_| GrumpkinScalar::random(&mut rng))
-        .collect::<Vec<_>>();
-      let eval = MultilinearPolynomial::evaluate_with(&poly, &point);
-
-      let ck = GrumpkinCommitmentEngine::setup(b"test", n);
-
-      let commitment = GrumpkinCommitmentEngine::commit(&ck, &poly);
-
-      let (prover_key, verifier_key) = GrumpkinIPA::setup(&ck);
-      let mut prover_transcript = GrumpkinTranscript::new(b"TestEval");
-      let proof = GrumpkinIPA::prove(
-        &ck,
-        &prover_key,
-        &mut prover_transcript,
-        &commitment,
-        &poly,
-        &point,
-        &eval,
-      )
-      .unwrap();
-      let pcp = prover_transcript.squeeze(b"c").unwrap();
-
-      let mut verifier_transcript = GrumpkinTranscript::new(b"TestEval");
-      GrumpkinIPA::verify(
-        &verifier_key,
-        &mut verifier_transcript,
-        &commitment,
-        &point,
-        &eval,
-        &proof,
-      )
-      .unwrap();
-      let pcv = verifier_transcript.squeeze(b"c").unwrap();
-
-      assert_eq!(pcp, pcv);
+      test_from_seed::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
+      test_fail_bad_proof::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
     }
   }
 }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -414,13 +414,13 @@ where
 #[cfg(test)]
 mod test {
   use crate::provider::ipa_pc::EvaluationEngine;
-  use crate::provider::util::test_utils::test_from_ell;
+  use crate::provider::util::test_utils::prove_verify_from_ell;
   use crate::provider::GrumpkinEngine;
 
   #[test]
   fn test_multiple_seeds() {
     for ell in [4, 5, 6] {
-      test_from_ell::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
+      prove_verify_from_ell::<GrumpkinEngine, EvaluationEngine<GrumpkinEngine>>(ell);
     }
   }
 }

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -429,7 +429,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::util::test_utils::test_from_ell;
+  use crate::provider::util::test_utils::prove_verify_from_ell;
   use crate::{
     provider::keccak::Keccak256Transcript, traits::commitment::CommitmentTrait, CommitmentKey,
   };
@@ -558,7 +558,7 @@ mod tests {
   fn test_mlkzg_more() {
     // test the mlkzg prover and verifier with random instances (derived from a seed)
     for ell in [4, 5, 6] {
-      test_from_ell::<NE, EvaluationEngine<E, NE>>(ell);
+      prove_verify_from_ell::<NE, EvaluationEngine<E, NE>>(ell);
     }
   }
 }

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -429,7 +429,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::util::test_utils::prove_verify_from_ell;
+  use crate::provider::util::test_utils::prove_verify_from_num_vars;
   use crate::{
     provider::keccak::Keccak256Transcript, traits::commitment::CommitmentTrait, CommitmentKey,
   };
@@ -557,8 +557,8 @@ mod tests {
   #[test]
   fn test_mlkzg_more() {
     // test the mlkzg prover and verifier with random instances (derived from a seed)
-    for ell in [4, 5, 6] {
-      prove_verify_from_ell::<NE, EvaluationEngine<E, NE>>(ell);
+    for num_vars in [4, 5, 6] {
+      prove_verify_from_num_vars::<_, EvaluationEngine<E, NE>>(num_vars);
     }
   }
 }

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -429,12 +429,11 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::provider::util::test_utils::{test_fail_bad_proof, test_from_seed};
   use crate::{
-    provider::keccak::Keccak256Transcript, spartan::polys::multilinear::MultilinearPolynomial,
-    traits::commitment::CommitmentTrait, CommitmentKey,
+    provider::keccak::Keccak256Transcript, traits::commitment::CommitmentTrait, CommitmentKey,
   };
   use bincode::Options;
-  use rand::SeedableRng;
 
   type E = halo2curves::bn256::Bn256;
   type NE = crate::provider::Bn256EngineKZG;
@@ -559,53 +558,8 @@ mod tests {
   fn test_mlkzg_more() {
     // test the mlkzg prover and verifier with random instances (derived from a seed)
     for ell in [4, 5, 6] {
-      let mut rng = rand::rngs::StdRng::seed_from_u64(ell as u64);
-
-      let n = 1 << ell; // n = 2^ell
-
-      let poly = (0..n).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
-      let point = (0..ell).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
-      let eval = MultilinearPolynomial::evaluate_with(&poly, &point);
-
-      let ck: CommitmentKey<NE> =
-        <KZGCommitmentEngine<E> as CommitmentEngineTrait<NE>>::setup(b"test", n);
-      let (pk, vk): (KZGProverKey<E>, KZGVerifierKey<E>) = EvaluationEngine::<E, NE>::setup(&ck);
-
-      // make a commitment
-      let C = <KZGCommitmentEngine<E> as CommitmentEngineTrait<NE>>::commit(&ck, &poly);
-
-      // prove an evaluation
-      let mut prover_transcript = Keccak256Transcript::<NE>::new(b"TestEval");
-      let proof: EvaluationArgument<E> = EvaluationEngine::<E, NE>::prove(
-        &ck,
-        &pk,
-        &mut prover_transcript,
-        &C,
-        &poly,
-        &point,
-        &eval,
-      )
-      .unwrap();
-
-      // verify the evaluation
-      let mut verifier_tr = Keccak256Transcript::<NE>::new(b"TestEval");
-      assert!(
-        EvaluationEngine::<E, NE>::verify(&vk, &mut verifier_tr, &C, &point, &eval, &proof).is_ok()
-      );
-
-      // Change the proof and expect verification to fail
-      let mut bad_proof = proof.clone();
-      bad_proof.comms[0] = (bad_proof.comms[0] + bad_proof.comms[1]).to_affine();
-      let mut verifier_tr2 = Keccak256Transcript::<NE>::new(b"TestEval");
-      assert!(EvaluationEngine::<E, NE>::verify(
-        &vk,
-        &mut verifier_tr2,
-        &C,
-        &point,
-        &eval,
-        &bad_proof
-      )
-      .is_err());
+      test_from_seed::<NE, EvaluationEngine<E, NE>>(ell);
+      test_fail_bad_proof::<NE, EvaluationEngine<E, NE>>(ell);
     }
   }
 }

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -429,7 +429,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::util::test_utils::{test_fail_bad_proof, test_from_seed};
+  use crate::provider::util::test_utils::test_from_ell;
   use crate::{
     provider::keccak::Keccak256Transcript, traits::commitment::CommitmentTrait, CommitmentKey,
   };
@@ -558,8 +558,7 @@ mod tests {
   fn test_mlkzg_more() {
     // test the mlkzg prover and verifier with random instances (derived from a seed)
     for ell in [4, 5, 6] {
-      test_from_seed::<NE, EvaluationEngine<E, NE>>(ell);
-      test_fail_bad_proof::<NE, EvaluationEngine<E, NE>>(ell);
+      test_from_ell::<NE, EvaluationEngine<E, NE>>(ell);
     }
   }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,7 +15,10 @@ pub(crate) mod traits;
 // a non-hiding variant of {kzg, zeromorph}
 pub(crate) mod kzg_commitment;
 pub(crate) mod non_hiding_kzg;
+#[cfg(not(feature = "bench"))]
 mod util;
+#[cfg(feature = "bench")]
+pub mod util;
 
 // crate-private modules
 mod keccak;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,10 +15,7 @@ pub(crate) mod traits;
 // a non-hiding variant of {kzg, zeromorph}
 pub(crate) mod kzg_commitment;
 pub(crate) mod non_hiding_kzg;
-#[cfg(not(feature = "bench"))]
-mod util;
-#[cfg(feature = "bench")]
-pub mod util;
+pub(crate) mod util;
 
 // crate-private modules
 mod keccak;

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -539,7 +539,7 @@ mod test {
         batched_lifted_degree_quotient, eval_and_quotient_scalars, trim, ZMEvaluation, ZMPCS,
       },
       traits::DlogGroup,
-      util::test_utils::test_from_ell,
+      util::test_utils::prove_verify_from_ell,
       Bn256Engine, Bn256EngineZM,
     },
     spartan::polys::multilinear::MultilinearPolynomial,
@@ -605,9 +605,9 @@ mod test {
   }
 
   #[test]
-  fn test_multiple_seeds() {
+  fn test_multiple_polynomial_size() {
     for ell in [4, 5, 6] {
-      test_from_ell::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
+      prove_verify_from_ell::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
     }
   }
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -539,7 +539,7 @@ mod test {
         batched_lifted_degree_quotient, eval_and_quotient_scalars, trim, ZMEvaluation, ZMPCS,
       },
       traits::DlogGroup,
-      util::test_utils::prove_verify_from_ell,
+      util::test_utils::prove_verify_from_num_vars,
       Bn256Engine, Bn256EngineZM,
     },
     spartan::polys::multilinear::MultilinearPolynomial,
@@ -606,8 +606,8 @@ mod test {
 
   #[test]
   fn test_multiple_polynomial_size() {
-    for ell in [4, 5, 6] {
-      prove_verify_from_ell::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
+    for num_vars in [4, 5, 6] {
+      prove_verify_from_num_vars::<_, ZMPCS<Bn256, Bn256EngineZM>>(num_vars);
     }
   }
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -529,17 +529,17 @@ mod test {
   use rand_core::SeedableRng;
 
   use super::quotients;
-  use crate::errors::PCSError;
-  use crate::provider::non_hiding_kzg::{KZGProverKey, UVKZGCommitment, UVKZGPCS};
+
   use crate::{
+    errors::PCSError,
     provider::{
       keccak::Keccak256Transcript,
-      non_hiding_kzg::{UVKZGPoly, UniversalKZGParam},
+      non_hiding_kzg::{KZGProverKey, UVKZGCommitment, UVKZGPoly, UniversalKZGParam, UVKZGPCS},
       non_hiding_zeromorph::{
         batched_lifted_degree_quotient, eval_and_quotient_scalars, trim, ZMEvaluation, ZMPCS,
       },
       traits::DlogGroup,
-      util::test_utils::{test_fail_bad_proof, test_from_seed},
+      util::test_utils::test_from_ell,
       Bn256Engine, Bn256EngineZM,
     },
     spartan::polys::multilinear::MultilinearPolynomial,
@@ -607,8 +607,7 @@ mod test {
   #[test]
   fn test_multiple_seeds() {
     for ell in [4, 5, 6] {
-      test_from_seed::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
-      test_fail_bad_proof::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
+      test_from_ell::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
     }
   }
 

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -443,19 +443,19 @@ fn eval_and_quotient_scalars<F: Field>(y: F, x: F, z: F, point: &[F]) -> (F, (Ve
   //           = [- (y^i * x^(2^num_vars - d_i - 1) + z * (x^(2^i) * Φ_(n-i-1)(x^(2^(i+1))) - u_i * Φ_(n-i)(x^(2^i)))), i ∈ [0, num_vars-1]]
   #[allow(clippy::disallowed_methods)]
   let q_scalars = iter::successors(Some(F::ONE), |acc| Some(*acc * y)).take(num_vars)
-    .zip_eq(offsets_of_x)
-    // length: num_vars + 1
-    .zip(squares_of_x)
-    // length: num_vars + 1
-    .zip(&vs)
-    .zip_eq(&vs[1..])
-    .zip_eq(point.iter().rev()) // assume variables come in BE form
-    .map(
-      |(((((power_of_y, offset_of_x), square_of_x), v_i), v_j), u_i)| {
-        (-(power_of_y * offset_of_x), -(z * (square_of_x * v_j - *u_i * v_i)))
-      },
-    )
-    .unzip();
+      .zip_eq(offsets_of_x)
+      // length: num_vars + 1
+      .zip(squares_of_x)
+      // length: num_vars + 1
+      .zip(&vs)
+      .zip_eq(&vs[1..])
+      .zip_eq(point.iter().rev()) // assume variables come in BE form
+      .map(
+        |(((((power_of_y, offset_of_x), square_of_x), v_i), v_j), u_i)| {
+          (-(power_of_y * offset_of_x), -(z * (square_of_x * v_j - *u_i * v_i)))
+        },
+      )
+      .unzip();
 
   // -vs[0] * z = -z * (x^(2^num_vars) - 1) / (x - 1) = -z Φ_n(x)
   (-vs[0] * z, q_scalars)
@@ -539,7 +539,8 @@ mod test {
         batched_lifted_degree_quotient, eval_and_quotient_scalars, trim, ZMEvaluation, ZMPCS,
       },
       traits::DlogGroup,
-      Bn256Engine,
+      util::test_utils::{test_fail_bad_proof, test_from_seed},
+      Bn256Engine, Bn256EngineZM,
     },
     spartan::polys::multilinear::MultilinearPolynomial,
     traits::{Engine as NovaEngine, Group, TranscriptEngineTrait, TranscriptReprTrait},
@@ -601,6 +602,14 @@ mod test {
   #[test]
   fn test_commit_open_verify() {
     commit_open_verify_with::<Bn256, Bn256Engine>();
+  }
+
+  #[test]
+  fn test_multiple_seeds() {
+    for ell in [4, 5, 6] {
+      test_from_seed::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
+      test_fail_bad_proof::<Bn256EngineZM, ZMPCS<Bn256, Bn256EngineZM>>(ell);
+    }
   }
 
   #[test]

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -37,7 +37,7 @@ pub(crate) mod test_utils {
     // Mock commitment key.
     let ck = E::CE::setup(b"test", 1 << seed);
     // Commits to the provided vector using the provided generators.
-    let commitment = E::CE::commit(&ck, &poly.evaluations());
+    let commitment = E::CE::commit(&ck, poly.evaluations());
 
     // Generate Prover and verifier key for given commitment key.
     let (prover_key, verifier_key) = EE::setup(&ck);
@@ -49,7 +49,7 @@ pub(crate) mod test_utils {
       &prover_key,
       &mut prover_transcript,
       &commitment,
-      &poly.evaluations(),
+      poly.evaluations(),
       &point,
       &eval,
     )
@@ -97,7 +97,7 @@ pub(crate) mod test_utils {
     // Mock commitment key.
     let ck = E::CE::setup(b"test", 1 << seed);
     // Commits to the provided vector using the provided generators.
-    let commitment = E::CE::commit(&ck, &prover_poly.evaluations());
+    let commitment = E::CE::commit(&ck, prover_poly.evaluations());
 
     // Generate Prover and verifier key for given commitment key.
     let (prover_key, verifier_key) = EE::setup(&ck);
@@ -109,7 +109,7 @@ pub(crate) mod test_utils {
       &prover_key,
       &mut prover_transcript,
       &commitment,
-      &prover_poly.evaluations(),
+      prover_poly.evaluations(),
       &prover_point,
       &prover_eval,
     )

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -21,8 +21,7 @@ pub mod test_utils {
 
   /// Generates a random polynomial and point from a seed to test a proving/verifying flow of one
   /// of our EvaluationEngine over a given Engine.
-  #[cfg(test)]
-  pub(crate) fn test_from_ell<E: Engine, EE: EvaluationEngineTrait<E>>(ell: usize) {
+  pub(crate) fn prove_verify_from_ell<E: Engine, EE: EvaluationEngineTrait<E>>(ell: usize) {
     use rand_core::SeedableRng;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(ell as u64);
@@ -34,11 +33,10 @@ pub mod test_utils {
     // Commits to the provided vector using the provided generators.
     let commitment = E::CE::commit(&ck, poly.evaluations());
 
-    test_prove_verify_with::<E, EE>(&ck, &commitment, &poly, &point, &eval, true)
+    prove_verify_with::<E, EE>(&ck, &commitment, &poly, &point, &eval, true)
   }
 
-  #[cfg(test)]
-  pub(crate) fn test_prove_verify_with<E: Engine, EE: EvaluationEngineTrait<E>>(
+  pub(crate) fn prove_verify_with<E: Engine, EE: EvaluationEngineTrait<E>>(
     ck: &<<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey,
     commitment: &<<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment,
     poly: &MultilinearPolynomial<<E as Engine>::Scalar>,

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -10,3 +10,121 @@ pub mod msm {
     best_multiexp(scalars, bases)
   }
 }
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+  use crate::spartan::polys::multilinear::MultilinearPolynomial;
+  use crate::traits::commitment::CommitmentEngineTrait;
+  use crate::traits::evaluation::EvaluationEngineTrait;
+  use crate::traits::{Engine, TranscriptEngineTrait};
+  use ff::Field;
+  use rand_core::SeedableRng;
+
+  /// Generates a random polynomial and point from a seed to test a proving/verifying flow of one
+  /// of our EvaluationEngine over a given Engine.
+  pub(crate) fn test_from_seed<E: Engine, EE: EvaluationEngineTrait<E>>(seed: usize) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
+
+    // Generate random polynomial and point.
+    let poly = MultilinearPolynomial::random(seed, &mut rng);
+    let point = (0..seed)
+      .map(|_| E::Scalar::random(&mut rng))
+      .collect::<Vec<_>>();
+
+    // Calculation evaluation of point over polynomial.
+    let eval = MultilinearPolynomial::evaluate_with(poly.evaluations(), &point);
+
+    // Mock commitment key.
+    let ck = E::CE::setup(b"test", 1 << seed);
+    // Commits to the provided vector using the provided generators.
+    let commitment = E::CE::commit(&ck, &poly.evaluations());
+
+    // Generate Prover and verifier key for given commitment key.
+    let (prover_key, verifier_key) = EE::setup(&ck);
+
+    // Generate proof.
+    let mut prover_transcript = E::TE::new(b"TestEval");
+    let proof = EE::prove(
+      &ck,
+      &prover_key,
+      &mut prover_transcript,
+      &commitment,
+      &poly.evaluations(),
+      &point,
+      &eval,
+    )
+    .unwrap();
+    let pcp = prover_transcript.squeeze(b"c").unwrap();
+
+    // Verify proof.
+    let mut verifier_transcript = E::TE::new(b"TestEval");
+    EE::verify(
+      &verifier_key,
+      &mut verifier_transcript,
+      &commitment,
+      &point,
+      &eval,
+      &proof,
+    )
+    .unwrap();
+    let pcv = verifier_transcript.squeeze(b"c").unwrap();
+
+    // Check if the prover transcript and verifier transcript are kept in the same state.
+    assert_eq!(pcp, pcv);
+  }
+
+  /// Test the flow where we have a bad proof generated and we try to verify it. We expect it to fail,
+  /// as it should.
+  pub(crate) fn test_fail_bad_proof<E: Engine, EE: EvaluationEngineTrait<E>>(seed: usize) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
+
+    // Generate random polynomial and point to create proof. Also produce eval.
+    let prover_poly = MultilinearPolynomial::random(seed, &mut rng);
+    let prover_point = (0..seed)
+      .map(|_| E::Scalar::random(&mut rng))
+      .collect::<Vec<_>>();
+    let prover_eval =
+      MultilinearPolynomial::evaluate_with(prover_poly.evaluations(), &prover_point);
+
+    // Generate another point to verify proof. Also produce eval.
+    let verifier_point = prover_point
+      .iter()
+      .map(|_| E::Scalar::random(&mut rng))
+      .collect::<Vec<_>>();
+    let verifier_eval =
+      MultilinearPolynomial::evaluate_with(prover_poly.evaluations(), &prover_point);
+
+    // Mock commitment key.
+    let ck = E::CE::setup(b"test", 1 << seed);
+    // Commits to the provided vector using the provided generators.
+    let commitment = E::CE::commit(&ck, &prover_poly.evaluations());
+
+    // Generate Prover and verifier key for given commitment key.
+    let (prover_key, verifier_key) = EE::setup(&ck);
+
+    // Generate proof.
+    let mut prover_transcript = E::TE::new(b"TestEval");
+    let proof = EE::prove(
+      &ck,
+      &prover_key,
+      &mut prover_transcript,
+      &commitment,
+      &prover_poly.evaluations(),
+      &prover_point,
+      &prover_eval,
+    )
+    .unwrap();
+
+    // Verify proof, should fail.
+    let mut verifier_transcript = E::TE::new(b"TestEval");
+    assert!(EE::verify(
+      &verifier_key,
+      &mut verifier_transcript,
+      &commitment,
+      &verifier_point,
+      &verifier_eval,
+      &proof,
+    )
+    .is_err());
+  }
+}

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -19,17 +19,22 @@ pub mod test_utils {
     commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, Engine,
   };
 
+  /// Methods used to test the prove and verify flow of [`MultilinearPolynomial`] Commitment Schemes
+  /// (PCS).
+  ///
   /// Generates a random polynomial and point from a seed to test a proving/verifying flow of one
-  /// of our EvaluationEngine over a given Engine.
-  pub(crate) fn prove_verify_from_ell<E: Engine, EE: EvaluationEngineTrait<E>>(ell: usize) {
+  /// of our [`EvaluationEngine`].
+  pub(crate) fn prove_verify_from_num_vars<E: Engine, EE: EvaluationEngineTrait<E>>(
+    num_vars: usize,
+  ) {
     use rand_core::SeedableRng;
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(ell as u64);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(num_vars as u64);
 
-    let (poly, point, eval) = MultilinearPolynomial::random_with_eval(ell, &mut rng);
+    let (poly, point, eval) = MultilinearPolynomial::random_with_eval(num_vars, &mut rng);
 
     // Mock commitment key.
-    let ck = E::CE::setup(b"test", 1 << ell);
+    let ck = E::CE::setup(b"test", 1 << num_vars);
     // Commits to the provided vector using the provided generators.
     let commitment = E::CE::commit(&ck, poly.evaluations());
 

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -1,4 +1,4 @@
-/// Utilities for provider module
+//! Utilities for provider module.
 pub(in crate::provider) mod fb_msm;
 pub mod msm {
   use halo2curves::msm::best_multiexp;
@@ -11,18 +11,27 @@ pub mod msm {
   }
 }
 
-#[cfg(test)]
-pub(crate) mod test_utils {
+#[cfg(any(test, feature = "bench"))]
+pub mod test_utils {
+  //! Contains utilities for testing and benchmarking.
+
   use crate::spartan::polys::multilinear::MultilinearPolynomial;
   use crate::traits::commitment::CommitmentEngineTrait;
   use crate::traits::evaluation::EvaluationEngineTrait;
-  use crate::traits::{Engine, TranscriptEngineTrait};
+  use crate::traits::Engine;
+  #[cfg(test)]
+  use crate::traits::TranscriptEngineTrait;
   use ff::Field;
   use rand_core::SeedableRng;
-
-  /// Generates a random polynomial and point from a seed to test a proving/verifying flow of one
-  /// of our EvaluationEngine over a given Engine.
-  pub(crate) fn test_from_seed<E: Engine, EE: EvaluationEngineTrait<E>>(seed: usize) {
+  /// Generates a random polynomial and point from a seed. Then, produces the evaluation of the point
+  /// over the polynomial.
+  pub fn gen_poly_point_eval<E: Engine>(
+    seed: usize,
+  ) -> (
+    MultilinearPolynomial<<E as Engine>::Scalar>,
+    Vec<<E as Engine>::Scalar>,
+    <E as Engine>::Scalar,
+  ) {
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
 
     // Generate random polynomial and point.
@@ -34,6 +43,20 @@ pub(crate) mod test_utils {
     // Calculation evaluation of point over polynomial.
     let eval = MultilinearPolynomial::evaluate_with(poly.evaluations(), &point);
 
+    (poly, point, eval)
+  }
+
+  /// Commits to the provided vector using the provided generators, and generate Prover and verifier
+  /// key for given commitment key.
+  pub fn commitment_setup<E: Engine, EE: EvaluationEngineTrait<E>>(
+    seed: usize,
+    poly: &MultilinearPolynomial<<E as Engine>::Scalar>,
+  ) -> (
+    <<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey,
+    <<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment,
+    <EE as EvaluationEngineTrait<E>>::ProverKey,
+    <EE as EvaluationEngineTrait<E>>::VerifierKey,
+  ) {
     // Mock commitment key.
     let ck = E::CE::setup(b"test", 1 << seed);
     // Commits to the provided vector using the provided generators.
@@ -41,6 +64,17 @@ pub(crate) mod test_utils {
 
     // Generate Prover and verifier key for given commitment key.
     let (prover_key, verifier_key) = EE::setup(&ck);
+
+    (ck, commitment, prover_key, verifier_key)
+  }
+
+  /// Generates a random polynomial and point from a seed to test a proving/verifying flow of one
+  /// of our EvaluationEngine over a given Engine.
+  #[cfg(test)]
+  pub(crate) fn test_from_seed<E: Engine, EE: EvaluationEngineTrait<E>>(seed: usize) {
+    let (poly, point, eval) = gen_poly_point_eval::<E>(seed);
+
+    let (ck, commitment, prover_key, verifier_key) = commitment_setup::<E, EE>(seed, &poly);
 
     // Generate proof.
     let mut prover_transcript = E::TE::new(b"TestEval");
@@ -75,16 +109,11 @@ pub(crate) mod test_utils {
 
   /// Test the flow where we have a bad proof generated and we try to verify it. We expect it to fail,
   /// as it should.
+  #[cfg(test)]
   pub(crate) fn test_fail_bad_proof<E: Engine, EE: EvaluationEngineTrait<E>>(seed: usize) {
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
 
-    // Generate random polynomial and point to create proof. Also produce eval.
-    let prover_poly = MultilinearPolynomial::random(seed, &mut rng);
-    let prover_point = (0..seed)
-      .map(|_| E::Scalar::random(&mut rng))
-      .collect::<Vec<_>>();
-    let prover_eval =
-      MultilinearPolynomial::evaluate_with(prover_poly.evaluations(), &prover_point);
+    let (prover_poly, prover_point, prover_eval) = gen_poly_point_eval::<E>(seed);
 
     // Generate another point to verify proof. Also produce eval.
     let verifier_point = prover_point
@@ -94,13 +123,7 @@ pub(crate) mod test_utils {
     let verifier_eval =
       MultilinearPolynomial::evaluate_with(prover_poly.evaluations(), &prover_point);
 
-    // Mock commitment key.
-    let ck = E::CE::setup(b"test", 1 << seed);
-    // Commits to the provided vector using the provided generators.
-    let commitment = E::CE::commit(&ck, prover_poly.evaluations());
-
-    // Generate Prover and verifier key for given commitment key.
-    let (prover_key, verifier_key) = EE::setup(&ck);
+    let (ck, commitment, prover_key, verifier_key) = commitment_setup::<E, EE>(seed, &prover_poly);
 
     // Generate proof.
     let mut prover_transcript = E::TE::new(b"TestEval");

--- a/src/spartan/polys/mod.rs
+++ b/src/spartan/polys/mod.rs
@@ -2,6 +2,6 @@
 pub(crate) mod eq;
 pub(crate) mod identity;
 pub(crate) mod masked_eq;
-pub(crate) mod multilinear;
+pub mod multilinear;
 pub(crate) mod power;
 pub(crate) mod univariate;

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -77,23 +77,6 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     )
   }
 
-  /// Returns a random polynomial, a point and calculate its evaluation.
-  pub fn random_with_eval<R: RngCore + CryptoRng>(
-    num_vars: usize,
-    mut rng: &mut R,
-  ) -> (Self, Vec<Scalar>, Scalar) {
-    let poly = Self::random(num_vars, &mut rng);
-    // Generate random polynomial and point.
-    let point = (0..num_vars)
-      .map(|_| Scalar::random(&mut rng))
-      .collect::<Vec<_>>();
-
-    // Calculation evaluation of point over polynomial.
-    let eval = Self::evaluate_with(poly.evaluations(), &point);
-
-    (poly, point, eval)
-  }
-
   /// Binds the polynomial's top variable using the given scalar.
   ///
   /// This operation modifies the polynomial in-place.

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -63,14 +63,39 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     self.Z.len()
   }
 
+  /// Returns true if no evaluations.
+  pub fn is_empty(&self) -> bool {
+    self.Z.len() == 0
+  }
+
   /// Returns a random polynomial
-  ///
   pub fn random<R: RngCore + CryptoRng>(num_vars: usize, mut rng: &mut R) -> Self {
     Self::new(
       std::iter::from_fn(|| Some(Scalar::random(&mut rng)))
         .take(1 << num_vars)
         .collect(),
     )
+  }
+
+  /// Returns a random polynomial, a point and calculate its evaluation.
+  pub fn random_with_eval<R: RngCore + CryptoRng>(
+    num_vars: usize,
+    mut rng: &mut R,
+  ) -> (Self, Vec<Scalar>, Scalar) {
+    let poly = Self::new(
+      std::iter::from_fn(|| Some(Scalar::random(&mut rng)))
+        .take(1 << num_vars)
+        .collect(),
+    );
+    // Generate random polynomial and point.
+    let point = (0..num_vars)
+      .map(|_| Scalar::random(&mut rng))
+      .collect::<Vec<_>>();
+
+    // Calculation evaluation of point over polynomial.
+    let eval = Self::evaluate_with(poly.evaluations(), &point);
+
+    (poly, point, eval)
   }
 
   /// Binds the polynomial's top variable using the given scalar.

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -82,11 +82,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     num_vars: usize,
     mut rng: &mut R,
   ) -> (Self, Vec<Scalar>, Scalar) {
-    let poly = Self::new(
-      std::iter::from_fn(|| Some(Scalar::random(&mut rng)))
-        .take(1 << num_vars)
-        .collect(),
-    );
+    let poly = Self::random(num_vars, &mut rng);
     // Generate random polynomial and point.
     let point = (0..num_vars)
       .map(|_| Scalar::random(&mut rng))


### PR DESCRIPTION
## Goal of this PR

The goal of this PR is to implement test vectors & benchmark for PCS.

### Current progress

Implemented two generic test functions that we can use over any `<Engine, EvaluationEngine<Engine>>` for both the correct prove/verify flow and a bad proof verification flow.

### Left TODO

- [x] Part of the issue is to tackle benchmark for proof size, proving time and verification time.

## Related issue

This is part of tackling the issue #212
