### PR TITLE
refactor: avoid superfluous clones in `ProverKey` and `VerifierKey` for Nova & SuperNova

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ generic-array = "1.0.0"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 bincode = "1.3"
 bitvec = "1.0"
 byteorder = "1.4.3"

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -1,5 +1,5 @@
 //! Non-hiding variant of KZG10 scheme for univariate polynomials.
-use crate::zip_with_for_each;
+use crate::{digest::SimpleDigestible, zip_with_for_each};
 use abomonation_derive::Abomonation;
 use ff::{Field, PrimeField, PrimeFieldBits};
 use group::{prime::PrimeCurveAffine, Curve, Group as _};
@@ -8,7 +8,7 @@ use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
 use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use std::{borrow::Borrow, marker::PhantomData, ops::Mul};
+use std::{borrow::Borrow, marker::PhantomData, ops::Mul, sync::Arc};
 
 use crate::{
   errors::{NovaError, PCSError},
@@ -49,36 +49,59 @@ impl<E: Engine> Len for UniversalKZGParam<E> {
 }
 
 /// `UnivariateProverKey` is used to generate a proof
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Abomonation)]
-#[abomonation_omit_bounds]
-#[serde(bound(
-  serialize = "E::G1Affine: Serialize",
-  deserialize = "E::G1Affine: Deserialize<'de>"
-))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KZGProverKey<E: Engine> {
-  /// generators
-  #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
-  pub powers_of_g: Vec<E::G1Affine>,
+  /// generators from the universal parameters
+  uv_params: Arc<UniversalKZGParam<E>>,
+  /// offset at which we start reading into the SRS
+  offset: usize,
+  /// maximum supported size
+  supported_size: usize,
+}
+
+impl<E: Engine> KZGProverKey<E> {
+  pub(in crate::provider) fn new(
+    uv_params: Arc<UniversalKZGParam<E>>,
+    offset: usize,
+    supported_size: usize,
+  ) -> Self {
+    assert!(
+      uv_params.max_degree() >= offset + supported_size,
+      "not enough bases (req: {} from offset {}) in the UVKZGParams (length: {})",
+      supported_size,
+      offset,
+      uv_params.max_degree()
+    );
+    Self {
+      uv_params,
+      offset,
+      supported_size,
+    }
+  }
+
+  pub fn powers_of_g(&self) -> &[E::G1Affine] {
+    &self.uv_params.powers_of_g[self.offset..self.offset + self.supported_size]
+  }
 }
 
 /// `UVKZGVerifierKey` is used to check evaluation proofs for a given
 /// commitment.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Abomonation)]
-#[abomonation_omit_bounds]
-#[serde(bound(
-  serialize = "E::G1Affine: Serialize, E::G2Affine: Serialize",
-  deserialize = "E::G1Affine: Deserialize<'de>, E::G2Affine: Deserialize<'de>"
-))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(bound(serialize = "E::G1Affine: Serialize, E::G2Affine: Serialize",))]
 pub struct KZGVerifierKey<E: Engine> {
   /// The generator of G1.
-  #[abomonate_with([u64; 8])] // this is a hack; we just assume the size of the element.
   pub g: E::G1Affine,
   /// The generator of G2.
-  #[abomonate_with([u64; 16])] // this is a hack; we just assume the size of the element.
   pub h: E::G2Affine,
   /// β times the above generator of G2.
-  #[abomonate_with([u64; 16])] // this is a hack; we just assume the size of the element.
   pub beta_h: E::G2Affine,
+}
+
+impl<E: Engine> SimpleDigestible for KZGVerifierKey<E>
+where
+  E::G1Affine: Serialize,
+  E::G2Affine: Serialize,
+{
 }
 
 impl<E: Engine> UniversalKZGParam<E> {
@@ -86,50 +109,26 @@ impl<E: Engine> UniversalKZGParam<E> {
   pub fn max_degree(&self) -> usize {
     self.powers_of_g.len()
   }
+}
 
-  /// Returns the prover parameters
-  ///
-  /// # Panics
-  /// if `supported_size` is greater than `self.max_degree()`
-  pub fn extract_prover_key(&self, supported_size: usize) -> KZGProverKey<E> {
-    let powers_of_g = self.powers_of_g[..=supported_size].to_vec();
-    KZGProverKey { powers_of_g }
-  }
-
-  /// Returns the verifier parameters
-  ///
-  /// # Panics
-  /// If self.prover_params is empty.
-  pub fn extract_verifier_key(&self, supported_size: usize) -> KZGVerifierKey<E> {
-    assert!(
-      self.powers_of_g.len() >= supported_size,
-      "supported_size is greater than self.max_degree()"
-    );
-    KZGVerifierKey {
-      g: self.powers_of_g[0],
-      h: self.powers_of_h[0],
-      beta_h: self.powers_of_h[1],
-    }
-  }
-
-  /// Trim the universal parameters to specialize the public parameters
-  /// for univariate polynomials to the given `supported_size`, and
-  /// returns prover key and verifier key. `supported_size` should
-  /// be in range `1..params.len()`
-  ///
-  /// # Panics
-  /// If `supported_size` is greater than `self.max_degree()`, or `self.max_degree()` is zero.
-  pub fn trim(&self, supported_size: usize) -> (KZGProverKey<E>, KZGVerifierKey<E>) {
-    let powers_of_g = self.powers_of_g[..=supported_size].to_vec();
-
-    let pk = KZGProverKey { powers_of_g };
-    let vk = KZGVerifierKey {
-      g: self.powers_of_g[0],
-      h: self.powers_of_h[0],
-      beta_h: self.powers_of_h[1],
-    };
-    (pk, vk)
-  }
+/// Trim the universal parameters to specialize the public parameters
+/// for univariate polynomials to the given `supported_size`, and
+/// returns prover key and verifier key. `supported_size` should
+/// be in range `1..params.len()`
+///
+/// # Panics
+/// If `supported_size` is greater than `self.max_degree()`, or `self.max_degree()` is zero.
+pub fn trim<E: Engine>(
+  ukzg: Arc<UniversalKZGParam<E>>,
+  supported_size: usize,
+) -> (KZGProverKey<E>, KZGVerifierKey<E>) {
+  assert!(ukzg.max_degree() > 0, "max_degree is zero");
+  let g = ukzg.powers_of_g[0];
+  let h = ukzg.powers_of_h[0];
+  let beta_h = ukzg.powers_of_h[1];
+  let pk = KZGProverKey::new(ukzg, 0, supported_size + 1);
+  let vk = KZGVerifierKey { g, h, beta_h };
+  (pk, vk)
 }
 
 impl<E: Engine> UniversalKZGParam<E>
@@ -246,12 +245,12 @@ where
   ) -> Result<UVKZGCommitment<E>, NovaError> {
     let prover_param = prover_param.borrow();
 
-    if poly.degree() > prover_param.powers_of_g.len() {
+    if poly.degree() > prover_param.powers_of_g().len() {
       return Err(NovaError::PCSError(PCSError::LengthError));
     }
 
     let scalars = poly.coeffs.as_slice();
-    let bases = prover_param.powers_of_g.as_slice();
+    let bases = prover_param.powers_of_g();
 
     // We can avoid some scalar multiplications if 'scalars' contains a lot of leading zeroes using
     // offset, that points where non-zero scalars start.
@@ -271,12 +270,12 @@ where
   ) -> Result<UVKZGCommitment<E>, NovaError> {
     let prover_param = prover_param.borrow();
 
-    if poly.degree() > prover_param.powers_of_g.len() {
+    if poly.degree() > prover_param.powers_of_g().len() {
       return Err(NovaError::PCSError(PCSError::LengthError));
     }
     let C = <E::G1 as DlogGroup>::vartime_multiscalar_mul(
       poly.coeffs.as_slice(),
-      &prover_param.powers_of_g.as_slice()[..poly.coeffs.len()],
+      &prover_param.powers_of_g()[..poly.coeffs.len()],
     );
     Ok(UVKZGCommitment(C.to_affine()))
   }
@@ -312,7 +311,7 @@ where
       .ok_or(NovaError::PCSError(PCSError::ZMError))?;
     let proof = <E::G1 as DlogGroup>::vartime_multiscalar_mul(
       witness_polynomial.coeffs.as_slice(),
-      &prover_param.powers_of_g.as_slice()[..witness_polynomial.coeffs.len()],
+      &prover_param.powers_of_g()[..witness_polynomial.coeffs.len()],
     );
     let evaluation = UVKZGEvaluation(polynomial.evaluate(point));
 
@@ -456,8 +455,10 @@ mod tests {
       let mut rng = &mut thread_rng();
       let degree = rng.gen_range(2..20);
 
-      let pp = UniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, degree);
-      let (ck, vk) = pp.trim(degree);
+      let pp = Arc::new(UniversalKZGParam::<E>::gen_srs_for_testing(
+        &mut rng, degree,
+      ));
+      let (ck, vk) = trim(pp, degree);
       let p = random(degree, rng);
       let comm = UVKZGPCS::<E>::commit(&ck, &p)?;
       let point = E::Fr::random(rng);
@@ -488,8 +489,10 @@ mod tests {
 
       let degree = rng.gen_range(2..20);
 
-      let pp = UniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, degree);
-      let (ck, vk) = pp.trim(degree);
+      let pp = Arc::new(UniversalKZGParam::<E>::gen_srs_for_testing(
+        &mut rng, degree,
+      ));
+      let (ck, vk) = trim(pp, degree);
 
       let mut comms = Vec::new();
       let mut values = Vec::new();

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::{
+  digest::SimpleDigestible,
   errors::{NovaError, PCSError},
   provider::{
     non_hiding_kzg::{
@@ -18,7 +19,6 @@ use crate::{
   },
   Commitment,
 };
-use abomonation_derive::Abomonation;
 use ff::{BatchInvert, Field, PrimeField, PrimeFieldBits};
 use group::{Curve, Group as _};
 use itertools::Itertools as _;
@@ -29,17 +29,13 @@ use rayon::{
 };
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::{borrow::Borrow, iter, marker::PhantomData};
 
 use crate::provider::kzg_commitment::KZGCommitmentEngine;
 
 /// `ZMProverKey` is used to generate a proof
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Abomonation)]
-#[abomonation_omit_bounds]
-#[serde(bound(
-  serialize = "E::G1Affine: Serialize",
-  deserialize = "E::G1Affine: Deserialize<'de>"
-))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ZMProverKey<E: Engine> {
   commit_pp: KZGProverKey<E>,
   open_pp: KZGProverKey<E>,
@@ -47,16 +43,18 @@ pub struct ZMProverKey<E: Engine> {
 
 /// `ZMVerifierKey` is used to check evaluation proofs for a given
 /// commitment.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Abomonation)]
-#[abomonation_omit_bounds]
-#[serde(bound(
-  serialize = "E::G1Affine: Serialize, E::G2Affine: Serialize",
-  deserialize = "E::G1Affine: Deserialize<'de>, E::G2Affine: Deserialize<'de>"
-))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(bound(serialize = "E::G1Affine: Serialize, E::G2Affine: Serialize",))]
 pub struct ZMVerifierKey<E: Engine> {
   vp: KZGVerifierKey<E>,
-  #[abomonate_with([u64; 16])] // this is a hack; we just assume the size of the element.
   s_offset_h: E::G2Affine,
+}
+
+impl<E: Engine> SimpleDigestible for ZMVerifierKey<E>
+where
+  E::G1Affine: Serialize,
+  E::G2Affine: Serialize,
+{
 }
 
 /// Trim the universal parameters to specialize the public parameters
@@ -65,23 +63,18 @@ pub struct ZMVerifierKey<E: Engine> {
 /// be in range `1..params.len()`
 ///
 /// # Panics
-/// If `supported_size` is greater than `self.max_degree()`, or `self.max_degree()` is zero.
+/// If `params.max_degree() < 2 * max_degree + 1`
 //
 // TODO: important, we need a better way to handle that the commitment key should be 2^max_degree sized,
 // see the runtime error in commit() below
-fn trim<E: Engine>(
-  params: &UniversalKZGParam<E>,
+fn trim_zeromorph<E: Engine>(
+  params: Arc<UniversalKZGParam<E>>,
   max_degree: usize,
 ) -> (ZMProverKey<E>, ZMVerifierKey<E>) {
-  let (commit_pp, vp) = params.trim(max_degree);
-  let offset = params.powers_of_g.len() - max_degree;
-  let open_pp = {
-    let offset_powers_of_g1 = params.powers_of_g[offset..].to_vec();
-    KZGProverKey {
-      powers_of_g: offset_powers_of_g1,
-    }
-  };
+  let (commit_pp, vp) = crate::provider::non_hiding_kzg::trim(params.clone(), max_degree);
+  let offset = params.max_degree() - max_degree;
   let s_offset_h = params.powers_of_h[offset];
+  let open_pp = KZGProverKey::new(params, offset, max_degree);
 
   (
     ZMProverKey { commit_pp, open_pp },
@@ -160,7 +153,7 @@ where
     poly: &MultilinearPolynomial<E::Fr>,
   ) -> Result<ZMCommitment<E>, NovaError> {
     let pp = pp.borrow();
-    if pp.commit_pp.powers_of_g.len() < poly.Z.len() {
+    if pp.commit_pp.powers_of_g().len() < poly.Z.len() {
       return Err(PCSError::LengthError.into());
     }
     UVKZGPCS::commit(&pp.commit_pp, UVKZGPoly::ref_cast(&poly.Z)).map(|c| c.into())
@@ -179,7 +172,7 @@ where
     transcript.dom_sep(Self::protocol_name());
 
     let pp = pp.borrow();
-    if pp.commit_pp.powers_of_g.len() < poly.Z.len() {
+    if pp.commit_pp.powers_of_g().len() < poly.Z.len() {
       return Err(NovaError::PCSError(PCSError::LengthError));
     }
 
@@ -475,8 +468,9 @@ where
 
   type EvaluationArgument = ZMProof<E>;
 
-  fn setup(ck: &UniversalKZGParam<E>) -> (Self::ProverKey, Self::VerifierKey) {
-    trim(ck, ck.length() - 1)
+  fn setup(ck: Arc<UniversalKZGParam<E>>) -> (Self::ProverKey, Self::VerifierKey) {
+    let len = ck.length() - 1;
+    trim_zeromorph(ck, len)
   }
 
   fn prove(
@@ -515,9 +509,6 @@ where
 
 #[cfg(test)]
 mod test {
-  use std::borrow::Borrow;
-  use std::iter;
-
   use ff::{Field, PrimeField, PrimeFieldBits};
   use group::Curve;
   use halo2curves::bn256::Bn256;
@@ -527,16 +518,22 @@ mod test {
   use rand::thread_rng;
   use rand_chacha::ChaCha20Rng;
   use rand_core::SeedableRng;
+  use std::borrow::Borrow;
+  use std::iter;
+  use std::sync::Arc;
 
   use super::quotients;
+  use super::trim_zeromorph;
 
   use crate::{
     errors::PCSError,
     provider::{
       keccak::Keccak256Transcript,
-      non_hiding_kzg::{KZGProverKey, UVKZGCommitment, UVKZGPoly, UniversalKZGParam, UVKZGPCS},
+      non_hiding_kzg::{
+        trim, KZGProverKey, UVKZGCommitment, UVKZGPoly, UniversalKZGParam, UVKZGPCS,
+      },
       non_hiding_zeromorph::{
-        batched_lifted_degree_quotient, eval_and_quotient_scalars, trim, ZMEvaluation, ZMPCS,
+        batched_lifted_degree_quotient, eval_and_quotient_scalars, ZMEvaluation, ZMPCS,
       },
       traits::DlogGroup,
       util::test_utils::prove_verify_from_num_vars,
@@ -556,14 +553,17 @@ mod test {
     let max_vars = 16;
     let mut rng = thread_rng();
     let max_poly_size = 1 << (max_vars + 1);
-    let universal_setup = UniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, max_poly_size);
+    let universal_setup = Arc::new(UniversalKZGParam::<E>::gen_srs_for_testing(
+      &mut rng,
+      max_poly_size,
+    ));
 
     for num_vars in 3..max_vars {
       // Setup
       let (pp, vk) = {
         let poly_size = 1 << (num_vars + 1);
 
-        trim(&universal_setup, poly_size)
+        trim_zeromorph(universal_setup.clone(), poly_size)
       };
 
       // Commit and open
@@ -830,12 +830,12 @@ mod test {
   {
     let prover_param = prover_param.borrow();
 
-    if poly.degree() > prover_param.powers_of_g.len() {
+    if poly.degree() > prover_param.powers_of_g().len() {
       return Err(NovaError::PCSError(PCSError::LengthError));
     }
 
     // We use following filter to optimise MSM for cases where scalars contain a lot of zeroes
-    let initial_bases = &prover_param.powers_of_g.as_slice()[..poly.coeffs.len()].to_vec();
+    let initial_bases = &prover_param.powers_of_g()[..poly.coeffs.len()].to_vec();
     let mut scalars = vec![];
     let mut bases = vec![];
     for (index, scalar) in poly.coeffs.iter().enumerate() {
@@ -875,8 +875,10 @@ mod test {
 
     let (q_hat, offset) = batched_lifted_degree_quotient(E::Fr::random(&mut rng), &quotients_polys);
 
-    let pp = UniversalKZGParam::<E>::gen_srs_for_testing(&mut rng, degree);
-    let (ck, _vk) = pp.trim(degree);
+    let pp = Arc::new(UniversalKZGParam::<E>::gen_srs_for_testing(
+      &mut rng, degree,
+    ));
+    let (ck, _vk) = trim(pp, degree);
 
     let commitment_expected = UVKZGPCS::commit(&ck, &q_hat)?;
     let commitment_actual_1 = commit_filtered(&ck, &q_hat)?;

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -6,7 +6,6 @@
 use ff::Field;
 use serde::{Deserialize, Serialize};
 
-use abomonation::Abomonation;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
@@ -103,8 +102,6 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
   for BatchedRelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as ff::PrimeField>::Repr: Abomonation,
 {
   type ProverKey = ProverKey<E, EE>;
 

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -35,34 +35,29 @@ use crate::{
   zip_with, zip_with_for_each, Commitment, CommitmentKey, CompressedCommitment,
 };
 use abomonation::Abomonation;
-use abomonation_derive::Abomonation;
 use ff::{Field, PrimeField};
 use itertools::{chain, Itertools as _};
 use once_cell::sync::*;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// A type that represents the prover's key
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
-#[serde(bound = "")]
-#[abomonation_bounds(where < E::Scalar as PrimeField >::Repr: Abomonation)]
+#[derive(Debug, Clone)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   pk_ee: EE::ProverKey,
   S_repr: Vec<R1CSShapeSparkRepr<E>>,
   S_comm: Vec<R1CSShapeSparkCommitment<E>>,
-  #[abomonate_with(<E::Scalar as PrimeField >::Repr)]
   vk_digest: E::Scalar, // digest of verifier's key
 }
 
 /// A type that represents the verifier's key
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(bound = "")]
-#[abomonation_bounds(where < E::Scalar as PrimeField >::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   vk_ee: EE::VerifierKey,
   S_comm: Vec<R1CSShapeSparkCommitment<E>>,
   num_vars: Vec<usize>,
-  #[abomonation_skip]
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<E::Scalar>,
 }
@@ -80,6 +75,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> VerifierKey<E, EE> {
     }
   }
 }
+
 impl<E: Engine, EE: EvaluationEngineTrait<E>> SimpleDigestible for VerifierKey<E, EE> {}
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierKey<E, EE> {
@@ -147,7 +143,7 @@ where
   }
 
   fn setup(
-    ck: &CommitmentKey<E>,
+    ck: Arc<CommitmentKey<E>>,
     S: Vec<&R1CSShape<E>>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     for s in S.iter() {
@@ -157,13 +153,13 @@ where
         return Err(NovaError::InternalError);
       }
     }
-    let (pk_ee, vk_ee) = EE::setup(ck);
+    let (pk_ee, vk_ee) = EE::setup(ck.clone());
 
     let S = S.iter().map(|s| s.pad()).collect::<Vec<_>>();
     let S_repr = S.iter().map(R1CSShapeSparkRepr::new).collect::<Vec<_>>();
     let S_comm = S_repr
       .iter()
-      .map(|s_repr| s_repr.commit(ck))
+      .map(|s_repr| s_repr.commit(&*ck))
       .collect::<Vec<_>>();
     let num_vars = S.iter().map(|s| s.num_vars).collect::<Vec<_>>();
     let vk = VerifierKey::new(num_vars, S_comm.clone(), vk_ee);

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -34,8 +34,7 @@ use crate::{
   },
   zip_with, zip_with_for_each, Commitment, CommitmentKey, CompressedCommitment,
 };
-use abomonation::Abomonation;
-use ff::{Field, PrimeField};
+use ff::Field;
 use itertools::{chain, Itertools as _};
 use once_cell::sync::*;
 use rayon::prelude::*;
@@ -126,8 +125,6 @@ pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
   for BatchedRelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as PrimeField>::Repr: Abomonation,
 {
   type ProverKey = ProverKey<E, EE>;
   type VerifierKey = VerifierKey<E, EE>;
@@ -1088,10 +1085,7 @@ where
   }
 }
 
-impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as PrimeField>::Repr: Abomonation,
-{
+impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARK<E, EE> {
   /// Runs the batched Sumcheck protocol for the claims of multiple instance of possibly different sizes.
   ///
   /// # Details

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -325,8 +325,7 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE>
-{
+impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
   fn prove_helper<T1, T2, T3, T4>(
     mem: &mut T1,
     outer: &mut T2,
@@ -465,8 +464,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
   }
 }
 
-impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for RelaxedR1CSSNARK<E, EE>
-{
+impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for RelaxedR1CSSNARK<E, EE> {
   type ProverKey = ProverKey<E, EE>;
   type VerifierKey = VerifierKey<E, EE>;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -34,10 +34,8 @@ use crate::{
   },
   zip_with, Commitment, CommitmentKey, CompressedCommitment,
 };
-use abomonation::Abomonation;
-use abomonation_derive::Abomonation;
 use core::cmp::max;
-use ff::{Field, PrimeField};
+use ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
@@ -53,35 +51,26 @@ fn padded<E: Engine>(v: &[E::Scalar], n: usize, e: &E::Scalar) -> Vec<E::Scalar>
 }
 
 /// A type that holds `R1CSShape` in a form amenable to memory checking
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-#[abomonation_bounds(where <E::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct R1CSShapeSparkRepr<E: Engine> {
   pub(in crate::spartan) N: usize, // size of the vectors
 
   // dense representation
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) row: Vec<E::Scalar>,
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) col: Vec<E::Scalar>,
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) val_A: Vec<E::Scalar>,
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) val_B: Vec<E::Scalar>,
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) val_C: Vec<E::Scalar>,
 
   // timestamp polynomials
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) ts_row: Vec<E::Scalar>,
-  #[abomonate_with(Vec<<E::Scalar as PrimeField>::Repr>)]
   pub(in crate::spartan) ts_col: Vec<E::Scalar>,
 }
 
 /// A type that holds a commitment to a sparse polynomial
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-#[abomonation_bounds(where <E::Scalar as PrimeField>::Repr: Abomonation)]
 pub struct R1CSShapeSparkCommitment<E: Engine> {
   pub(in crate::spartan) N: usize, // size of each vector
 
@@ -337,8 +326,6 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as PrimeField>::Repr: Abomonation,
 {
   fn prove_helper<T1, T2, T3, T4>(
     mem: &mut T1,
@@ -479,8 +466,6 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 }
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for RelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as PrimeField>::Repr: Abomonation,
 {
   type ProverKey = ProverKey<E, EE>;
   type VerifierKey = VerifierKey<E, EE>;

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -24,32 +24,26 @@ use crate::{
 };
 
 use abomonation::Abomonation;
-use abomonation_derive::Abomonation;
 use ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
-
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// A type that represents the prover's key
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
-#[serde(bound = "")]
-#[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
+#[derive(Debug, Clone)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   pk_ee: EE::ProverKey,
-  #[abomonate_with(<E::Scalar as ff::PrimeField>::Repr)]
   vk_digest: E::Scalar, // digest of the verifier's key
 }
 
 /// A type that represents the verifier's key
-#[derive(Debug, Clone, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(bound = "")]
-#[abomonation_bounds(where <E::Scalar as ff::PrimeField>::Repr: Abomonation)]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   vk_ee: EE::VerifierKey,
   S: R1CSShape<E>,
-  #[abomonation_skip]
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<E::Scalar>,
 }
@@ -104,7 +98,7 @@ where
   type VerifierKey = VerifierKey<E, EE>;
 
   fn setup(
-    ck: &CommitmentKey<E>,
+    ck: Arc<CommitmentKey<E>>,
     S: &R1CSShape<E>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     let (pk_ee, vk_ee) = EE::setup(ck);

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -23,7 +23,6 @@ use crate::{
   CommitmentKey,
 };
 
-use abomonation::Abomonation;
 use ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
@@ -90,10 +89,7 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for RelaxedR1CSSNARK<E, EE>
-where
-  <E::Scalar as ff::PrimeField>::Repr: Abomonation,
-{
+impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for RelaxedR1CSSNARK<E, EE> {
   type ProverKey = ProverKey<E, EE>;
   type VerifierKey = VerifierKey<E, EE>;
 

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -11,6 +11,7 @@ use crate::supernova::circuit::{
 };
 use crate::traits::snark::default_ck_hint;
 use crate::{bellpepper::test_shape_cs::TestShapeCS, gadgets::utils::alloc_one};
+use abomonation::Abomonation;
 use bellpepper_core::num::AllocatedNum;
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -6,8 +6,8 @@ use crate::{
   CommitmentKey,
 };
 
-use abomonation::Abomonation;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// Public parameter creation takes a size hint. This size hint carries the particular requirements of
 /// the final compressing SNARK the user expected to use with these public parameters, and the below
@@ -23,15 +23,10 @@ pub trait RelaxedR1CSSNARKTrait<E: Engine>:
   Send + Sync + Serialize + for<'de> Deserialize<'de>
 {
   /// A type that represents the prover's key
-  type ProverKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
+  type ProverKey: Send + Sync;
 
   /// A type that represents the verifier's key
-  type VerifierKey: Send
-    + Sync
-    + Serialize
-    + for<'de> Deserialize<'de>
-    + DigestHelperTrait<E>
-    + Abomonation;
+  type VerifierKey: Send + Sync + Serialize;
 
   /// This associated function (not a method) provides a hint that offers
   /// a minimum sizing cue for the commitment key used by this SNARK
@@ -44,7 +39,7 @@ pub trait RelaxedR1CSSNARKTrait<E: Engine>:
 
   /// Produces the keys for the prover and the verifier
   fn setup(
-    ck: &CommitmentKey<E>,
+    ck: Arc<CommitmentKey<E>>,
     S: &R1CSShape<E>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError>;
 
@@ -66,15 +61,10 @@ pub trait BatchedRelaxedR1CSSNARKTrait<E: Engine>:
   Send + Sync + Serialize + for<'de> Deserialize<'de>
 {
   /// A type that represents the prover's key
-  type ProverKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + Abomonation;
+  type ProverKey: Send + Sync;
 
   /// A type that represents the verifier's key
-  type VerifierKey: Send
-    + Sync
-    + Serialize
-    + for<'de> Deserialize<'de>
-    + DigestHelperTrait<E>
-    + Abomonation;
+  type VerifierKey: Send + Sync + DigestHelperTrait<E>;
 
   /// This associated function (not a method) provides a hint that offers
   /// a minimum sizing cue for the commitment key used by this SNARK
@@ -85,8 +75,11 @@ pub trait BatchedRelaxedR1CSSNARKTrait<E: Engine>:
   }
 
   /// Produces the keys for the prover and the verifier
+  ///
+  /// **Note:** This method should be cheap and should not copy most of the
+  /// commitment key. Look at CommitmentEngineTrait::setup for generating SRS data.
   fn setup(
-    ck: &CommitmentKey<E>,
+    ck: Arc<CommitmentKey<E>>,
     S: Vec<&R1CSShape<E>>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError>;
 


### PR DESCRIPTION
This PR removes extra copies of the `CommitmentKey` in the `ProverKey` and `VerifierKey`.

Using the results of this PR, we hope to remove the ProverKey and VerifierKey in Lurk's PublicParams, leaving only the nova::PublicParams field there, from which it's cheap to derive the removed fields as needed,

## In Detail

This notices that it is fundamentally cheap to derive prover and verifier key from a set of universal public parameters (in nova parlance, the `CommitmentKey`), and takes that into motion:
- the setup functions for instances of `EvaluationEgine` are deterministic and near-free,
- by composition, so is the setup of `CompressedSNARK`,
- those functions do not need to allocate a significant amount of data,
- we consequently drop the `Serialize`, `Deserialize` and `Abomonate` bounds on all `ProverKey`s,
- we consequently drop the `Deserialize` and `Abomonate` bounds on all `VerifierKey`s,
- the `Serialize` bound on the `VerifierKey` is momentarily kept in order to compute its `Digestible` instance using `SimpleDigestible` (it's not essential to keep, but a bit involved for this short PR)

## In More Detail: repairing the `Abomonate` functionality

This introduces `Arc` inside the fields of the `PublicParams` data structures, which is at odds with `Abomonate`-ing them in the course of a proof. Since it is highly non trivial (if at all possible) to `Abomonate` something under an `Arc`, we bypass the problem in the following way:

- we implement `FlatPublicParams`, a facade with no `Arc`, which we know how to `Abomonate`
- `TryFrom<PublicParams> for FlatPublicParams` and
- `From<FlatPublicParams> for <PublicParams>`,

The `TryFrom<PublicParams> for FlatPublicParams` relies on `Arc::try_unwrap` for each of the two problematic fields, and the only thing we'd have to take care of at runtime is that we haven't left a trailing `ProverKey` or `VerifierKey` in scope before doing the conversion.

Then instead of trying to have `Abomonate` on the `PublicParams`, what the caching logic does is `FlatPublicParams::try_from(nova_public_params)?.encode()` and `PublicParams::from(decode::<FlatPublicParams>(bytes).clone())`. We demonstrate that in the minroot example.

> [!NOTE]
> Lurk is not expected to compile on top of this. Companion PR at https://github.com/lurk-lab/lurk-rs/pull/1085