### PR TITLE
ci: Refactor GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,15 @@
+name: Generate and deploy crate docs
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  workflow_dispatch:
+
+jobs:
+  docs:
+    uses: lurk-lab/ci-workflows/.github/workflows/docs.yml@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,18 @@
+# Nightly sanity checks
+name: nightly
+
+on:
+  workflow_dispatch: {}
+  # Once per day at 00:00 UTC
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unused-dependencies:
+    uses: lurk-lab/ci-workflows/.github/workflows/unused-deps.yml@main
+
+  rust-version-check:
+    uses: lurk-lab/ci-workflows/.github/workflows/rust-version-check.yml@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   build:
     runs-on: buildjet-8vcpu-ubuntu-2204
-    env:
-      RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,6 @@ jobs:
   check-lurk-compiles:
     uses: lurk-lab/ci-workflows/.github/workflows/check-lurk-compiles.yml@main
     with:
-      package-name: "arecibo"
       runner: "buildjet-8vcpu-ubuntu-2204"
 
   # Wasm build, rustfmt, clippy, doctests, and MSRV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,13 +9,6 @@ on:
       - 'feat/**'
       - release-candidate
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUSTUP_MAX_RETRIES: 10
-  RUST_BACKTRACE: short
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -26,6 +19,10 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: lurk-lab/ci-workflows
+    - uses: ./.github/actions/ci-env
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: taiki-e/install-action@nextest
@@ -44,29 +41,10 @@ jobs:
         cargo nextest run --profile ci --workspace --cargo-profile dev-ci --features "asm" -E 'test(test_pp_digest)'
 
   check-lurk-compiles:
-    if: github.event_name == 'pull_request'
-    runs-on: buildjet-8vcpu-ubuntu-2204
-    env:
-      RUSTFLAGS: -D warnings
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        path: ${{ github.workspace }}/arecibo
-    - uses: actions/checkout@v4
-      with:
-        repository: lurk-lab/lurk-rs
-        path: ${{ github.workspace }}/lurk
-        submodules: recursive
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
-    - name: Patch Cargo.toml
-      working-directory: ${{ github.workspace }}/lurk
-      run: |
-        echo "[patch.'https://github.com/lurk-lab/arecibo']" >> Cargo.toml
-        echo "nova = { path='../arecibo', package='arecibo' }" >> Cargo.toml
-    - name: Check Lurk-rs types don't break spectacularly
-      working-directory: ${{ github.workspace }}/lurk
-      run: cargo check --all --tests --benches --examples
+    uses: lurk-lab/ci-workflows/.github/workflows/check-lurk-compiles.yml@main
+    with:
+      package-name: "arecibo"
+      runner: "buildjet-8vcpu-ubuntu-2204"
 
   # Wasm build, rustfmt, clippy, doctests, and MSRV
   code-quality:


### PR DESCRIPTION
- The pull request introduces predefined GitHub actions for CI env setup from `lurk-lab/ci-workflows` to simplify the existing Rust action workflow,
- A new workflow for generating and deploying crate docs has been added, triggering on push to the `dev` branch and on changes in Rust and Cargo files.
- Updates have been made to the dependabot configuration to enable 'minor' and 'patch' types for rust dependencies.
- Lastly, a new nightly workflow is set up for sanity checks, including jobs to examine unused dependencies and verify rust version.

- [x] After https://github.com/lurk-lab/ci-workflows/pull/6
- [x] After https://github.com/lurk-lab/ci-workflows/pull/11
- [x] After https://github.com/lurk-lab/ci-workflows/pull/12