### PR TITLE
fix: Integrate CUDA feature with grumpkin_msm dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ derive_more = "0.99.17"
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle
 # see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
+grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # see https://github.com/rust-random/rand/pull/948
@@ -112,7 +112,7 @@ abomonate = []
 asm = ["halo2curves/asm"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["grumpkin-msm/portable"]
-cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
+cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24", "dep:grumpkin-msm"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/lurk-lab/arecibo"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
-rust-version="1.70.0"
+rust-version="1.72.0"
 
 [dependencies]
 bellpepper-core = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -7,7 +7,7 @@ use crate::{
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda"))]
 use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves
 use halo2curves::{CurveAffine, CurveExt};
@@ -31,28 +31,28 @@ pub mod grumpkin {
   };
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda"))]
 impl_traits!(
   bn256,
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
   bn256_msm
 );
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda")))]
 impl_traits!(
   bn256,
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
 );
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda"))]
 impl_traits!(
   grumpkin,
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
   grumpkin_msm
 );
-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda")))]
 impl_traits!(
   grumpkin,
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -59,13 +59,13 @@ macro_rules! impl_traits {
         name = "<_ as Group>::vartime_multiscalar_mul"
       )]
       fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::Affine]) -> Self {
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda"))]
         if scalars.len() >= 128 {
           grumpkin_msm::pasta::$name(bases, scalars)
         } else {
           cpu_best_msm(bases, scalars)
         }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        #[cfg(not(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda")))]
         cpu_best_msm(bases, scalars)
       }
 

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -74,13 +74,13 @@ macro_rules! impl_traits {
       type Compressed = $name::Compressed;
 
       fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::AffineExt]) -> Self {
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda"))]
         if scalars.len() >= 128 {
           $large_msm_method(bases, scalars)
         } else {
           cpu_best_msm(bases, scalars)
         }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        #[cfg(not(all(any(target_arch = "x86_64", target_arch = "aarch64"), feature = "cuda")))]
         cpu_best_msm(bases, scalars)
       }
 


### PR DESCRIPTION
- Modified grumpkin-msm dependency to be optional for x86_64/aarch64 targets and added it to CUDA dependencies in `Cargo.toml`.
- Inserted `cuda` feature guard for `vartime_multiscalar_mul` function in `traits.rs` file to only allow execution when `cuda` feature and specific architecture are enabled.
- Adjusted targeting condition for grumpkin_msm algorithm use in `pasta.rs`. The algorithm is now dependent on the 'cuda' feature and x86_64 or aarch64 architecture.
- Updated conditional compilation in `bn256_grumpkin.rs` to integrate CUDA feature for both bn256 and grumpkin.

Fixes https://github.com/lurk-lab/lurk-rs/issues/1030