### PR TITLE
refactor: Remove clone trait from key and SNARK structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ itertools = "0.12.0"
 rand = "0.8.5"
 ref-cast = "1.0.20"
 derive_more = "0.99.17"
+static_assertions = "1.1.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -41,7 +41,7 @@ use crate::{
 /// A succinct proof of knowledge of a witness to a batch of relaxed R1CS instances
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   sc_proof_outer: SumcheckProof<E>,
@@ -59,7 +59,7 @@ pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the prover's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -69,7 +69,7 @@ pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the verifier's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -623,5 +623,20 @@ where
     )?;
 
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{BatchedRelaxedR1CSSNARK, ProverKey, VerifierKey};
+  use static_assertions::assert_not_impl_any;
+
+  use crate::provider::{ipa_pc::EvaluationEngine, PallasEngine};
+
+  #[test]
+  fn test_keys_and_snarks_should_not_be_cloned() {
+    assert_not_impl_any!(ProverKey<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(VerifierKey<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(BatchedRelaxedR1CSSNARK<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
   }
 }

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -43,7 +43,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A type that represents the prover's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where < E::Scalar as PrimeField >::Repr: Abomonation)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -55,7 +55,7 @@ pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the verifier's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where < E::Scalar as PrimeField >::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -99,7 +99,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   // commitment to oracles: the first three are for Az, Bz, Cz,
@@ -1359,5 +1359,20 @@ where
       .iter()
       .map(|claim| scaling * claim)
       .collect()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{BatchedRelaxedR1CSSNARK, ProverKey, VerifierKey};
+  use static_assertions::assert_not_impl_any;
+
+  use crate::provider::{ipa_pc::EvaluationEngine, PallasEngine};
+
+  #[test]
+  fn test_keys_and_snarks_should_not_be_cloned() {
+    assert_not_impl_any!(ProverKey<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(VerifierKey<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(BatchedRelaxedR1CSSNARK<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
   }
 }

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -26,7 +26,7 @@ pub struct UniPoly<Scalar> {
 
 // ax^2 + bx + c stored as vec![c, a]
 // ax^3 + bx^2 + cx + d stored as vec![d, c, a]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CompressedUniPoly<Scalar> {
   coeffs_except_linear_term: Vec<Scalar>,
 }

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -52,7 +52,7 @@ fn padded<E: Engine>(v: &[E::Scalar], n: usize, e: &E::Scalar) -> Vec<E::Scalar>
 }
 
 /// A type that holds `R1CSShape` in a form amenable to memory checking
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct R1CSShapeSparkRepr<E: Engine> {
@@ -255,7 +255,7 @@ impl<E: Engine> R1CSShapeSparkRepr<E> {
 }
 
 /// A type that represents the prover's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -267,7 +267,7 @@ pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the verifier's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -285,7 +285,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> SimpleDigestible for VerifierKey<E
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   // commitment to oracles: the first three are for Az, Bz, Cz,
@@ -1071,7 +1071,11 @@ where
 }
 #[cfg(test)]
 mod tests {
+  use crate::provider::ipa_pc::EvaluationEngine;
   use crate::provider::PallasEngine;
+
+  use super::{ProverKey, RelaxedR1CSSNARK, VerifierKey};
+  use static_assertions::assert_not_impl_any;
 
   use super::*;
   use ff::Field;
@@ -1089,5 +1093,12 @@ mod tests {
     assert_eq!(result.len(), n);
     assert_eq!(&result[0..10], &v[..]);
     assert!(result[10..].iter().all(|&i| i == e));
+  }
+
+  #[test]
+  fn test_keys_and_snarks_should_not_be_cloned() {
+    assert_not_impl_any!(ProverKey::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(VerifierKey::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(RelaxedR1CSSNARK::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
   }
 }

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -33,7 +33,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A type that represents the prover's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -43,7 +43,7 @@ pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the verifier's key
-#[derive(Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Serialize, Deserialize, Abomonation)]
 #[serde(bound = "")]
 #[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
@@ -83,7 +83,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   sc_proof_outer: SumcheckProof<E>,
@@ -557,4 +557,20 @@ pub(in crate::spartan) fn batch_eval_verify<E: Engine>(
   let u_joint = PolyEvalInstance::batch_diff_size(&comms, evals_batch, &num_rounds, r, gamma);
 
   Ok(u_joint)
+}
+
+#[cfg(test)]
+mod tests {
+
+  use super::{ProverKey, RelaxedR1CSSNARK, VerifierKey};
+  use static_assertions::assert_not_impl_any;
+
+  use crate::provider::{ipa_pc::EvaluationEngine, PallasEngine};
+
+  #[test]
+  fn test_keys_and_snarks_should_not_be_cloned() {
+    assert_not_impl_any!(ProverKey::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(VerifierKey::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+    assert_not_impl_any!(RelaxedR1CSSNARK::<PallasEngine, EvaluationEngine<PallasEngine>>: Clone);
+  }
 }

--- a/src/spartan/sumcheck/mod.rs
+++ b/src/spartan/sumcheck/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 pub(in crate::spartan) mod engine;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub(crate) struct SumcheckProof<E: Engine> {
   compressed_polys: Vec<CompressedUniPoly<E::Scalar>>,


### PR DESCRIPTION
## Summary

We've been a bit loose in allowing macro-derived Clone implementations in spartan SNARK structures. This removes the unused ones, and checks that we won't re-introduce these Clone implementations in the future for structs where this will not make sense (`ProverKey`, `VerifierKey`, `SNARK`).

- After https://github.com/lurk-lab/lurk-rs/pull/1064

## Details
- Removed `Clone` trait from various structs across multiple files, including `ProverKey`, `VerifierKey`, and multiple versions of `RelaxedR1CSSNARK` and `BatchedRelaxedR1CSSNARK`, among others.
- Instituted tests to confirm that the `Clone` trait is **not** implemented for previously mentioned structs where Clone will not make sense.
- Added a new `static_assertions` dependency to the project configuration file, Cargo.toml.