### PR TITLE
Optimising proving by avoiding recomputing final `Pi` polynomial in MLKZG

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This library implements Nova, a high-speed recursive SNARK.
 #![deny(
-  //warnings,
-  //unused,
+  warnings,
+  unused,
   future_incompatible,
   nonstandard_style,
   rust_2018_idioms,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This library implements Nova, a high-speed recursive SNARK.
 #![deny(
-  warnings,
-  unused,
+  //warnings,
+  //unused,
   future_incompatible,
   nonstandard_style,
   rust_2018_idioms,


### PR DESCRIPTION
Fixes https://github.com/lurk-lab/arecibo/issues/228

The obvious solution could be just reducing the number of iteration in [following]((https://github.com/lurk-lab/arecibo/blob/dev/src/provider/mlkzg.rs#L232)) loop to `ell-1` with subsequent pushing `eval` to `polys`. But, as @adr1anh noted in some of discussions we don't need to compute the commitment to this constant polynomial at prover side, since verifier has all necessary information to do that on its side, so in this PR, the `EvaluationArgument` created by prover contains `comms` without commitment to `eval`. It is recomputed at verifier's side and added to `com` vector before executing `kzg_verify_batch`. 

**Important detail**

The following check:
```
if i == ell - 1 && *eval != Pi[0] {
    return Err(NovaError::UnSat);
}
```

from initial implementation is no longer needed, because we don't compute final `Pi` but add `eval` to `polys` instead, so it is removed. The wrong `eval` is now detected during proof verification and unit-test added to enforce this. 

**Question to reviewers**

We don't actually use the `C` parameter while proving. In original implementation it [was used](https://github.com/lurk-lab/arecibo/blob/dev/src/provider/mlkzg.rs#L197) only inside `kzg_open_batch` just to validate the input size and nowhere else at sensible computations. Is that expected?

 