### PR TITLE
chore: Update halo2curves dependency and adjust grumpkin-msm source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bellpepper-core = { git="https://github.com/lurk-lab/bellpepper", branch="dev", 
 bellpepper = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
+halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
 sha3 = "0.10"
 rayon = "1.7"
 rand_core = { version = "0.6", default-features = false }
@@ -50,16 +51,11 @@ derive_more = "0.99.17"
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle
 # see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-halo2curves = { version = "0.5.0", features = ["bits", "derive_serde", "multicore"] }
+grumpkin-msm = { git = "https://github.com/huitseeker/grumpkin-msm", branch = "upgrade_halo2curves" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # see https://github.com/rust-random/rand/pull/948
 getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
-# bypass the default "multicore" feature
-halo2curves = { version = "0.5.0", default-features = false, features = ["bits", "derive_serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ derive_more = "0.99.17"
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle
 # see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-grumpkin-msm = { git = "https://github.com/huitseeker/grumpkin-msm", branch = "upgrade_halo2curves" }
+grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # see https://github.com/rust-random/rand/pull/948

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,12 +1139,12 @@ mod tests {
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, EE<_>, EE<_>>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      &expect!["7652ef8326b01e784eaac7b44bd0bc2f27af3904c96ef2bf7ab1b923b8aae701"],
+      &expect!["fd2ff9d03e5512c66014399352ce0a8d722fe9c95005067ca05fe5ce84aabb02"],
     );
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, EE<_>, EE<_>>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      &expect!["da51e6bac881c054c4ed08320ce42d8a0e61a22fbd70bbbbf05384ec4adeb201"],
+      &expect!["1e4526ea166c8cccb685bd065ba82438b3ba89e24612d3e071fd30a6065c2b03"],
     );
   }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -643,7 +643,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, _>(
     &test_rom_secp,
-    &expect!["326db6480944b0869a524ff22e71e9cff0f900728845679da5d9615cf78a2903"],
+    &expect!["e955513a59f75c63bc0649425045e6e472bddf4490a558e95bfcab14b4911a00"],
   );
 }
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -14,6 +14,7 @@ use crate::{bellpepper::test_shape_cs::TestShapeCS, gadgets::utils::alloc_one};
 use bellpepper_core::num::AllocatedNum;
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
+use expect_test::{expect, Expect};
 use ff::Field;
 use ff::PrimeField;
 use std::fmt::Write;
@@ -568,7 +569,7 @@ fn test_recursive_circuit() {
   );
 }
 
-fn test_pp_digest_with<E1, E2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &str)
+fn test_pp_digest_with<E1, E2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &Expect)
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -595,7 +596,7 @@ where
       let _ = write!(output, "{b:02x}");
       output
     });
-  assert_eq!(digest_str, expected);
+  expected.assert_eq(&digest_str);
 }
 
 #[test]
@@ -612,7 +613,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<PallasEngine, VestaEngine, _, _, _>(
     &test_rom,
-    "7e203fdfeab0ee8f56f8948497f8de73539d52e64cef89e44fff84711cf8b100",
+    &expect!["7e203fdfeab0ee8f56f8948497f8de73539d52e64cef89e44fff84711cf8b100"],
   );
 
   let rom = vec![
@@ -627,7 +628,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<Bn256Engine, GrumpkinEngine, _, _, _>(
     &test_rom_grumpkin,
-    "5caf6efbdb5a928b44a6eb4ff597e2b5f6764450ceb86b7065aac6cf965c0203",
+    &expect!["5caf6efbdb5a928b44a6eb4ff597e2b5f6764450ceb86b7065aac6cf965c0203"],
   );
 
   let rom = vec![
@@ -642,7 +643,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _, _>(
     &test_rom_secp,
-    "326db6480944b0869a524ff22e71e9cff0f900728845679da5d9615cf78a2903",
+    &expect!["326db6480944b0869a524ff22e71e9cff0f900728845679da5d9615cf78a2903"],
   );
 }
 


### PR DESCRIPTION
- Introduced `halo2curves` version `0.6.0` as a global dependency with additional features
- Eliminated specific target architecture dependency on `halo2curves`

- Testing with an updated `grumpkin-msm` source using a distinct git URL and branch

Companion PR of
- https://github.com/lurk-lab/grumpkin-msm/pull/11
- https://github.com/lurk-lab/lurk-rs/pull/1037