### PR TITLE
Enable `grumpkin-msm` CUDA feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ abomonate = []
 asm = ["halo2curves/asm"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["grumpkin-msm/portable"]
-cuda = []
+cuda = ["grumpkin-msm/cuda"]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ abomonate = []
 asm = ["halo2curves/asm"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["grumpkin-msm/portable"]
-cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
+cuda = []
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
 
 # This is needed to ensure halo2curves, which imports pasta-curves, uses the *same* traits in bn256_grumpkin


### PR DESCRIPTION
Adapts to https://github.com/lurk-lab/grumpkin-msm/pull/9, enabling GPU acceleration when the `cuda` feature is enabled