### PR TITLE
Refactor MSM instances in the IPA

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -202,7 +202,10 @@ where
       let B = kzg_compute_batch_polynomial(f, q);
 
       // Now open B at u0, ..., u_{t-1}
-      let w = u.par_iter().map(|ui| kzg_open(&B, *ui)).collect::<Vec<_>>();
+      let w = u
+        .into_par_iter()
+        .map(|ui| kzg_open(&B, *ui))
+        .collect::<Vec<_>>();
 
       // The prover computes the challenge to keep the transcript in the same
       // state as that of the verifier

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -19,13 +19,13 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// Provides an implementation of the prover key
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ProverKey<E: Engine> {
   ck_s: CommitmentKey<E>,
 }
 
 /// Provides an implementation of the verifier key
-#[derive(Clone, Debug, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(bound = "")]
 pub struct VerifierKey<E: Engine> {
   ck_v: Arc<CommitmentKey<E>>,
@@ -44,7 +44,7 @@ impl<E> EvaluationEngineTrait<E> for EvaluationEngine<E>
 where
   E: Engine,
   E::GE: DlogGroup,
-  CommitmentKey<E>: CommitmentKeyExtTrait<E>,
+  CommitmentKey<E>: CommitmentKeyExtTrait<E> + Clone,
 {
   type ProverKey = ProverKey<E>;
   type VerifierKey = VerifierKey<E>;

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -44,7 +44,7 @@ impl<E> EvaluationEngineTrait<E> for EvaluationEngine<E>
 where
   E: Engine,
   E::GE: DlogGroup,
-  CommitmentKey<E>: CommitmentKeyExtTrait<E> + Clone,
+  CommitmentKey<E>: CommitmentKeyExtTrait<E>,
 {
   type ProverKey = ProverKey<E>;
   type VerifierKey = VerifierKey<E>;
@@ -76,7 +76,7 @@ where
     let u = InnerProductInstance::new(comm, &EqPolynomial::evals_from_points(point), eval);
     let w = InnerProductWitness::new(poly);
 
-    InnerProductArgument::prove(ck, &pk.ck_s, &u, &w, transcript)
+    InnerProductArgument::prove(ck.clone(), pk.ck_s.clone(), &u, &w, transcript)
   }
 
   /// A method to verify purported evaluations of a batch of polynomials
@@ -90,7 +90,7 @@ where
   ) -> Result<(), NovaError> {
     let u = InnerProductInstance::new(comm, &EqPolynomial::evals_from_points(point), eval);
 
-    arg.verify(&vk.ck_v, &vk.ck_s, 1 << point.len(), &u, transcript)?;
+    arg.verify(&vk.ck_v, vk.ck_s.clone(), 1 << point.len(), &u, transcript)?;
 
     Ok(())
   }
@@ -165,8 +165,8 @@ where
   }
 
   fn prove(
-    ck: &CommitmentKey<E>,
-    ck_c: &CommitmentKey<E>,
+    ck: CommitmentKey<E>,
+    mut ck_c: CommitmentKey<E>,
     U: &InnerProductInstance<E>,
     W: &InnerProductWitness<E>,
     transcript: &mut E::TE,
@@ -184,12 +184,12 @@ where
 
     // sample a random base for commiting to the inner product
     let r = transcript.squeeze(b"r")?;
-    let ck_c = ck_c.scale(&r);
+    ck_c.scale(&r);
 
     // a closure that executes a step of the recursive inner product argument
     let prove_inner = |a_vec: &[E::Scalar],
                        b_vec: &[E::Scalar],
-                       ck: &CommitmentKey<E>,
+                       ck: CommitmentKey<E>,
                        transcript: &mut E::TE|
      -> Result<
       (
@@ -245,7 +245,7 @@ where
         .map(|(b_L, b_R)| *b_L * r_inverse + r * *b_R)
         .collect::<Vec<E::Scalar>>();
 
-      let ck_folded = ck.fold(&r_inverse, &r);
+      let ck_folded = CommitmentKeyExtTrait::fold(&ck_L, &ck_R, &r_inverse, &r);
 
       Ok((L, R, a_vec_folded, b_vec_folded, ck_folded))
     };
@@ -260,7 +260,7 @@ where
     let mut ck = ck;
     for _i in 0..usize::try_from(U.b_vec.len().ilog2()).unwrap() {
       let (L, R, a_vec_folded, b_vec_folded, ck_folded) =
-        prove_inner(&a_vec, &b_vec, &ck, transcript)?;
+        prove_inner(&a_vec, &b_vec, ck, transcript)?;
       L_vec.push(L);
       R_vec.push(R);
 
@@ -279,12 +279,12 @@ where
   fn verify(
     &self,
     ck: &CommitmentKey<E>,
-    ck_c: &CommitmentKey<E>,
+    mut ck_c: CommitmentKey<E>,
     n: usize,
     U: &InnerProductInstance<E>,
     transcript: &mut E::TE,
   ) -> Result<(), NovaError> {
-    let (ck, _) = ck.split_at(U.b_vec.len());
+    let (ck, _) = ck.clone().split_at(U.b_vec.len());
 
     transcript.dom_sep(Self::protocol_name());
     if U.b_vec.len() != n
@@ -300,7 +300,7 @@ where
 
     // sample a random base for commiting to the inner product
     let r = transcript.squeeze(b"r")?;
-    let ck_c = ck_c.scale(&r);
+    ck_c.scale(&r);
 
     let P = U.comm_a_vec + CE::<E>::commit(&ck_c, &[U.c]);
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -280,8 +280,10 @@ where
   // combines the left and right halves of `self` using `w1` and `w2` as the weights
   fn fold(L: &Self, R: &Self, w1: &E::Scalar, w2: &E::Scalar) -> Self {
     debug_assert!(L.ck.len() == R.ck.len());
-    let ck_curve: Vec<E::GE> =
-      zip_with!(par_iter, (L.ck, R.ck), |l, r| *l * w1 + *r * w2).collect();
+    let ck_curve: Vec<E::GE> = zip_with!(par_iter, (L.ck, R.ck), |l, r| {
+      E::GE::vartime_multiscalar_mul(&[*w1, *w2], &[*l, *r])
+    })
+    .collect();
     let mut ck_affine = vec![<E::GE as PrimeCurve>::Affine::identity(); L.ck.len()];
     E::GE::batch_normalize(&ck_curve, &mut ck_affine);
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -23,7 +23,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A type that holds commitment generators
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Abomonation)]
 #[abomonation_omit_bounds]
 pub struct CommitmentKey<E>
 where
@@ -32,19 +32,6 @@ where
 {
   #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
   ck: Vec<<E::GE as PrimeCurve>::Affine>,
-}
-
-/// [`CommitmentKey`]s are often large, and this helps with cloning bottlenecks
-impl<E> Clone for CommitmentKey<E>
-where
-  E: Engine,
-  E::GE: DlogGroup<ScalarExt = E::Scalar>,
-{
-  fn clone(&self) -> Self {
-    Self {
-      ck: self.ck[..].par_iter().cloned().collect(),
-    }
-  }
 }
 
 impl<E> Len for CommitmentKey<E>

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -1,7 +1,9 @@
 use crate::traits::{Group, TranscriptReprTrait};
+use group::prime::PrimeCurveAffine;
 use group::{prime::PrimeCurve, GroupEncoding};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use std::ops::Mul;
 
 /// A trait that defines extensions to the Group trait
 pub trait DlogGroup:
@@ -11,7 +13,16 @@ pub trait DlogGroup:
   + PrimeCurve<Scalar = <Self as DlogGroup>::ScalarExt, Affine = <Self as DlogGroup>::AffineExt>
 {
   type ScalarExt;
-  type AffineExt: Clone + Debug + Eq + Serialize + for<'de> Deserialize<'de> + Sync + Send;
+  type AffineExt: Clone
+    + Debug
+    + Eq
+    + Serialize
+    + for<'de> Deserialize<'de>
+    + Sync
+    + Send
+    // technical bounds, should disappear when associated_type_bounds stabilizes
+    + Mul<Self::ScalarExt, Output = Self>
+    + PrimeCurveAffine<Curve = Self, Scalar = Self::ScalarExt>;
   type Compressed: Clone
     + Debug
     + Eq

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -68,6 +68,7 @@ pub trait CommitmentEngineTrait<E: Engine>: Clone + Send + Sync {
   /// Holds the type of the commitment key
   /// The key should quantify its length in terms of group generators.
   type CommitmentKey: Len
+    + Clone
     + PartialEq
     + Debug
     + Send

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -68,7 +68,6 @@ pub trait CommitmentEngineTrait<E: Engine>: Clone + Send + Sync {
   /// Holds the type of the commitment key
   /// The key should quantify its length in terms of group generators.
   type CommitmentKey: Len
-    + Clone
     + PartialEq
     + Debug
     + Send

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -12,11 +12,10 @@ use serde::{Deserialize, Serialize};
 /// A trait that ties different pieces of the commitment evaluation together
 pub trait EvaluationEngineTrait<E: Engine>: Clone + Send + Sync {
   /// A type that holds the prover key
-  type ProverKey: Clone + Send + Sync;
+  type ProverKey: Send + Sync;
 
   /// A type that holds the verifier key
-  type VerifierKey: Clone
-    + Send
+  type VerifierKey: Send
     + Sync
     // required for easy Digest computation purposes, could be relaxed to
     // [`crate::digest::Digestible`]


### PR DESCRIPTION
## What's in this PR

This experiments with re-structuring the IPA to:
- avoid implicit or needless `CommitmentKey` clones (I've had to import some changes from #287),
- avoid depending on calling the MSM in `impl CommitmentKeyExtTrait for pedersen::CommitmentKey`, instead relying on an already-available implementation of `Mul<E::Scalar, Output = E> for E::Affine`.

That experiement is largely unsuccessful, since MSM implementation (which resolves to `cpu_best_msm` since the scalar length is 2) is about 5% faster[^1]. We tactically revert to the MSM in that particular line.

## Benchmarks

<details> 
<summary> I ran the pcs benchmarks (click to unfold) </summary>

```
group                                                                                                                                      dev                                unmsm_ipa
PCS-Proving 10/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/10                                              1.00     32.2±0.18ms    1.00     32.1±0.28ms
PCS-Proving 12/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/12                                              1.00     86.3±0.35ms    1.00     86.7±0.22ms
PCS-Proving 14/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/14                                              1.00    295.3±1.40ms    1.00    294.1±1.19ms
PCS-Proving 16/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/16                                              1.00   1115.9±5.35ms    1.00   1114.3±5.28ms
PCS-Proving 18/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/18                                              1.00       4.4±0.04s    1.00       4.4±0.03s
PCS-Proving 20/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/20                                              1.00      17.5±0.07s    1.00      17.5±0.05s
PCS-Verifying 10/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/10                                            1.04      3.4±0.05ms    1.00      3.3±0.04ms
PCS-Verifying 12/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/12                                            1.04      5.8±0.10ms    1.00      5.6±0.17ms
PCS-Verifying 14/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/14                                            1.00     13.9±0.37ms    1.01     14.0±0.43ms
PCS-Verifying 16/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/16                                            1.01     35.9±0.79ms    1.00     35.6±0.26ms
PCS-Verifying 18/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/18                                            1.00    124.9±0.95ms    1.00    124.8±0.84ms
PCS-Verifying 20/arecibo::provider::ipa_pc::EvaluationEngine<arecibo::provider::Bn256Engine>/20                                            1.00   506.0±30.68ms    1.01   508.9±21.72ms
```
</details>

> [!NOTE]
> Companion PR at https://github.com/lurk-lab/lurk-rs/pull/1088

[^1]: note the `scale` function moving away from the MSM doesn't seem to have nearly the same perf. impact, 