### PR TITLE
CI : Add issue templates

### DIFF
--- a/.github/templates/UNUSED_DEPS_ISSSUE.md
+++ b/.github/templates/UNUSED_DEPS_ISSSUE.md
@@ -1,0 +1,15 @@
+---
+title: "chore: some installed deps are not needed"
+labels: automated-issue
+---
+
+Some dependencies specified in `Cargo.toml` are not needed.
+
+Check the [unused dependencies sanity check]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow at `https://github.com/lurk-lab/ci-workflows/tree/main/.github/workflows/unused-deps.yml`.
+
+> **Note**
+> If this is a false positive, please refer to the [`cargo-udeps` docs][cargo-udeps-docs] on how to ignore the dependencies.
+
+[cargo-udeps-docs]: https://github.com/est31/cargo-udeps#ignoring-some-of-the-dependencies

--- a/.github/templates/VERSION_CHECK.md
+++ b/.github/templates/VERSION_CHECK.md
@@ -1,0 +1,10 @@
+---
+title: "chore: rust toolchain needs an upgrade"
+labels: debt, automated-issues
+---
+
+The rust version specified in `rust-toolchain.toml` is out of date with the latest stable.
+
+Check the [rust version check]({{env.WORKFLOW_URL}}) workflow for details.
+
+This issue was raised by the workflow at `https://github.com/lurk-lab/ci-workflows/tree/main/.github/workflows/rust-version-check.yml`.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+.github/templates/*


### PR DESCRIPTION
- those support nightly CI workflows: I haven't found a way to make reusable workflow use templates from the workflow definition repo.
- Created a new file `VERSION_CHECK.md` for automated monitoring of Rust's toolchain updates.
- Introduced a new issue template for unused dependencies in `Cargo.toml`.