### PR TITLE
Add Grumpkin-Pasta bindings

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   cuda:
     name: Rust tests on CUDA
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    # if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: [self-hosted, gpu-ci]
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   opencl:
     name: Rust tests on OpenCL
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    # if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: [self-hosted, gpu-ci]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   cuda:
     name: Rust tests on CUDA
-    # if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: [self-hosted, gpu-ci]
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   opencl:
     name: Rust tests on OpenCL
-    # if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: [self-hosted, gpu-ci]
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,10 @@ ref-cast = "1.0.20"
 derive_more = "0.99.17"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev", version = "0.1.4" }
-# pasta-msm also calls into sppark, which defines the same common sorting code this crate would: 
-# the `dont-implement-sort` feature avoids creating conflicting symbols.
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev", features = ["dont-implement-sort"] }
+# grumpkin-msm has been patched to support MSMs for the pasta curve cycle
+# see: https://github.com/lurk-lab/grumpkin-msm/pull/3
+# pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev", version = "0.1.4" }
+grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 halo2curves = { version = "0.5.0", features = ["bits", "derive_serde", "multicore"] }
@@ -108,7 +108,7 @@ default = []
 abomonate = []
 asm = ["halo2curves/asm"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
-portable = ["pasta-msm/portable"]
+portable = ["grumpkin-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ derive_more = "0.99.17"
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle
 # see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-# pasta-msm = { git = "https://github.com/lurk-lab/pasta-msm", branch = "dev", version = "0.1.4" }
 grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -61,7 +61,7 @@ macro_rules! impl_traits {
       fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::Affine]) -> Self {
         #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         if scalars.len() >= 128 {
-          pasta_msm::$name(bases, scalars)
+          grumpkin_msm::pasta::$name(bases, scalars)
         } else {
           cpu_best_msm(bases, scalars)
         }


### PR DESCRIPTION
This PR deals with the upstream changes in `grumpkin-msm` (https://github.com/lurk-lab/grumpkin-msm/pull/3) that add pasta bindings, causing the removal `pasta-msm`.