### PR TITLE
refactor: Implement and integrate `rlc` function for simplified lin. combination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,35 +52,12 @@ use r1cs::{
   CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
-use std::ops::{AddAssign, MulAssign};
 use traits::{
   circuit::StepCircuit,
   commitment::{CommitmentEngineTrait, CommitmentTrait},
   snark::RelaxedR1CSSNARKTrait,
   AbsorbInROTrait, Engine, ROConstants, ROConstantsCircuit, ROTrait,
 };
-
-/// This function employs Horner's scheme and core traits to create a combination of an iterator input with the powers
-/// of a provided coefficient.
-pub(crate) fn rlc<T: Clone, F, K: Borrow<T>>(
-  iter: impl DoubleEndedIterator<Item = K>,
-  coefficient: &F,
-) -> T
-where
-  T: for<'a> MulAssign<&'a F> + for<'r> AddAssign<&'r T>,
-{
-  let mut iter = iter.rev();
-  let Some(fst) = iter.next() else {
-    panic!("input iterator should not be empty")
-  };
-
-  iter.fold(fst.borrow().clone(), |mut acc, item| {
-    acc *= coefficient;
-    acc += item.borrow();
-    acc
-  })
-}
 
 /// A type that holds parameters for the primary and secondary circuits of Nova and SuperNova
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Abomonation)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,35 @@ use r1cs::{
   CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
+use std::ops::{AddAssign, MulAssign};
 use traits::{
   circuit::StepCircuit,
   commitment::{CommitmentEngineTrait, CommitmentTrait},
   snark::RelaxedR1CSSNARKTrait,
   AbsorbInROTrait, Engine, ROConstants, ROConstantsCircuit, ROTrait,
 };
+
+/// This function employs Horner's scheme and core traits to create a combination of an iterator input with the powers
+/// of a provided coefficient.
+pub(crate) fn rlc<T: Clone, F, K: Borrow<T>>(
+  iter: impl DoubleEndedIterator<Item = K>,
+  coefficient: &F,
+) -> T
+where
+  T: for<'a> MulAssign<&'a F> + for<'r> AddAssign<&'r T>,
+{
+  let mut iter = iter.rev();
+  let Some(fst) = iter.next() else {
+    panic!("input iterator should not be empty")
+  };
+
+  iter.fold(fst.borrow().clone(), |mut acc, item| {
+    acc *= coefficient;
+    acc += item.borrow();
+    acc
+  })
+}
 
 /// A type that holds parameters for the primary and secondary circuits of Nova and SuperNova
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Abomonation)]

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -7,8 +7,8 @@ use crate::{
     non_hiding_kzg::{KZGProverKey, KZGVerifierKey, UniversalKZGParam},
     pedersen::Commitment,
     traits::DlogGroup,
+    util::iterators::DoubleEndedIteratorExt as _,
   },
-  rlc,
   spartan::polys::univariate::UniPoly,
   traits::{
     commitment::{CommitmentEngineTrait, Len},
@@ -171,7 +171,7 @@ where
      -> (Vec<E::G1Affine>, Vec<Vec<E::Fr>>) {
       let kzg_compute_batch_polynomial = |f: Vec<Vec<E::Fr>>, q: E::Fr| -> Vec<E::Fr> {
         // Compute B(x) = f_0(x) + q * f_1(x) + ... + q^(k-1) * f_{k-1}(x)
-        let B: UniPoly<E::Fr> = rlc(f.into_iter().map(UniPoly::new), &q);
+        let B: UniPoly<E::Fr> = f.into_iter().map(UniPoly::new).rlc(&q);
         B.coeffs
       };
       ///////// END kzg_open_batch closure helpers

--- a/src/provider/mlkzg.rs
+++ b/src/provider/mlkzg.rs
@@ -8,6 +8,7 @@ use crate::{
     pedersen::Commitment,
     traits::DlogGroup,
   },
+  rlc,
   spartan::polys::univariate::UniPoly,
   traits::{
     commitment::{CommitmentEngineTrait, Len},
@@ -164,30 +165,14 @@ where
         .to_affine()
     };
 
-    let kzg_open_batch = |f: &[Vec<E::Fr>],
+    let kzg_open_batch = |f: Vec<Vec<E::Fr>>,
                           u: &[E::Fr],
                           transcript: &mut <NE as NovaEngine>::TE|
      -> (Vec<E::G1Affine>, Vec<Vec<E::Fr>>) {
-      let scalar_vector_muladd = |a: &mut Vec<E::Fr>, v: &Vec<E::Fr>, s: E::Fr| {
-        assert!(a.len() >= v.len());
-        #[allow(clippy::disallowed_methods)]
-        a.par_iter_mut()
-          .zip(v.par_iter())
-          .for_each(|(c, v)| *c += s * v);
-      };
-
-      let kzg_compute_batch_polynomial = |f: &[Vec<E::Fr>], q: E::Fr| -> Vec<E::Fr> {
-        let k = f.len(); // Number of polynomials we're batching
-
-        let q_powers = Self::batch_challenge_powers(q, k);
-
-        // Compute B(x) = f[0] + q*f[1] + q^2 * f[2] + ... q^(k-1) * f[k-1]
-        let mut B = f[0].clone();
-        for i in 1..k {
-          scalar_vector_muladd(&mut B, &f[i], q_powers[i]); // B += q_powers[i] * f[i]
-        }
-
-        B
+      let kzg_compute_batch_polynomial = |f: Vec<Vec<E::Fr>>, q: E::Fr| -> Vec<E::Fr> {
+        // Compute B(x) = f_0(x) + q * f_1(x) + ... + q^(k-1) * f_{k-1}(x)
+        let B: UniPoly<E::Fr> = rlc(f.into_iter().map(UniPoly::new), &q);
+        B.coeffs
       };
       ///////// END kzg_open_batch closure helpers
 
@@ -199,7 +184,7 @@ where
       let mut v = vec![vec!(E::Fr::ZERO; k); t];
       v.par_iter_mut().enumerate().for_each(|(i, v_i)| {
         // for each point u
-        v_i.par_iter_mut().zip_eq(f).for_each(|(v_ij, f)| {
+        v_i.par_iter_mut().zip_eq(&f).for_each(|(v_ij, f)| {
           // for each poly f (except the last one - since it is constant)
           *v_ij = UniPoly::ref_cast(f).evaluate(&u[i]);
         });
@@ -259,7 +244,7 @@ where
     let u = vec![r, -r, r * r];
 
     // Phase 3 -- create response
-    let (w, evals) = kzg_open_batch(&polys, &u, transcript);
+    let (w, evals) = kzg_open_batch(polys, &u, transcript);
 
     Ok(EvaluationArgument { comms, w, evals })
   }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod traits;
 // a non-hiding variant of {kzg, zeromorph}
 mod kzg_commitment;
 mod non_hiding_kzg;
-mod util;
+pub(crate) mod util;
 
 // crate-private modules
 mod keccak;

--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -11,6 +11,35 @@ pub mod msm {
   }
 }
 
+pub mod iterators {
+  use std::borrow::Borrow;
+  use std::iter::DoubleEndedIterator;
+  use std::ops::{AddAssign, MulAssign};
+
+  pub trait DoubleEndedIteratorExt: DoubleEndedIterator {
+    /// This function employs Horner's scheme and core traits to create a combination of an iterator input with the powers
+    /// of a provided coefficient.
+    fn rlc<T, F>(&mut self, coefficient: &F) -> T
+    where
+      T: Clone + for<'a> MulAssign<&'a F> + for<'r> AddAssign<&'r T>,
+      Self::Item: Borrow<T>,
+    {
+      let mut iter = self.rev();
+      let Some(fst) = iter.next() else {
+        panic!("input iterator should not be empty")
+      };
+
+      iter.fold(fst.borrow().clone(), |mut acc, item| {
+        acc *= coefficient;
+        acc += item.borrow();
+        acc
+      })
+    }
+  }
+
+  impl<I: DoubleEndedIterator> DoubleEndedIteratorExt for I {}
+}
+
 #[cfg(test)]
 pub mod test_utils {
   //! Contains utilities for testing and benchmarking.

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -12,7 +12,7 @@ use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-  rlc,
+  provider::util::iterators::DoubleEndedIteratorExt as _,
   traits::{Group, TranscriptReprTrait},
 };
 
@@ -134,7 +134,7 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
   }
 
   pub fn evaluate(&self, r: &Scalar) -> Scalar {
-    rlc(self.coeffs.iter(), r)
+    self.coeffs.iter().rlc(r)
   }
 
   pub fn compress(&self) -> CompressedUniPoly<Scalar> {

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -11,7 +11,10 @@ use rayon::prelude::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelI
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{Group, TranscriptReprTrait};
+use crate::{
+  rlc,
+  traits::{Group, TranscriptReprTrait},
+};
 
 // ax^2 + bx + c stored as vec![c, b, a]
 // ax^3 + bx^2 + cx + d stored as vec![d, c, b, a]
@@ -131,13 +134,7 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
   }
 
   pub fn evaluate(&self, r: &Scalar) -> Scalar {
-    let mut eval = self.coeffs[0];
-    let mut power = *r;
-    for coeff in self.coeffs.iter().skip(1) {
-      eval += power * coeff;
-      power *= r;
-    }
-    eval
+    rlc(self.coeffs.iter(), r)
   }
 
   pub fn compress(&self) -> CompressedUniPoly<Scalar> {


### PR DESCRIPTION
## Summary

This is mostly implemented as a proof-of-concept to align with @adr1anh on #223. The RLC implements Horner's scheme on any iterator operand with the correct `MulAssign`, `AddAssign` traits.

## Details
- Introduced a new function `rlc`, which implements Horner's scheme,
- Applied traits `Borrow`, `MulAssign`, and `AddAssign` to define it, which exist on `UniPoly`,
- Used `rlc` function in `evaluate` method and `kzg_compute_batch_polynomial`,
- Updated closures in `mlkzg.rs` file to directly handle vector arguments, simplifying the overall operations.
- Streamlined the code by eliminating unnecessary assertions in `kzg_verify_batch` closure and redundant inner function in `kzg_compute_batch_polynomial`.

## Next steps
1. extend the rlc to different parts of the code base, improve ergonomics, etc ... 
    - I'd be happy for pointers!
    - for instance, do we want to extend this to iterated square powers (as we do in ML polys)?
2. implement a really parallelized variant, by generating powers using a parallel prefix scan (which then allows parallelizing the final multiplication, Horner's scheme being inherently sequential).