### PR TITLE
chore: Refactor GPU tests and dependencies, remove OpenCL support

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,4 +1,4 @@
-# Runs the test suite on a self-hosted GPU machine with CUDA and OpenCL enabled
+# Runs the test suite on a self-hosted GPU machine with CUDA enabled
 name: GPU tests
 
 on:
@@ -33,25 +33,3 @@ jobs:
       - name: CUDA tests
         run: |
           cargo nextest run --profile ci --cargo-profile dev-ci --features cuda
-
-  opencl:
-    name: Rust tests on OpenCL
-    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
-    runs-on: [self-hosted, gpu-ci]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: lurk-lab/ci-workflows
-      - uses: ./.github/actions/gpu-setup
-        with:
-          gpu-framework: 'opencl'
-      - uses: ./.github/actions/ci-env
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-      - name: OpenCL tests
-        run: |
-          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda,opencl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,7 @@ group = "0.13.0"
 pairing = "0.23.0"
 abomonation = "0.7.3"
 abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
-tap = "1.0.1"
 tracing = "0.1.37"
-tracing-texray = "0.2.0"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
 itertools = "0.12.0"
@@ -65,11 +62,13 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [dev-dependencies]
 flate2 = "1.0"
 hex = "0.4.3"
-
 sha2 = "0.10.7"
 tracing-test = "0.2.4"
 expect-test = "1.4.1"
 anyhow = "1.0.72"
+tap = "1.0.1"
+tracing-texray = "0.2.0"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [build-dependencies]
 vergen = { version = "8", features = ["build", "git", "gitcl"] }
@@ -113,7 +112,6 @@ asm = ["halo2curves/asm"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["grumpkin-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
-opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin


### PR DESCRIPTION
- Removed OpenCL support from GPU testing and respective CI/CD processes
- Revised `gpu-ci.yml` to reflect changes in the GPU testing environment
- Eliminated unnecessary dependencies from main dependencies of `Cargo.toml`
- Moved dependencies `tap`, `tracing-texray`, and `tracing-subscriber` to development dependencies
- Cleaned up formatting in `dev-dependencies` section of `Cargo.toml`