### PR TITLE
ci: Disable debug info for GPU tests

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: CUDA tests
         run: |
-          cargo nextest run --profile ci --cargo-profile dev-ci --features cuda
+          cargo nextest run --profile ci --release --features cuda,asm


### PR DESCRIPTION
- Fixes a timeout issue due to the inclusion of `debuginfo`, which is solved by using the `release` Cargo profile instead of `dev-ci`
- Activates the `asm` feature to improve performance of Bn256 tests

Successful run: https://github.com/lurk-lab/arecibo/actions/runs/7575501849/job/20632243364?pr=271