### PR TITLE
fix: remove needless visibility modifiers

### DIFF
--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -112,7 +112,7 @@ fn inner_product<T: Field + Send + Sync>(a: &[T], b: &[T]) -> T {
 
 /// An inner product instance consists of a commitment to a vector `a` and another vector `b`
 /// and the claim that c = <a, b>.
-pub struct InnerProductInstance<E: Engine> {
+struct InnerProductInstance<E: Engine> {
   comm_a_vec: Commitment<E>,
   b_vec: Vec<E::Scalar>,
   c: E::Scalar,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -7,15 +7,15 @@ pub mod non_hiding_zeromorph;
 
 // crate-public modules, made crate-public mostly for tests
 pub(crate) mod bn256_grumpkin;
-pub(crate) mod pasta;
-pub(crate) mod pedersen;
+mod pasta;
+mod pedersen;
 pub(crate) mod poseidon;
 pub(crate) mod secp_secq;
 pub(crate) mod traits;
 // a non-hiding variant of {kzg, zeromorph}
-pub(crate) mod kzg_commitment;
-pub(crate) mod non_hiding_kzg;
-pub(crate) mod util;
+mod kzg_commitment;
+mod non_hiding_kzg;
+mod util;
 
 // crate-private modules
 mod keccak;

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -310,7 +310,7 @@ where
   /// Verifies that `value` is the evaluation at `x` of the polynomial
   /// committed inside `comm`.
   #[allow(dead_code, clippy::unnecessary_wraps)]
-  pub fn verify(
+  fn verify(
     verifier_param: impl Borrow<KZGVerifierKey<E>>,
     commitment: &UVKZGCommitment<E>,
     point: &E::Fr,

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -69,7 +69,7 @@ pub struct ZMVerifierKey<E: Engine> {
 //
 // TODO: important, we need a better way to handle that the commitment key should be 2^max_degree sized,
 // see the runtime error in commit() below
-pub fn trim<E: Engine>(
+fn trim<E: Engine>(
   params: &UniversalKZGParam<E>,
   max_degree: usize,
 ) -> (ZMProverKey<E>, ZMVerifierKey<E>) {
@@ -93,7 +93,7 @@ pub fn trim<E: Engine>(
 #[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct ZMCommitment<E: Engine>(
   /// the actual commitment is an affine point.
-  pub E::G1Affine,
+  E::G1Affine,
 );
 
 impl<E: Engine> From<UVKZGCommitment<E>> for ZMCommitment<E> {
@@ -126,11 +126,11 @@ impl<E: Engine> From<UVKZGEvaluation<E>> for ZMEvaluation<E> {
 /// Proofs
 pub struct ZMProof<E: Engine> {
   /// proof
-  pub pi: E::G1Affine,
+  pi: E::G1Affine,
   /// Polynomial commitment to qhat
-  pub cqhat: UVKZGCommitment<E>,
+  cqhat: UVKZGCommitment<E>,
   /// Polynomial commitment to qk
-  pub ck: Vec<UVKZGCommitment<E>>,
+  ck: Vec<UVKZGCommitment<E>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
@@ -155,7 +155,7 @@ where
 
   /// Generate a commitment for a polynomial
   /// Note that the scheme is not hidding
-  pub fn commit(
+  fn commit(
     pp: impl Borrow<ZMProverKey<E>>,
     poly: &MultilinearPolynomial<E::Fr>,
   ) -> Result<ZMCommitment<E>, NovaError> {
@@ -168,7 +168,7 @@ where
 
   /// On input a polynomial `poly` and a point `point`, outputs a proof for the
   /// same.
-  pub fn open(
+  fn open(
     pp: &impl Borrow<ZMProverKey<E>>,
     comm: &ZMCommitment<E>,
     poly: &MultilinearPolynomial<E::Fr>,
@@ -252,7 +252,7 @@ where
 
   /// Verifies that `value` is the evaluation at `x` of the polynomial
   /// committed inside `comm`.
-  pub fn verify(
+  fn verify(
     vk: &impl Borrow<ZMVerifierKey<E>>,
     transcript: &mut impl TranscriptEngineTrait<NE>,
     comm: &ZMCommitment<E>,
@@ -819,7 +819,7 @@ mod test {
     }
   }
 
-  pub fn commit_filtered<E>(
+  fn commit_filtered<E>(
     prover_param: impl Borrow<KZGProverKey<E>>,
     poly: &UVKZGPoly<E::Fr>,
   ) -> Result<UVKZGCommitment<E>, NovaError>

--- a/src/provider/util/fb_msm.rs
+++ b/src/provider/util/fb_msm.rs
@@ -84,7 +84,7 @@ where
 /// Given a scalar and a table of pre-computed multiples of a base point, this function
 /// efficiently computes the scalar multiplication by breaking the scalar into windows and
 /// adding the corresponding multiples from the table.
-pub(crate) fn windowed_mul<T>(
+fn windowed_mul<T>(
   outerc: usize,
   window: usize,
   multiples_of_g: &[Vec<T::Affine>],

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -23,7 +23,7 @@ pub mod test_utils {
   use rand_core::{CryptoRng, RngCore};
 
   /// Returns a random polynomial, a point and calculate its evaluation.
-  pub fn random_poly_with_eval<E: Engine, R: RngCore + CryptoRng>(
+  fn random_poly_with_eval<E: Engine, R: RngCore + CryptoRng>(
     num_vars: usize,
     mut rng: &mut R,
   ) -> (
@@ -65,7 +65,7 @@ pub mod test_utils {
     prove_verify_with::<E, EE>(&ck, &commitment, &poly, &point, &eval, true)
   }
 
-  pub(crate) fn prove_verify_with<E: Engine, EE: EvaluationEngineTrait<E>>(
+  fn prove_verify_with<E: Engine, EE: EvaluationEngineTrait<E>>(
     ck: &<<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey,
     commitment: &<<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment,
     poly: &MultilinearPolynomial<<E as Engine>::Scalar>,

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -10,11 +10,11 @@ pub mod batched;
 pub mod batched_ppsnark;
 #[macro_use]
 mod macros;
-pub(crate) mod math;
+mod math;
 pub mod polys;
 pub mod ppsnark;
 pub mod snark;
-pub(in crate::spartan) mod sumcheck;
+mod sumcheck;
 
 use crate::{
   r1cs::{R1CSShape, SparseMatrix},
@@ -35,7 +35,7 @@ fn powers<E: Engine>(s: &E::Scalar, n: usize) -> Vec<E::Scalar> {
 }
 
 /// A type that holds a witness to a polynomial evaluation instance
-pub struct PolyEvalWitness<E: Engine> {
+struct PolyEvalWitness<E: Engine> {
   p: Vec<E::Scalar>, // polynomial
 }
 
@@ -114,7 +114,7 @@ impl<E: Engine> PolyEvalWitness<E> {
 }
 
 /// A type that holds a polynomial evaluation instance
-pub struct PolyEvalInstance<E: Engine> {
+struct PolyEvalInstance<E: Engine> {
   c: Commitment<E>,  // commitment to the polynomial
   x: Vec<E::Scalar>, // evaluation point
   e: E::Scalar,      // claimed evaluation
@@ -185,7 +185,7 @@ impl<E: Engine> PolyEvalInstance<E> {
 }
 
 /// Bounds "row" variables of (A, B, C) matrices viewed as 2d multilinear polynomials
-pub fn compute_eval_table_sparse<E: Engine>(
+fn compute_eval_table_sparse<E: Engine>(
   S: &R1CSShape<E>,
   rx: &[E::Scalar],
 ) -> (Vec<E::Scalar>, Vec<E::Scalar>, Vec<E::Scalar>) {

--- a/src/spartan/polys/masked_eq.rs
+++ b/src/spartan/polys/masked_eq.rs
@@ -62,7 +62,7 @@ impl<'a, Scalar: PrimeField> MaskedEqPolynomial<'a, Scalar> {
   /// representation.
   ///
   /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
-  pub fn evals_from_points(r: &[Scalar], num_masked_vars: usize) -> Vec<Scalar> {
+  fn evals_from_points(r: &[Scalar], num_masked_vars: usize) -> Vec<Scalar> {
     let mut evals = EqPolynomial::evals_from_points(r);
 
     // replace the first 2^m evaluations with 0

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -70,7 +70,7 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
     }
   }
 
-  pub fn is_zero(&self) -> bool {
+  fn is_zero(&self) -> bool {
     self.coeffs.is_empty() || self.coeffs.iter().all(|c| c == &Scalar::ZERO)
   }
 
@@ -80,7 +80,7 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
     }
   }
 
-  pub fn leading_coefficient(&self) -> Option<&Scalar> {
+  fn leading_coefficient(&self) -> Option<&Scalar> {
     self.coeffs.last()
   }
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -218,7 +218,7 @@ impl<E: Engine> R1CSShapeSparkRepr<E> {
   }
 
   // computes evaluation oracles
-  pub(in crate::spartan) fn evaluation_oracles(
+  fn evaluation_oracles(
     &self,
     S: &R1CSShape<E>,
     r_x: &E::Scalar,

--- a/src/spartan/sumcheck/mod.rs
+++ b/src/spartan/sumcheck/mod.rs
@@ -99,7 +99,7 @@ impl<E: Engine> SumcheckProof<E> {
   }
 
   #[inline]
-  pub(in crate::spartan) fn compute_eval_points_quad<F>(
+  fn compute_eval_points_quad<F>(
     poly_A: &MultilinearPolynomial<E::Scalar>,
     poly_B: &MultilinearPolynomial<E::Scalar>,
     comb_func: &F,
@@ -300,7 +300,7 @@ impl<E: Engine> SumcheckProof<E> {
   }
 
   #[inline]
-  pub(in crate::spartan) fn compute_eval_points_cubic<F>(
+  fn compute_eval_points_cubic<F>(
     poly_A: &MultilinearPolynomial<E::Scalar>,
     poly_B: &MultilinearPolynomial<E::Scalar>,
     poly_C: &MultilinearPolynomial<E::Scalar>,
@@ -344,7 +344,7 @@ impl<E: Engine> SumcheckProof<E> {
   }
 
   #[inline]
-  pub(in crate::spartan) fn compute_eval_points_cubic_with_additive_term<F>(
+  fn compute_eval_points_cubic_with_additive_term<F>(
     poly_A: &MultilinearPolynomial<E::Scalar>,
     poly_B: &MultilinearPolynomial<E::Scalar>,
     poly_C: &MultilinearPolynomial<E::Scalar>,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -85,7 +85,7 @@ where
   C2: StepCircuit<E2::Scalar>,
 {
   /// The internal circuit shapes
-  pub circuit_shapes: Vec<R1CSWithArity<E1>>,
+  circuit_shapes: Vec<R1CSWithArity<E1>>,
 
   ro_consts_primary: ROConstants<E1>,
   ro_consts_circuit_primary: ROConstantsCircuit<E2>,
@@ -383,7 +383,7 @@ where
   }
 
   /// Returns all the primary R1CS Shapes
-  pub fn primary_r1cs_shapes(&self) -> Vec<&R1CSShape<E1>> {
+  fn primary_r1cs_shapes(&self) -> Vec<&R1CSShape<E1>> {
     self
       .circuit_shapes
       .iter()
@@ -396,7 +396,7 @@ where
 /// which allows the reuse of memory allocations and avoids unnecessary new allocations in the critical section.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct ResourceBuffer<E: Engine> {
+struct ResourceBuffer<E: Engine> {
   l_w: Option<R1CSWitness<E>>,
   l_u: Option<R1CSInstance<E>>,
 
@@ -1075,7 +1075,7 @@ where
 }
 
 /// Extension trait to simplify getting scalar form of initial circuit index.
-pub trait InitialProgramCounter<E1, E2, C1, C2>: NonUniformCircuit<E1, E2, C1, C2>
+trait InitialProgramCounter<E1, E2, C1, C2>: NonUniformCircuit<E1, E2, C1, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -1148,7 +1148,7 @@ fn num_ro_inputs(num_circuits: usize, num_limbs: usize, arity: usize, is_primary
 
 pub mod error;
 pub mod snark;
-pub(crate) mod utils;
+mod utils;
 
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
We've recently introduced quite a few visibility modifiers, here are the ones that are not needed (found through brute force).

The experimental nature of our repo will probably make the next release a major bump, so backwards-compatibility probably isn't the priority.

This will also help with https://github.com/microsoft/Nova/pull/283