### PR TITLE
Remove unneeded derive(Serialize, Deserialize) (easy)

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -46,7 +46,7 @@ impl NovaAugmentedCircuitParams {
   }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 #[serde(bound = "")]
 pub struct NovaAugmentedCircuitInputs<E: Engine> {
   params: E::Scalar,

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -46,7 +46,7 @@ pub struct EvaluationArgument<E: Engine> {
 }
 
 /// Provides an implementation of a polynomial evaluation engine using KZG
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct EvaluationEngine<E, NE> {
   _p: PhantomData<(E, NE)>,
 }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -35,7 +35,7 @@ pub struct VerifierKey<E: Engine> {
 impl<E: Engine> SimpleDigestible for VerifierKey<E> {}
 
 /// Provides an implementation of a polynomial evaluation engine using IPA
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct EvaluationEngine<E> {
   _p: PhantomData<E>,
 }

--- a/src/provider/kzg_commitment.rs
+++ b/src/provider/kzg_commitment.rs
@@ -22,7 +22,7 @@ use crate::provider::{
 };
 
 /// Provides a commitment engine
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KZGCommitmentEngine<E> {
   _p: PhantomData<E>,
 }

--- a/src/provider/non_hiding_zeromorph.rs
+++ b/src/provider/non_hiding_zeromorph.rs
@@ -83,7 +83,7 @@ fn trim_zeromorph<E: Engine>(
 }
 
 /// Commitments
-#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct ZMCommitment<E: Engine>(
   /// the actual commitment is an affine point.
   E::G1Affine,

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -209,7 +209,7 @@ where
 }
 
 /// Provides a commitment engine
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitmentEngine<E> {
   _p: PhantomData<E>,
 }

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -35,7 +35,7 @@ impl<Scalar: PrimeField> Default for PoseidonConstantsCircuit<Scalar> {
 }
 
 /// A Poseidon-based RO to use outside circuits
-#[derive(Debug, Serialize, Deserialize, Abomonation)]
+#[derive(Debug, Abomonation)]
 #[abomonation_bounds(
   where
     Base: PrimeField,
@@ -115,7 +115,7 @@ where
 }
 
 /// A Poseidon-based RO gadget to use inside the verifier circuit.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct PoseidonROCircuit<Scalar: PrimeField> {
   // Internal state
   state: Vec<AllocatedNum<Scalar>>,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -51,7 +51,7 @@ use circuit::{
 use error::SuperNovaError;
 
 /// A struct that manages all the digests of the primary circuits of a SuperNova instance
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct CircuitDigests<E: Engine> {
   digests: Vec<E::Scalar>,
 }
@@ -80,7 +80,7 @@ impl<E: Engine> CircuitDigests<E> {
 }
 
 /// A vector of [`R1CSWithArity`] adjoined to a set of [`PublicParams`]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 #[serde(bound = "")]
 pub struct PublicParams<E1, E2, C1, C2>
 where
@@ -112,7 +112,7 @@ where
 /// Auxiliary [`PublicParams`] information about the commitment keys and
 /// secondary circuit. This is used as a helper struct when reconstructing
 /// [`PublicParams`] downstream in lurk.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(bound = "")]
 pub struct AuxParams<E1, E2>
 where
@@ -135,8 +135,7 @@ where
 
 /// A variant of [`crate::supernova::AuxParams`] that is suitable for fast ser/de using Abomonation
 #[cfg(feature = "abomonate")]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Abomonation)]
-#[serde(bound = "")]
+#[derive(Debug, Clone, PartialEq, Abomonation)]
 #[abomonation_bounds(
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,


### PR DESCRIPTION
Tested on Lurk. The structs that lose `Deserialize`but not `Serialize` here in general need the later to be `Digestible`