### PR TITLE
Remove superfluous instances of derive(Clone) (easy)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use thiserror::Error;
 
 /// Errors returned by Nova
-#[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[derive(Debug, Eq, PartialEq, Error)]
 #[non_exhaustive]
 pub enum NovaError {
   /// returned if the supplied row or col in (row,col,val) tuple is out of range
@@ -72,7 +72,7 @@ pub enum NovaError {
 }
 
 /// Errors specific to the Polynomial commitment scheme
-#[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[derive(Debug, Eq, PartialEq, Error)]
 pub enum PCSError {
   /// returned when an invalid inner product argument is provided
   #[error("InvalidIPA")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,7 +818,7 @@ where
 }
 
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct CompressedSNARK<E1, E2, C1, C2, S1, S2>
 where

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 /// A SNARK that holds the proof of a step of an incremental computation
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct NIFS<E: Engine> {
   pub(crate) comm_T: CompressedCommitment<E>,

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -14,7 +14,7 @@ const KECCAK256_PREFIX_CHALLENGE_LO: u8 = 0;
 const KECCAK256_PREFIX_CHALLENGE_HI: u8 = 1;
 
 /// Provides an implementation of `TranscriptEngine`
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Keccak256Transcript<E: Engine> {
   round: u16,
   state: [u8; KECCAK256_STATE_SIZE],

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -210,10 +210,10 @@ where
 }
 
 /// Polynomial Evaluation
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default)]
 pub struct UVKZGEvaluation<E: Engine>(pub E::Fr);
 
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default)]
 
 /// Proofs
 pub struct UVKZGProof<E: Engine> {
@@ -224,7 +224,7 @@ pub struct UVKZGProof<E: Engine> {
 /// Polynomial and its associated types
 pub type UVKZGPoly<F> = crate::spartan::polys::univariate::UniPoly<F>;
 
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default)]
 /// KZG Polynomial Commitment Scheme on univariate polynomial.
 /// Note: this is non-hiding, which is why we will implement traits on this token struct,
 /// as we expect to have several impls for the trait pegged on the same instance of a pairing::Engine.

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -40,7 +40,7 @@ use crate::{
 /// A succinct proof of knowledge of a witness to a batch of relaxed R1CS instances
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   sc_proof_outer: SumcheckProof<E>,
@@ -58,14 +58,14 @@ pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the prover's key
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   pk_ee: EE::ProverKey,
   vk_digest: E::Scalar, // digest of the verifier's key
 }
 
 /// A type that represents the verifier's key
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(bound = "")]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   vk_ee: EE::VerifierKey,

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A type that represents the prover's key
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   pk_ee: EE::ProverKey,
   S_repr: Vec<R1CSShapeSparkRepr<E>>,
@@ -51,7 +51,7 @@ pub struct ProverKey<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 /// A type that represents the verifier's key
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(bound = "")]
 pub struct VerifierKey<E: Engine, EE: EvaluationEngineTrait<E>> {
   vk_ee: EE::VerifierKey,
@@ -94,7 +94,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   // commitment to oracles: the first three are for Az, Bz, Cz,

--- a/src/supernova/error.rs
+++ b/src/supernova/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::errors::NovaError;
 
 /// Errors returned by Nova
-#[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[derive(Debug, Eq, PartialEq, Error)]
 pub enum SuperNovaError {
   /// Nova error
   #[error("NovaError")]

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -51,7 +51,7 @@ use circuit::{
 use error::SuperNovaError;
 
 /// A struct that manages all the digests of the primary circuits of a SuperNova instance
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CircuitDigests<E: Engine> {
   digests: Vec<E::Scalar>,
 }
@@ -80,7 +80,7 @@ impl<E: Engine> CircuitDigests<E> {
 }
 
 /// A vector of [R1CSWithArity] adjoined to a set of [PublicParams]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct PublicParams<E1, E2, C1, C2>
 where

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 /// A type that holds the prover key for `CompressedSNARK`
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProverKey<E1, E2, C1, C2, S1, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -33,7 +33,7 @@ where
 }
 
 /// A type that holds the verifier key for `CompressedSNARK`
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct VerifierKey<E1, E2, C1, C2, S1, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -49,7 +49,7 @@ where
 }
 
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct CompressedSNARK<E1, E2, C1, C2, S1, S2>
 where


### PR DESCRIPTION
This should help us be more rigorous with cloning. Tested to not break Lurk in the (currently unused) scenario where we'd use pre-processing variants of compressing SNARKs. There will probably be another, slightly more extensive cleanup after #285 merges (as that PR has the downstream effect of shrinking Lurk's requirements on Arecibo, see https://github.com/lurk-lab/lurk-rs/pull/1085).