### PR TITLE
chore: Upgrade rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.73"
+channel = "1.75"
 targets = [ "wasm32-unknown-unknown" ]
 

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -327,6 +327,7 @@ where
       ),
       (proof.proof, verifier_param.beta_h.into()),
     ];
+    #[allow(clippy::map_identity)] // this does by_ref() on a tuple
     let pairing_input_refs = pairing_inputs
       .iter()
       .map(|(a, b)| (a, b))


### PR DESCRIPTION
- Added `#[allow(clippy::map_identity)]` clause to the `verify` function in `src/provider/non_hiding_kzg.rs` to avoid Clippy's interference
- Upgraded the Rust toolchain to version `1.75` in `rust-toolchain.toml`.
- Closes #266