### PR TITLE
Shorten benchmark names and fix CI

### DIFF
--- a/.github/workflows/gpu-bench.yml
+++ b/.github/workflows/gpu-bench.yml
@@ -86,7 +86,7 @@ jobs:
       # Create a `criterion-table` and write in commit comment
       - name: Run `criterion-table`
         run: |
-          cat supernova-ci-${{ env.BASE_COMMIT }}.json | criterion-table > BENCHMARKS.md
+          cat supernova-ci-${{ env.BASE_COMMIT }}.json supernova-ci-${{ github.sha }}.json | criterion-table > BENCHMARKS.md
       - name: Write bench on commit comment
         uses: peter-evans/commit-comment@v3
         with:

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -15,10 +15,14 @@ impl BenchParams {
     let output_type = output_type_env().unwrap_or("stdout".into());
     match output_type.as_ref() {
       "pr-comment" => BenchmarkId::new(name, format!("StepCircuitSize-{}", self.step_size)),
-      "commit-comment" => BenchmarkId::new(
-        format!("ref={}", self.sha),
-        format!("{}-StepCircuitSize-{}", name, self.step_size),
-      ),
+      "commit-comment" => {
+        let mut short_sha = self.sha.to_owned();
+        short_sha.truncate(7);
+        BenchmarkId::new(
+          format!("ref={}", short_sha),
+          format!("{}-NumCons-{}", name, self.step_size),
+        )
+      }
       // TODO: refine "gh-pages"
       _ => BenchmarkId::new(
         name,

--- a/benches/common/supernova/targets.rs
+++ b/benches/common/supernova/targets.rs
@@ -6,40 +6,20 @@ use crate::common::supernova::{bench::run_bench, SnarkType, S1, S2, SS1, SS2};
 
 // Recursive Supernova SNARK benchmarks
 pub fn bench_one_augmented_circuit_recursive_snark(c: &mut Criterion) {
-  run_bench::<S1, S2>(
-    c,
-    "RecursiveSNARKSuperNova-1circuit",
-    1,
-    SnarkType::Recursive,
-  )
+  run_bench::<S1, S2>(c, "RecursiveSNARK-NIVC-1", 1, SnarkType::Recursive)
 }
 
 pub fn bench_two_augmented_circuit_recursive_snark(c: &mut Criterion) {
-  run_bench::<S1, S2>(
-    c,
-    "RecursiveSNARKSuperNova-2circuit",
-    2,
-    SnarkType::Recursive,
-  )
+  run_bench::<S1, S2>(c, "RecursiveSNARK-NIVC-2", 2, SnarkType::Recursive)
 }
 
 // Compressed Supernova SNARK benchmarks
 pub fn bench_one_augmented_circuit_compressed_snark(c: &mut Criterion) {
-  run_bench::<S1, S2>(
-    c,
-    "CompressedSNARKSuperNova-1circuit",
-    1,
-    SnarkType::Compressed,
-  )
+  run_bench::<S1, S2>(c, "CompressedSNARK-NIVC-1", 1, SnarkType::Compressed)
 }
 
 pub fn bench_two_augmented_circuit_compressed_snark(c: &mut Criterion) {
-  run_bench::<S1, S2>(
-    c,
-    "CompressedSNARKSuperNova-2circuit",
-    2,
-    SnarkType::Compressed,
-  )
+  run_bench::<S1, S2>(c, "CompressedSNARK-NIVC-2", 2, SnarkType::Compressed)
 }
 
 pub fn bench_two_augmented_circuit_compressed_snark_with_computational_commitments(
@@ -47,7 +27,7 @@ pub fn bench_two_augmented_circuit_compressed_snark_with_computational_commitmen
 ) {
   run_bench::<SS1, SS2>(
     c,
-    "CompressedSNARKSuperNova-Commitments-2circuit",
+    "CompressedSNARK-NIVC-Commitments-2",
     2,
     SnarkType::Compressed,
   )


### PR DESCRIPTION
- Shortens Criterion benchmark report names to account for the 100 character limit in https://github.com/bheisler/cargo-criterion/blob/main/src/report.rs#L123. Starts with Supernova benches as the others aren't used in CI
- Fixes a missing input to `criterion-table` in the GPU regression check