### PR TITLE
Remove uneeded bounds on structs

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -29,7 +29,7 @@ impl<T: SimpleDigestible> Digestible for T {
   }
 }
 
-pub struct DigestComputer<'a, F: PrimeField, T> {
+pub struct DigestComputer<'a, F, T> {
   inner: &'a T,
   _phantom: PhantomData<F>,
 }

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -788,7 +788,7 @@ mod tests {
   #[cfg(not(target_arch = "wasm32"))]
   use proptest::prelude::*;
 
-  pub struct PolynomialMultiplier<Scalar: PrimeField> {
+  pub struct PolynomialMultiplier<Scalar> {
     pub a: Vec<Scalar>,
     pub b: Vec<Scalar>,
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1007,7 +1007,7 @@ mod tests {
   type SPrime<E, EE> = spartan::ppsnark::RelaxedR1CSSNARK<E, EE>;
 
   #[derive(Clone, Debug, Default)]
-  struct CubicCircuit<F: PrimeField> {
+  struct CubicCircuit<F> {
     _p: PhantomData<F>,
   }
 
@@ -1506,7 +1506,7 @@ mod tests {
   {
     // y is a non-deterministic advice representing the fifth root of the input at a step.
     #[derive(Clone, Debug)]
-    struct FifthRootCheckingCircuit<F: PrimeField> {
+    struct FifthRootCheckingCircuit<F> {
       y: F,
     }
 

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -36,7 +36,7 @@ pub struct VerifierKey<E: Engine> {
 
 /// Provides an implementation of a polynomial evaluation engine using IPA
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EvaluationEngine<E: Engine> {
+pub struct EvaluationEngine<E> {
   _p: PhantomData<E>,
 }
 

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -23,7 +23,7 @@ use crate::provider::{
 
 /// Provides a commitment engine
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct KZGCommitmentEngine<E: Engine> {
+pub struct KZGCommitmentEngine<E> {
   _p: PhantomData<E>,
 }
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -210,7 +210,7 @@ where
 
 /// Provides a commitment engine
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CommitmentEngine<E: Engine> {
+pub struct CommitmentEngine<E> {
   _p: PhantomData<E>,
 }
 

--- a/src/r1cs/util.rs
+++ b/src/r1cs/util.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 
 /// Wrapper struct around a field element that implements additional traits
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FWrap<F: PrimeField>(pub F);
+pub struct FWrap<F>(pub F);
 
 impl<F: PrimeField> Copy for FWrap<F> {}
 

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -15,7 +15,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, Parall
 ///
 /// For instance, for e = 6 (with a binary representation of 0b110), the vector r would be [1, 1, 0].
 #[derive(Debug)]
-pub struct EqPolynomial<Scalar: PrimeField> {
+pub struct EqPolynomial<Scalar> {
   pub(crate) r: Vec<Scalar>,
 }
 

--- a/src/spartan/polys/identity.rs
+++ b/src/spartan/polys/identity.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use ff::PrimeField;
 
-pub struct IdentityPolynomial<Scalar: PrimeField> {
+pub struct IdentityPolynomial<Scalar> {
   ell: usize,
   _p: PhantomData<Scalar>,
 }

--- a/src/spartan/polys/masked_eq.rs
+++ b/src/spartan/polys/masked_eq.rs
@@ -10,7 +10,7 @@ use itertools::zip_eq;
 /// The polynomial is defined by the formula:
 /// eqₘ(x,r) = eq(x,r) - ( ∏_{0 ≤ i < n-m} (1−rᵢ)(1−xᵢ) )⋅( ∏_{n-m ≤ i < n} (1−rᵢ)(1−xᵢ) + rᵢ⋅xᵢ )
 #[derive(Debug)]
-pub struct MaskedEqPolynomial<'a, Scalar: PrimeField> {
+pub struct MaskedEqPolynomial<'a, Scalar> {
   eq: &'a EqPolynomial<Scalar>,
   num_masked_vars: usize,
 }

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -32,7 +32,7 @@ use crate::spartan::{math::Math, polys::eq::EqPolynomial};
 ///
 /// Vector $Z$ indicates $Z(e)$ where $e$ ranges from $0$ to $2^m-1$.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MultilinearPolynomial<Scalar: PrimeField> {
+pub struct MultilinearPolynomial<Scalar> {
   num_vars: usize,           // the number of variables in the multilinear polynomial
   pub(crate) Z: Vec<Scalar>, // evaluations of the polynomial in all the 2^num_vars Boolean inputs
 }
@@ -142,7 +142,7 @@ impl<Scalar: PrimeField> Index<usize> for MultilinearPolynomial<Scalar> {
 /// For example, the evaluations are [0, 0, 0, 1, 0, 1, 0, 2].
 /// The sparse polynomial only store the non-zero values, [(3, 1), (5, 1), (7, 2)].
 /// In the tuple, the first is index, the second is value.
-pub(crate) struct SparsePolynomial<Scalar: PrimeField> {
+pub(crate) struct SparsePolynomial<Scalar> {
   num_vars: usize,
   Z: Vec<(usize, Scalar)>,
 }

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -10,7 +10,7 @@ use std::iter::successors;
 /// $$
 /// \tilde{power}(x, t) = \prod_{i=1}^m(1 + (t^{2^i} - 1) * x_i)
 /// $$
-pub struct PowPolynomial<Scalar: PrimeField> {
+pub struct PowPolynomial<Scalar> {
   eq: EqPolynomial<Scalar>,
 }
 

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -17,14 +17,14 @@ use crate::traits::{Group, TranscriptReprTrait};
 // ax^3 + bx^2 + cx + d stored as vec![d, c, b, a]
 #[derive(Debug, Clone, PartialEq, Eq, RefCast)]
 #[repr(transparent)]
-pub struct UniPoly<Scalar: PrimeField> {
+pub struct UniPoly<Scalar> {
   pub coeffs: Vec<Scalar>,
 }
 
 // ax^2 + bx + c stored as vec![c, a]
 // ax^3 + bx^2 + cx + d stored as vec![d, c, a]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CompressedUniPoly<Scalar: PrimeField> {
+pub struct CompressedUniPoly<Scalar> {
   coeffs_except_linear_term: Vec<Scalar>,
 }
 

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -100,7 +100,7 @@ impl<F: PrimeField, S: StepCircuit<F>> EnforcingStepCircuit<F> for S {}
 
 /// A trivial step circuit that simply returns the input
 #[derive(Clone, Debug, Default)]
-pub struct TrivialTestCircuit<F: PrimeField> {
+pub struct TrivialTestCircuit<F> {
   _p: PhantomData<F>,
 }
 
@@ -130,7 +130,7 @@ where
 /// NOTE: This should not be needed. The secondary circuit doesn't need the program counter at all.
 /// Ideally, the need this fills could be met by `traits::circuit::TrivialTestCircuit` (or equivalent).
 #[derive(Clone, Debug, Default)]
-pub struct TrivialSecondaryCircuit<F: PrimeField> {
+pub struct TrivialSecondaryCircuit<F> {
   _p: PhantomData<F>,
 }
 

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -349,7 +349,7 @@ mod test {
   type S2<E> = RelaxedR1CSSNARK<E, EE<E>>;
 
   #[derive(Clone)]
-  struct SquareCircuit<E: Engine> {
+  struct SquareCircuit<E> {
     _p: PhantomData<E>,
   }
 
@@ -392,7 +392,7 @@ mod test {
   }
 
   #[derive(Clone)]
-  struct CubeCircuit<E: Engine> {
+  struct CubeCircuit<E> {
     _p: PhantomData<E>,
   }
 
@@ -576,7 +576,7 @@ mod test {
   }
 
   #[derive(Clone)]
-  struct BigPowerCircuit<E: Engine> {
+  struct BigPowerCircuit<E> {
     _p: PhantomData<E>,
   }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -22,16 +22,13 @@ use tap::TapOptional;
 use super::{utils::get_selector_vec_from_index, *};
 
 #[derive(Clone, Debug, Default)]
-struct CubicCircuit<F: PrimeField> {
+struct CubicCircuit<F> {
   _p: PhantomData<F>,
   circuit_index: usize,
   rom_size: usize,
 }
 
-impl<F> CubicCircuit<F>
-where
-  F: PrimeField,
-{
+impl<F> CubicCircuit<F> {
   fn new(circuit_index: usize, rom_size: usize) -> Self {
     Self {
       circuit_index,
@@ -154,16 +151,13 @@ where
 }
 
 #[derive(Clone, Debug, Default)]
-struct SquareCircuit<F: PrimeField> {
+struct SquareCircuit<F> {
   _p: PhantomData<F>,
   circuit_index: usize,
   rom_size: usize,
 }
 
-impl<F> SquareCircuit<F>
-where
-  F: PrimeField,
-{
+impl<F> SquareCircuit<F> {
   fn new(circuit_index: usize, rom_size: usize) -> Self {
     Self {
       circuit_index,
@@ -282,7 +276,6 @@ struct TestROM<E1, E2, S>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
-  S: EnforcingStepCircuit<E2::Scalar> + Default,
 {
   rom: Vec<usize>,
   _p: PhantomData<(E1, E2, S)>,
@@ -354,7 +347,6 @@ impl<E1, E2, S> TestROM<E1, E2, S>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
-  S: EnforcingStepCircuit<E2::Scalar> + Default,
 {
   fn new(rom: Vec<usize>) -> Self {
     Self {
@@ -656,7 +648,7 @@ fn test_supernova_pp_digest() {
 
 // y is a non-deterministic hint representing the cube root of the input at a step.
 #[derive(Clone, Debug)]
-struct CubeRootCheckingCircuit<F: PrimeField> {
+struct CubeRootCheckingCircuit<F> {
   y: Option<F>,
 }
 
@@ -704,7 +696,7 @@ where
 
 // y is a non-deterministic hint representing the fifth root of the input at a step.
 #[derive(Clone, Debug)]
-struct FifthRootCheckingCircuit<F: PrimeField> {
+struct FifthRootCheckingCircuit<F> {
   y: Option<F>,
 }
 

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -22,7 +22,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
 
 /// A trivial step circuit that simply returns the input
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct TrivialCircuit<F: PrimeField> {
+pub struct TrivialCircuit<F> {
   _p: PhantomData<F>,
 }
 


### PR DESCRIPTION
Bounds on structs are generally not preferable (see e.g. [ref](https://stackoverflow.com/questions/49229332/should-trait-bounds-be-duplicated-in-struct-and-impl)), yet they're present in many places in the code base, even on structs which operation is purely parametric in their contents. This is in part because trait bounds on structs are viral (they force any super-structure that reuses the struct to replicate them).

This PR removes some unneeded instances (and should also help w/ Supernova integration where applicable).