### PR TITLE
ci: Add comparative GPU benchmarks on `merge_group`

### DIFF
--- a/.github/PERF_REGRESSION.md
+++ b/.github/PERF_REGRESSION.md
@@ -2,6 +2,6 @@
 title: ":rotating_light: Performance regression in #{{ env.PR_NUMBER }}"
 labels: P-Performance, automated issue
 ---
-Regression >= 5% found during merge of: #{{ env.PR_NUMBER }}
+Regression >= {{ env.NOISE_THRESHOLD }} found during merge of: #{{ env.PR_NUMBER }}
 Commit: {{ env.GIT_SHA }}
 Triggered by: {{ env.WORKFLOW_URL }}

--- a/.github/PERF_REGRESSION.md
+++ b/.github/PERF_REGRESSION.md
@@ -1,0 +1,7 @@
+---
+title: ":rotating_light: Performance regression in #{{ env.PR_NUMBER }}"
+labels: P-Performance, automated issue
+---
+Regression >= 5% found during merge of: #{{ env.PR_NUMBER }}
+Commit: {{ env.GIT_SHA }}
+Triggered by: {{ env.WORKFLOW_URL }}

--- a/.github/tables.toml
+++ b/.github/tables.toml
@@ -1,0 +1,6 @@
+[table_comments]
+
+[top_comments]
+Overview = """
+This benchmark report shows the Arecibo GPU benchmarks.
+"""

--- a/.github/workflows/gpu-bench.yml
+++ b/.github/workflows/gpu-bench.yml
@@ -91,13 +91,15 @@ jobs:
           NUM_VCPUS=$(nproc --all)
           # Get total RAM in GB
           TOTAL_RAM=$(grep MemTotal /proc/meminfo | awk '{$2=$2/(1024^2); print int($2), "GB RAM";}')
+          WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           
           # Use conditionals to ensure that only non-empty variables are inserted
           [[ ! -z "${{ env.GPU_NAME }}" ]] && sed -i "/^\"\"\"$/i ${{ env.GPU_NAME }}" tables.toml
           [[ ! -z "$CPU_MODEL" ]] && sed -i "/^\"\"\"$/i $CPU_MODEL" tables.toml
           [[ ! -z "$NUM_VCPUS" ]] && sed -i "/^\"\"\"$/i $NUM_VCPUS" tables.toml
           [[ ! -z "$TOTAL_RAM" ]] && sed -i "/^\"\"\"$/i $TOTAL_RAM" tables.toml          
-          sed -i "/^\"\"\"$/i Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" tables.toml
+          sed -i "/^\"\"\"$/i Workflow run: $WORKFLOW_URL" tables.toml
+          echo "WORKFLOW_URL=$WORKFLOW_URL" | tee -a $GITHUB_ENV
         working-directory: ${{ github.workspace }}
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
@@ -126,21 +128,14 @@ jobs:
       - name: Get PR number from merge branch
         run: |
           echo "PR_NUMBER=$(echo ${{ github.event.merge_group.head_ref }} | sed -e 's/.*pr-\(.*\)-.*/\1/')" | tee -a $GITHUB_ENV
-      - name: Create file for issue
-        if: steps.regression-check.outcome == 'failure'
-        run: |
-          printf '%s\n' "Regression >= 10% found during merge for PR #${{ env.PR_NUMBER }}
-          Commit: ${{ github.sha }}
-          Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ./_body.md
-      - name: Open issue on regression
-        if: steps.regression-check.outcome == 'failure'
-        uses: peter-evans/create-issue-from-file@v4
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          GIT_SHA: ${{ github.sha }}
+          WORKFLOW_URL: ${{ env.WORKFLOW_URL }}
         with:
-          title: ':rotating_light: Performance regression detected for PR #${{ env.PR_NUMBER }}'
-          content-filepath: ./_body.md
-          labels: |
-            P-Performance
-            automated issue
+          filename: .github/PERF_REGRESSION.md
       - name: Remove old dev bench
         run: |
           rm ${{ env.BASE_COMMIT }}.json

--- a/.github/workflows/gpu-bench.yml
+++ b/.github/workflows/gpu-bench.yml
@@ -43,44 +43,25 @@ jobs:
           GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | tail -n1)
           echo "GPU_ID=$(echo $GPU_NAME | awk '{ print $NF }')" | tee -a $GITHUB_ENV
           echo "GPU_NAME=$GPU_NAME" | tee -a $GITHUB_ENV
-      # Checkout gh-pages to check for cached bench result
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Check for cached bench result
-        id: cached-bench
-        run: |
-          if [ -f "${{ env.BASE_COMMIT }}-${{ env.GPU_ID }}.json" ]
-          then
-            echo "cached=true" | tee -a $GITHUB_OUTPUT
-            cp ${{ env.BASE_COMMIT }}-${{ env.GPU_ID }}.json ../${{ env.BASE_COMMIT }}.json
-          else
-            echo "cached=false" | tee -a $GITHUB_OUTPUT
-          fi
-        working-directory: ${{ github.workspace }}/gh-pages
       # Checkout base branch for comparative bench
       - uses: actions/checkout@v4
-        if: steps.cached-bench.outputs.cached == 'false'
         with:
           ref: dev
           path: dev
       # Copy the script so the base can bench with the same parameters
       - name: Run GPU bench on base branch
-        if: steps.cached-bench.outputs.cached == 'false'
         run: |
-          # Copy justfile & env to dev, overwriting existing config with that of PR branch
-          cp ../benches/justfile ../benches/bench.env .
+          # Copy justfile to dev, overwriting existing config with that of PR branch
+          cp ../benches/justfile .
           # Run benchmark
           just gpu-bench-ci recursive-snark recursive-snark-supernova compressed-snark compressed-snark-supernova
           # Copy bench output to PR branch
-          cp ${{ env.BASE_COMMIT }}.json ..
+          cp *-${{ env.BASE_COMMIT }}.json ..
         working-directory: ${{ github.workspace }}/dev
       - name: Run GPU bench on PR branch
         run: |
           just gpu-bench-ci recursive-snark recursive-snark-supernova compressed-snark compressed-snark-supernova
-          cp ${{ github.sha }}.json ..
+          cp *-${{ github.sha }}.json ..
         working-directory: ${{ github.workspace }}/benches
       - name: copy the benchmark template and prepare it with data
         run: |
@@ -103,26 +84,37 @@ jobs:
         working-directory: ${{ github.workspace }}
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
-        run: cat ${{ env.BASE_COMMIT }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+        run: |
+          cat recursive-snark-${{ env.BASE_COMMIT }}.json recursive-snark-${{ github.sha }}.json \
+          recursive-snark-supernova-${{ env.BASE_COMMIT }}.json recursive-snark-supernova- ${{ github.sha }}.json \
+          compressed-snark-${{ env.BASE_COMMIT }}.json compressed-snark-${{ github.sha }}.json \
+          compressed-snark-supernova-${{ env.BASE_COMMIT }}.json compressed-snark-supernova- ${{ github.sha }}.json \
+          | criterion-table > BENCHMARKS.md
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:
           body-path: BENCHMARKS.md
-      # Check for a slowdown >= 10%. If so, open an issue but don't block merge
+      # Check for a slowdown >= `$ARECIBO_NOISE_THRESHOLD` (fallback is 5%). If so, open an issue but don't block merge
       - name: Check for perf regression
         id: regression-check
         run: |
-          regressions=$(awk -F'[*x]' '/slower/{print $12}' BENCHMARKS.md)
-
+          REGRESSIONS=$(awk -F'[*x]' '/slower/{print $12}' BENCHMARKS.md)
           echo $regressions
 
-          for r in $regressions
+          if [ ! -z "${{ env.ARECIBO_NOISE_THRESHOLD}}" ]; then
+            NOISE_THRESHOLD=$(echo "1+${{ env.ARECIBO_NOISE_THRESHOLD }}" | bc)
+          else
+            NOISE_THRESHOLD=1.05
+          fi
+
+          for r in $REGRESSIONS
           do
-            if (( $(echo "$r >= 1.10" | bc -l) ))
+            if (( $(echo "$r >= $NOISE_THRESHOLD" | bc -l) ))
             then
               exit 1
             fi
           done
+          echo "NOISE_THRESHOLD=$NOISE_THRESHOLD" | tee -a $GITHUB_ENV
         continue-on-error: true
       # Not possible to use ${{ github.event.number }} with the `merge_group` trigger
       - name: Get PR number from merge branch
@@ -134,17 +126,6 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
           GIT_SHA: ${{ github.sha }}
           WORKFLOW_URL: ${{ env.WORKFLOW_URL }}
+          NOISE_THRESHOLD: $${{ env.NOISE_THRESHOLD }}
         with:
           filename: .github/PERF_REGRESSION.md
-      - name: Remove old dev bench
-        run: |
-          rm ${{ env.BASE_COMMIT }}.json
-          mv ${{ github.sha }}.json ${{ github.sha }}-${{ env.GPU_ID }}.json
-        working-directory: ${{ github.workspace }}
-      - name: Commit bench result to `gh-pages` branch if no regression
-        if: steps.regression-check.outcome != 'failure'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          branch: gh-pages
-          commit_message: '[automated] GPU Benchmark from PR #${{ env.PR_NUMBER }}'
-          file_pattern: '${{ github.sha }}-${{ env.GPU_ID }}.json'

--- a/.github/workflows/gpu-bench.yml
+++ b/.github/workflows/gpu-bench.yml
@@ -1,0 +1,155 @@
+# Run final tests only when attempting to merge, shown as skipped status checks beforehand
+name: GPU benchmark regression test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [dev]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Run comparative benchmark against dev, open issue on regression
+  gpu-benchmark:
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    name: Run benchmarks on GPU
+    runs-on: [self-hosted, gpu-bench]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: lurk-lab/ci-workflows
+      - uses: ./.github/actions/gpu-setup
+        with:
+          gpu-framework: 'cuda'
+      - uses: ./.github/actions/ci-env
+      - uses: actions/checkout@v4
+      # Install dependencies
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.22
+      - name: Install criterion
+        run: |
+          cargo install cargo-criterion
+          cargo install criterion-table
+      - name: Set bench output format and base SHA
+        run: |
+          echo "ARECIBO_BENCH_OUTPUT=commit-comment" | tee -a $GITHUB_ENV
+          echo "BASE_COMMIT=${{ github.event.merge_group.base_sha }}" | tee -a $GITHUB_ENV
+          GPU_NAME=$(nvidia-smi --query-gpu=gpu_name --format=csv,noheader,nounits | tail -n1)
+          echo "GPU_ID=$(echo $GPU_NAME | awk '{ print $NF }')" | tee -a $GITHUB_ENV
+          echo "GPU_NAME=$GPU_NAME" | tee -a $GITHUB_ENV
+      # Checkout gh-pages to check for cached bench result
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Check for cached bench result
+        id: cached-bench
+        run: |
+          if [ -f "${{ env.BASE_COMMIT }}-${{ env.GPU_ID }}.json" ]
+          then
+            echo "cached=true" | tee -a $GITHUB_OUTPUT
+            cp ${{ env.BASE_COMMIT }}-${{ env.GPU_ID }}.json ../${{ env.BASE_COMMIT }}.json
+          else
+            echo "cached=false" | tee -a $GITHUB_OUTPUT
+          fi
+        working-directory: ${{ github.workspace }}/gh-pages
+      # Checkout base branch for comparative bench
+      - uses: actions/checkout@v4
+        if: steps.cached-bench.outputs.cached == 'false'
+        with:
+          ref: dev
+          path: dev
+      # Copy the script so the base can bench with the same parameters
+      - name: Run GPU bench on base branch
+        if: steps.cached-bench.outputs.cached == 'false'
+        run: |
+          # Copy justfile & env to dev, overwriting existing config with that of PR branch
+          cp ../benches/justfile ../benches/bench.env .
+          # Run benchmark
+          just gpu-bench-ci recursive-snark recursive-snark-supernova compressed-snark compressed-snark-supernova
+          # Copy bench output to PR branch
+          cp ${{ env.BASE_COMMIT }}.json ..
+        working-directory: ${{ github.workspace }}/dev
+      - name: Run GPU bench on PR branch
+        run: |
+          just gpu-bench-ci recursive-snark recursive-snark-supernova compressed-snark compressed-snark-supernova
+          cp ${{ github.sha }}.json ..
+        working-directory: ${{ github.workspace }}/benches
+      - name: copy the benchmark template and prepare it with data
+        run: |
+          cp .github/tables.toml .
+          # Get CPU model
+          CPU_MODEL=$(grep '^model name' /proc/cpuinfo | head -1 | awk -F ': ' '{ print $2 }')
+          # Get vCPU count
+          NUM_VCPUS=$(nproc --all)
+          # Get total RAM in GB
+          TOTAL_RAM=$(grep MemTotal /proc/meminfo | awk '{$2=$2/(1024^2); print int($2), "GB RAM";}')
+          
+          # Use conditionals to ensure that only non-empty variables are inserted
+          [[ ! -z "${{ env.GPU_NAME }}" ]] && sed -i "/^\"\"\"$/i ${{ env.GPU_NAME }}" tables.toml
+          [[ ! -z "$CPU_MODEL" ]] && sed -i "/^\"\"\"$/i $CPU_MODEL" tables.toml
+          [[ ! -z "$NUM_VCPUS" ]] && sed -i "/^\"\"\"$/i $NUM_VCPUS" tables.toml
+          [[ ! -z "$TOTAL_RAM" ]] && sed -i "/^\"\"\"$/i $TOTAL_RAM" tables.toml          
+          sed -i "/^\"\"\"$/i Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" tables.toml
+        working-directory: ${{ github.workspace }}
+      # Create a `criterion-table` and write in commit comment
+      - name: Run `criterion-table`
+        run: cat ${{ env.BASE_COMMIT }}.json ${{ github.sha }}.json | criterion-table > BENCHMARKS.md
+      - name: Write bench on commit comment
+        uses: peter-evans/commit-comment@v3
+        with:
+          body-path: BENCHMARKS.md
+      # Check for a slowdown >= 10%. If so, open an issue but don't block merge
+      - name: Check for perf regression
+        id: regression-check
+        run: |
+          regressions=$(awk -F'[*x]' '/slower/{print $12}' BENCHMARKS.md)
+
+          echo $regressions
+
+          for r in $regressions
+          do
+            if (( $(echo "$r >= 1.10" | bc -l) ))
+            then
+              exit 1
+            fi
+          done
+        continue-on-error: true
+      # Not possible to use ${{ github.event.number }} with the `merge_group` trigger
+      - name: Get PR number from merge branch
+        run: |
+          echo "PR_NUMBER=$(echo ${{ github.event.merge_group.head_ref }} | sed -e 's/.*pr-\(.*\)-.*/\1/')" | tee -a $GITHUB_ENV
+      - name: Create file for issue
+        if: steps.regression-check.outcome == 'failure'
+        run: |
+          printf '%s\n' "Regression >= 10% found during merge for PR #${{ env.PR_NUMBER }}
+          Commit: ${{ github.sha }}
+          Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ./_body.md
+      - name: Open issue on regression
+        if: steps.regression-check.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: ':rotating_light: Performance regression detected for PR #${{ env.PR_NUMBER }}'
+          content-filepath: ./_body.md
+          labels: |
+            P-Performance
+            automated issue
+      - name: Remove old dev bench
+        run: |
+          rm ${{ env.BASE_COMMIT }}.json
+          mv ${{ github.sha }}.json ${{ github.sha }}-${{ env.GPU_ID }}.json
+        working-directory: ${{ github.workspace }}
+      - name: Commit bench result to `gh-pages` branch if no regression
+        if: steps.regression-check.outcome != 'failure'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: gh-pages
+          commit_message: '[automated] GPU Benchmark from PR #${{ env.PR_NUMBER }}'
+          file_pattern: '${{ github.sha }}-${{ env.GPU_ID }}.json'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ hex = "0.4.3"
 sha2 = "0.10.7"
 tracing-test = "0.2.4"
 expect-test = "1.4.1"
+anyhow = "1.0.72"
+
+[build-dependencies]
+vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [[bench]]
 name = "recursive-snark"

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,37 @@
+use anyhow::anyhow;
+use criterion::BenchmarkId;
+
+// TODO: Why Copy and &'static str over String?
+#[derive(Clone, Debug, Copy)]
+pub(crate) struct BenchParams {
+  pub step_size: usize,
+  pub date: &'static str,
+  pub sha: &'static str,
+}
+impl BenchParams {
+  pub(crate) fn bench_id(&self, name: &str) -> BenchmarkId {
+    let output_type = bench_output_env().unwrap_or("stdout".into());
+    match output_type.as_ref() {
+      "pr-comment" => BenchmarkId::new(name, format!("StepCircuitSize-{}", self.step_size)),
+      "commit-comment" => BenchmarkId::new(
+        format!("ref={}", self.sha),
+        format!("{}-StepCircuitSize-{}", name, self.step_size),
+      ),
+      // TODO: refine "gh-pages"
+      _ => BenchmarkId::new(name, format!("StepCircuitSize-{}-{}", self.sha, self.date)),
+    }
+  }
+}
+
+fn bench_output_env() -> anyhow::Result<String> {
+  std::env::var("ARECIBO_BENCH_OUTPUT").map_err(|e| anyhow!("Bench output env var isn't set: {e}"))
+}
+
+pub(crate) fn noise_threshold_env() -> anyhow::Result<f64> {
+  std::env::var("ARECIBO_BENCH_NOISE_THRESHOLD")
+    .map_err(|e| anyhow!("Noise threshold env var isn't set: {e}"))
+    .and_then(|nt| {
+      nt.parse::<f64>()
+        .map_err(|e| anyhow!("Failed to parse noise threshold: {e}"))
+    })
+}

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -18,7 +18,13 @@ impl BenchParams {
         format!("{}-StepCircuitSize-{}", name, self.step_size),
       ),
       // TODO: refine "gh-pages"
-      _ => BenchmarkId::new(name, format!("StepCircuitSize-{}-{}", self.sha, self.date)),
+      _ => BenchmarkId::new(
+        name,
+        format!(
+          "StepCircuitSize-{}-{}-{}",
+          self.step_size, self.sha, self.date
+        ),
+      ),
     }
   }
 }

--- a/benches/compressed-snark-supernova.rs
+++ b/benches/compressed-snark-supernova.rs
@@ -167,6 +167,7 @@ fn bench_compressed_snark_internal_with_arity<
 
   let bench_params = BenchParams {
     step_size: num_cons,
+    date: env!("VERGEN_GIT_COMMIT_DATE"),
     sha: env!("VERGEN_GIT_SHA"),
   };
 

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -106,6 +106,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
 
   let bench_params = BenchParams {
     step_size: num_cons,
+    date: env!("VERGEN_GIT_COMMIT_DATE"),
     sha: env!("VERGEN_GIT_SHA"),
   };
 

--- a/benches/justfile
+++ b/benches/justfile
@@ -32,5 +32,5 @@ gpu-bench +benches: gpu-env
 gpu-bench-ci +benches:
   #!/bin/sh
   for bench in {{benches}}; do
-    cargo criterion --bench $bench --features "cuda" --message-format=json > {{commit}}.json
+    cargo criterion --bench $bench --features "cuda" --message-format=json > "$bench-{{commit}}".json
   done

--- a/benches/justfile
+++ b/benches/justfile
@@ -1,0 +1,36 @@
+# Install with `cargo install just`
+# Usage: `just <bench|gpu-bench|gpu-bench-ci> <args>`
+set dotenv-load
+set dotenv-filename := "bench.env"
+set ignore-comments := true
+
+commit := `git rev-parse HEAD`
+
+# Run CPU benchmarks
+bench +benches:
+  #!/bin/sh
+  for bench in {{benches}}; do
+    cargo criterion --bench $bench
+  done
+
+gpu-env: 
+  # The `compute`/`sm` number corresponds to the Nvidia GPU architecture
+  # In this case, the self-hosted machine uses the Ampere architecture, but we want this to be configurable
+  # See https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+  export CUDA_ARCH := `nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g'`
+  export EC_GPU_CUDA_NVCC_ARGS := "--fatbin --gpu-architecture=sm_$CUDA_ARCH --generate-code=arch=compute_$CUDA_ARCH,code=sm_$CUDA_ARCH"
+  export EC_GPU_FRAMEWORK := "cuda"
+
+# Run CUDA benchmarks on GPU
+gpu-bench +benches: gpu-env
+  #!/bin/sh
+  for bench in {{benches}}; do
+    cargo criterion --bench $bench --features "cuda"
+  done
+
+# Run CUDA benchmarks on GPU, tuned for CI
+gpu-bench-ci +benches:
+  #!/bin/sh
+  for bench in {{benches}}; do
+    cargo criterion --bench $bench --features "cuda" --message-format=json > {{commit}}.json
+  done

--- a/benches/recursive-snark-supernova.rs
+++ b/benches/recursive-snark-supernova.rs
@@ -157,6 +157,7 @@ fn bench_recursive_snark_internal_with_arity(
 
   let bench_params = BenchParams {
     step_size: num_cons,
+    date: env!("VERGEN_GIT_COMMIT_DATE"),
     sha: env!("VERGEN_GIT_SHA"),
   };
 

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -110,6 +110,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     let bench_params = BenchParams {
       step_size: num_cons,
+      date: env!("VERGEN_GIT_COMMIT_DATE"),
       sha: env!("VERGEN_GIT_SHA"),
     };
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+  // Emit the instructions
+  EmitBuilder::builder().all_git().emit()?;
+  Ok(())
+}


### PR DESCRIPTION
# GPU benchmarks for PR regression testing
- Adds a benchmark regression test when merging a PR, based on https://github.com/lurk-lab/lurk-rs/blob/main/.github/workflows/merge-tests.yml
- Refactors the `recursive-snark` benchmark group and ID to enable formatting with `criterion-table`. This will be extended to `compressed-snark` and their supernova counterparts when ready.
- I attempted to test the `criterion-table` output in https://github.com/lurk-lab/arecibo/commit/a621594fa19c6ba89bd93c0bd3772f3f2765c6b2#commitcomment-136557829, and the basic logic works. Unfortunately, we're limited by the fact that the base benchmarks on `dev` don't have the same formatting or parameters as this PR, so it's impossible to demo exactly what it will look like beyond the proposal below.
  - It does correctly pick up the artificial regression I introduced, which opened #245 (partially thanks to the Dockerfile fix in https://github.com/lurk-lab/gh-actions-runner/pull/25)
- I also can't run these actions in a fork, so rather than a suboptimal reconstruction in https://github.com/lurk-lab/ci-lab I'd like to merge this PR and then iron out any last issues in the interests of speed.

Proposed `criterion-table` output:


# Benchmarks

## Table of Contents

- [Benchmark Results](#benchmark-results)
    - [RecursiveSNARK](#recursivesnark)

## Benchmark Results

### RecursiveSNARK

|                                   | `ref=ae521be709871f94a622c85b0e5d6e8f776be144`          | `ref=ace6724dc77667506dbcd1122b9851bd6edb25d2`           |
|:----------------------------------|:--------------------------------------------------------|:-------------------------------------------------------- |
| **`Prove-StepCircuitSize-0`**     | `29.28 ms` (✅ **1.00x**)                                | `28.71 ms` (✅ **1.02x faster**)                          |
| **`Verify-StepCircuitSize-0`**    | `19.48 ms` (✅ **1.00x**)                                | `19.10 ms` (✅ **1.02x faster**)                          |
| **`Prove-StepCircuitSize-6559`**  | `35.57 ms` (✅ **1.00x**)                                | `35.27 ms` (✅ **1.01x faster**)                          |
| **`Verify-StepCircuitSize-6559`** | `23.84 ms` (✅ **1.00x**)                                | `23.89 ms` (✅ **1.00x slower**)                          |

---
Made with [criterion-table](https://github.com/nu11ptr/criterion-table)

## Design notes
For the other benchmarks which have more than one group, they would each appear in their own table (e.g. `CompressedSNARK` and `CompressedSNARK-Commitments`). This layout will be shown as well when implemented.

Some other display options:
- Split each `StepCircuitSize` into its own group, which is the existing behavior. This would proliferate the number of benchmark tables to a large degree if we are displaying four different sets of benchmarks in one `.md` file
- Split the `Prove` and `Verify` benchmarks into their own table or group them together. This would require some finagling since the benchmarks are currently ordered sequentially in the order they are run.

## Future work
- Refactor into a reusable workflow (https://github.com/lurk-lab/ci-workflows/issues/15)
- Cache the PR benchmark for reuse (#246)

Helps #243 