### PR TITLE
Some Type simplifications

### DIFF
--- a/benches/common/supernova/bench.rs
+++ b/benches/common/supernova/bench.rs
@@ -97,11 +97,11 @@ pub fn bench_snark_internal_with_arity<
 
   match snark_type {
     SnarkType::Compressed => {
-      let (prover_key, verifier_key) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+      let (prover_key, verifier_key) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
       // Benchmark the prove time
       group.bench_function(bench_params.bench_id("Prove"), |b| {
         b.iter(|| {
-          assert!(CompressedSNARK::<_, _, _, _, S1, S2>::prove(
+          assert!(CompressedSNARK::<_, _, S1, _, _, S2>::prove(
             black_box(&pp),
             black_box(&prover_key),
             black_box(&recursive_snark)
@@ -110,7 +110,7 @@ pub fn bench_snark_internal_with_arity<
         })
       });
 
-      let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &prover_key, &recursive_snark);
+      let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &prover_key, &recursive_snark);
       assert!(res.is_ok());
       let compressed_snark = res.unwrap();
       // Benchmark the verification time

--- a/benches/common/supernova/mod.rs
+++ b/benches/common/supernova/mod.rs
@@ -7,7 +7,7 @@ pub mod targets;
 use anyhow::anyhow;
 use arecibo::{
   supernova::{NonUniformCircuit, StepCircuit, TrivialTestCircuit},
-  traits::{CurveCycleEquipped, Engine, Dual},
+  traits::{CurveCycleEquipped, Dual, Engine},
 };
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;

--- a/benches/common/supernova/mod.rs
+++ b/benches/common/supernova/mod.rs
@@ -7,7 +7,7 @@ pub mod targets;
 use anyhow::anyhow;
 use arecibo::{
   supernova::{NonUniformCircuit, StepCircuit, TrivialTestCircuit},
-  traits::{CurveCycleEquipped, Engine, SecEng},
+  traits::{CurveCycleEquipped, Engine, Dual},
 };
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
@@ -94,7 +94,7 @@ where
   E1: CurveCycleEquipped,
 {
   type C1 = NonTrivialTestCircuit<E1::Scalar>;
-  type C2 = TrivialTestCircuit<<SecEng<E1> as Engine>::Scalar>;
+  type C2 = TrivialTestCircuit<<Dual<E1> as Engine>::Scalar>;
 
   fn num_circuits(&self) -> usize {
     self.num_circuits

--- a/benches/common/supernova/mod.rs
+++ b/benches/common/supernova/mod.rs
@@ -95,7 +95,7 @@ where
 }
 
 impl<E1, E2, S>
-  NonUniformCircuit<E1, E2, NonTrivialTestCircuit<E1::Scalar>, TrivialTestCircuit<E2::Scalar>>
+  NonUniformCircuit<E1, NonTrivialTestCircuit<E1::Scalar>, E2, TrivialTestCircuit<E2::Scalar>>
   for NonUniformBench<E1, E2, S>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -69,19 +69,15 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   let c_secondary = TrivialCircuit::default();
 
   // Produce public parameters
-  let pp = PublicParams::<E1, C1, E2, C2>::setup(
-    &c_primary,
-    &c_secondary,
-    &*S1::ck_floor(),
-    &*S2::ck_floor(),
-  );
+  let pp =
+    PublicParams::<E1, C1, C2>::setup(&c_primary, &c_secondary, &*S1::ck_floor(), &*S2::ck_floor());
 
   // Produce prover and verifier keys for CompressedSNARK
-  let (pk, vk) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
+  let (pk, vk) = CompressedSNARK::<_, _, S1, _, S2>::setup(&pp).unwrap();
 
   // produce a recursive SNARK
   let num_steps = 3;
-  let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> = RecursiveSNARK::new(
+  let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::new(
     &pp,
     &c_primary,
     &c_secondary,
@@ -113,7 +109,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   // Bench time to produce a compressed SNARK
   group.bench_function(bench_params.bench_id("Prove"), |b| {
     b.iter(|| {
-      assert!(CompressedSNARK::<_, _, S1, _, _, S2>::prove(
+      assert!(CompressedSNARK::<_, _, S1, _, S2>::prove(
         black_box(&pp),
         black_box(&pk),
         black_box(&recursive_snark)
@@ -121,7 +117,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
       .is_ok());
     })
   });
-  let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &pk, &recursive_snark);
+  let res = CompressedSNARK::<_, _, S1, _, S2>::prove(&pp, &pk, &recursive_snark);
   assert!(res.is_ok());
   let compressed_snark = res.unwrap();
 

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -27,8 +27,6 @@ type S2 = arecibo::spartan::snark::RelaxedR1CSSNARK<E2, EE2>;
 // SNARKs with computation commitmnets
 type SS1 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E1, EE1>;
 type SS2 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E2, EE2>;
-type C1 = NonTrivialCircuit<<E1 as Engine>::Scalar>;
-type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
 // Then `cargo criterion --bench compressed-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -69,15 +67,14 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   let c_secondary = TrivialCircuit::default();
 
   // Produce public parameters
-  let pp =
-    PublicParams::<E1, C1, C2>::setup(&c_primary, &c_secondary, &*S1::ck_floor(), &*S2::ck_floor());
+  let pp = PublicParams::<E1>::setup(&c_primary, &c_secondary, &*S1::ck_floor(), &*S2::ck_floor());
 
   // Produce prover and verifier keys for CompressedSNARK
-  let (pk, vk) = CompressedSNARK::<_, _, S1, _, S2>::setup(&pp).unwrap();
+  let (pk, vk) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
   // produce a recursive SNARK
   let num_steps = 3;
-  let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::new(
+  let mut recursive_snark: RecursiveSNARK<E1> = RecursiveSNARK::new(
     &pp,
     &c_primary,
     &c_secondary,
@@ -109,7 +106,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   // Bench time to produce a compressed SNARK
   group.bench_function(bench_params.bench_id("Prove"), |b| {
     b.iter(|| {
-      assert!(CompressedSNARK::<_, _, S1, _, S2>::prove(
+      assert!(CompressedSNARK::<_, S1, S2>::prove(
         black_box(&pp),
         black_box(&pk),
         black_box(&recursive_snark)
@@ -117,7 +114,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
       .is_ok());
     })
   });
-  let res = CompressedSNARK::<_, _, S1, _, S2>::prove(&pp, &pk, &recursive_snark);
+  let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark);
   assert!(res.is_ok());
   let compressed_snark = res.unwrap();
 

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -69,7 +69,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   let c_secondary = TrivialCircuit::default();
 
   // Produce public parameters
-  let pp = PublicParams::<E1, E2, C1, C2>::setup(
+  let pp = PublicParams::<E1, C1, E2, C2>::setup(
     &c_primary,
     &c_secondary,
     &*S1::ck_floor(),
@@ -77,11 +77,11 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   );
 
   // Produce prover and verifier keys for CompressedSNARK
-  let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+  let (pk, vk) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
 
   // produce a recursive SNARK
   let num_steps = 3;
-  let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> = RecursiveSNARK::new(
+  let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> = RecursiveSNARK::new(
     &pp,
     &c_primary,
     &c_secondary,
@@ -113,7 +113,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   // Bench time to produce a compressed SNARK
   group.bench_function(bench_params.bench_id("Prove"), |b| {
     b.iter(|| {
-      assert!(CompressedSNARK::<_, _, _, _, S1, S2>::prove(
+      assert!(CompressedSNARK::<_, _, S1, _, _, S2>::prove(
         black_box(&pp),
         black_box(&pk),
         black_box(&recursive_snark)
@@ -121,7 +121,7 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
       .is_ok());
     })
   });
-  let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
+  let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &pk, &recursive_snark);
   assert!(res.is_ok());
   let compressed_snark = res.unwrap();
 

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -29,7 +29,7 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<E1, E2, C1, C2>::setup(
+      PublicParams::<E1, C1, E2, C2>::setup(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
         black_box(&*default_ck_hint()),

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -29,7 +29,7 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<E1, C1, C2>::setup(
+      PublicParams::<E1>::setup(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
         black_box(&*default_ck_hint()),

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -29,7 +29,7 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<E1, C1, E2, C2>::setup(
+      PublicParams::<E1, C1, C2>::setup(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
         black_box(&*default_ck_hint()),

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -73,7 +73,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<E1, E2, C1, C2>::setup(
+    let pp = PublicParams::<E1, C1, E2, C2>::setup(
       &c_primary,
       &c_secondary,
       &*default_ck_hint(),
@@ -85,7 +85,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     // the first step is cheaper than other steps owing to the presence of
     // a lot of zeros in the satisfying assignment
     let num_warmup_steps = 10;
-    let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> = RecursiveSNARK::new(
+    let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -73,7 +73,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<E1, C1, E2, C2>::setup(
+    let pp = PublicParams::<E1, C1, C2>::setup(
       &c_primary,
       &c_secondary,
       &*default_ck_hint(),
@@ -85,7 +85,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     // the first step is cheaper than other steps owing to the presence of
     // a lot of zeros in the satisfying assignment
     let num_warmup_steps = 10;
-    let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> = RecursiveSNARK::new(
+    let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -19,8 +19,6 @@ use common::{noise_threshold_env, BenchParams};
 
 type E1 = PallasEngine;
 type E2 = VestaEngine;
-type C1 = NonTrivialCircuit<<E1 as Engine>::Scalar>;
-type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo-criterion`.
 // Then `cargo criterion --bench recursive-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -73,7 +71,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<E1, C1, C2>::setup(
+    let pp = PublicParams::<E1>::setup(
       &c_primary,
       &c_secondary,
       &*default_ck_hint(),
@@ -85,7 +83,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     // the first step is cheaper than other steps owing to the presence of
     // a lot of zeros in the satisfying assignment
     let num_warmup_steps = 10;
-    let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::new(
+    let mut recursive_snark: RecursiveSNARK<E1> = RecursiveSNARK::new(
       &pp,
       &c_primary,
       &c_secondary,

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -158,7 +158,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<E1, E2, C1, C2>::setup(
+    let pp = PublicParams::<E1, C1, E2, C2>::setup(
       &circuit_primary,
       &ttc,
       &*default_ck_hint(),

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -122,9 +122,6 @@ impl<Scalar: PrimeField + PrimeFieldBits> StepCircuit<Scalar> for Sha256Circuit<
   }
 }
 
-type C1 = Sha256Circuit<<E1 as Engine>::Scalar>;
-type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
-
 criterion_group! {
 name = recursive_snark;
 config = Criterion::default().warm_up_time(Duration::from_millis(3000));
@@ -158,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<E1, C1, C2>::setup(
+    let pp = PublicParams::<E1>::setup(
       &circuit_primary,
       &ttc,
       &*default_ck_hint(),

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -158,7 +158,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<E1, C1, E2, C2>::setup(
+    let pp = PublicParams::<E1, C1, C2>::setup(
       &circuit_primary,
       &ttc,
       &*default_ck_hint(),

--- a/examples/and.rs
+++ b/examples/and.rs
@@ -208,11 +208,14 @@ fn main() {
   println!("Nova-based 64-bit bitwise AND example");
   println!("=========================================================");
 
+  type C1 = AndCircuit<<E1 as Engine>::GE>;
+  type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
+
   let num_steps = 32;
   for num_ops_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65536] {
     // number of instances of AND per Nova's recursive step
-    let circuit_primary = AndCircuit::new(num_ops_per_step);
-    let circuit_secondary = TrivialCircuit::default();
+    let circuit_primary = C1::new(num_ops_per_step);
+    let circuit_secondary = C2::default();
 
     println!(
       "Proving {} AND ops ({num_ops_per_step} instances per step and {num_steps} steps)",
@@ -222,7 +225,7 @@ fn main() {
     // produce public parameters
     let start = Instant::now();
     println!("Producing public parameters...");
-    let pp = PublicParams::<E1, AndCircuit<<E1 as Engine>::GE>>::setup(
+    let pp = PublicParams::<E1>::setup(
       &circuit_primary,
       &circuit_secondary,
       &*S1::ck_floor(),
@@ -250,15 +253,12 @@ fn main() {
 
     // produce non-deterministic advice
     let circuits = (0..num_steps)
-      .map(|_| AndCircuit::new(num_ops_per_step))
+      .map(|_| C1::new(num_ops_per_step))
       .collect::<Vec<_>>();
-
-    type C1 = AndCircuit<<E1 as Engine>::GE>;
-    type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
 
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::<E1, C1, C2>::new(
+    let mut recursive_snark: RecursiveSNARK<E1> = RecursiveSNARK::<E1>::new(
       &pp,
       &circuits[0],
       &circuit_secondary,
@@ -291,11 +291,11 @@ fn main() {
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with multilinear KZG...");
-    let (pk, vk) = CompressedSNARK::<_, _, S1, _, S2>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
     let start = Instant::now();
 
-    let res = CompressedSNARK::<_, _, S1, _, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark);
     println!(
       "CompressedSNARK::prove: {:?}, took {:?}",
       res.is_ok(),

--- a/examples/and.rs
+++ b/examples/and.rs
@@ -224,8 +224,8 @@ fn main() {
     println!("Producing public parameters...");
     let pp = PublicParams::<
       E1,
-      E2,
       AndCircuit<<E1 as Engine>::GE>,
+      E2,
       TrivialCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -263,8 +263,8 @@ fn main() {
 
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> =
-      RecursiveSNARK::<E1, E2, C1, C2>::new(
+    let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> =
+      RecursiveSNARK::<E1, C1, E2, C2>::new(
         &pp,
         &circuits[0],
         &circuit_secondary,
@@ -297,11 +297,11 @@ fn main() {
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with multilinear KZG...");
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
 
     let start = Instant::now();
 
-    let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &pk, &recursive_snark);
     println!(
       "CompressedSNARK::prove: {:?}, took {:?}",
       res.is_ok(),

--- a/examples/and.rs
+++ b/examples/and.rs
@@ -222,12 +222,7 @@ fn main() {
     // produce public parameters
     let start = Instant::now();
     println!("Producing public parameters...");
-    let pp = PublicParams::<
-      E1,
-      AndCircuit<<E1 as Engine>::GE>,
-      E2,
-      TrivialCircuit<<E2 as Engine>::Scalar>,
-    >::setup(
+    let pp = PublicParams::<E1, AndCircuit<<E1 as Engine>::GE>>::setup(
       &circuit_primary,
       &circuit_secondary,
       &*S1::ck_floor(),
@@ -263,15 +258,14 @@ fn main() {
 
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> =
-      RecursiveSNARK::<E1, C1, E2, C2>::new(
-        &pp,
-        &circuits[0],
-        &circuit_secondary,
-        &[<E1 as Engine>::Scalar::zero()],
-        &[<E2 as Engine>::Scalar::zero()],
-      )
-      .unwrap();
+    let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::<E1, C1, C2>::new(
+      &pp,
+      &circuits[0],
+      &circuit_secondary,
+      &[<E1 as Engine>::Scalar::zero()],
+      &[<E2 as Engine>::Scalar::zero()],
+    )
+    .unwrap();
 
     let start = Instant::now();
     for circuit_primary in circuits.iter() {
@@ -297,11 +291,11 @@ fn main() {
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with multilinear KZG...");
-    let (pk, vk) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, S1, _, S2>::setup(&pp).unwrap();
 
     let start = Instant::now();
 
-    let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, S1, _, S2>::prove(&pp, &pk, &recursive_snark);
     println!(
       "CompressedSNARK::prove: {:?}, took {:?}",
       res.is_ok(),

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -223,8 +223,8 @@ fn main() {
     println!("Producing public parameters...");
     let pp = PublicParams::<
       E1,
-      E2,
       MinRootCircuit<<E1 as Engine>::GE>,
+      E2,
       TrivialCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -316,8 +316,8 @@ fn main() {
     type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<E1, E2, C1, C2> =
-      RecursiveSNARK::<E1, E2, C1, C2>::new(
+    let mut recursive_snark: RecursiveSNARK<E1, C1, E2, C2> =
+      RecursiveSNARK::<E1, C1, E2, C2>::new(
         &pp,
         &minroot_circuits[0],
         &circuit_secondary,
@@ -351,7 +351,7 @@ fn main() {
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with multilinear KZG...");
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
 
     let start = Instant::now();
     type E1 = Bn256EngineKZG;
@@ -361,7 +361,7 @@ fn main() {
     type S1 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E1, EE1>; // non-preprocessing SNARK
     type S2 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E2, EE2>; // non-preprocessing SNARK
 
-    let res = CompressedSNARK::<_, _, _, _, S1, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, S1, _, _, S2>::prove(&pp, &pk, &recursive_snark);
     println!(
       "CompressedSNARK::prove: {:?}, took {:?}",
       res.is_ok(),

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -195,6 +195,7 @@ fn main() {
     .with(EnvFilter::from_default_env())
     .with(TeXRayLayer::new());
   tracing::subscriber::set_global_default(subscriber).unwrap();
+  type C1 = MinRootCircuit<<Bn256EngineKZG as Engine>::GE>;
 
   println!("Nova-based VDF with MinRoot delay function");
   println!("=========================================================");
@@ -202,7 +203,7 @@ fn main() {
   let num_steps = 10;
   for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65536] {
     // number of iterations of MinRoot per Nova's recursive step
-    let circuit_primary = MinRootCircuit {
+    let circuit_primary = C1 {
       seq: vec![
         MinRootIteration {
           x_i: <E1 as Engine>::Scalar::zero(),
@@ -221,7 +222,7 @@ fn main() {
     // produce public parameters
     let start = Instant::now();
     println!("Producing public parameters...");
-    let pp = PublicParams::<E1, MinRootCircuit<<E1 as Engine>::GE>>::setup(
+    let pp = PublicParams::<E1>::setup(
       &circuit_primary,
       &circuit_secondary,
       &*S1::ck_floor(),
@@ -267,9 +268,7 @@ fn main() {
       let mut reader = std::io::BufReader::new(file);
       let mut bytes = Vec::new();
       reader.read_to_end(&mut bytes).unwrap();
-      if let Some((result, remaining)) =
-        unsafe { decode::<FlatPublicParams<E1, MinRootCircuit<<E1 as Engine>::GE>>>(&mut bytes) }
-      {
+      if let Some((result, remaining)) = unsafe { decode::<FlatPublicParams<E1>>(&mut bytes) } {
         let result_pp = PublicParams::from(result.clone());
         assert!(result_pp == pp, "decoded parameters not equal to original!");
         assert!(remaining.is_empty());
@@ -286,7 +285,7 @@ fn main() {
       &<E1 as Engine>::Scalar::one(),
     );
     let minroot_circuits = (0..num_steps)
-      .map(|i| MinRootCircuit {
+      .map(|i| C1 {
         seq: (0..num_iters_per_step)
           .map(|j| MinRootIteration {
             x_i: minroot_iterations[i * num_iters_per_step + j].x_i,
@@ -300,11 +299,9 @@ fn main() {
 
     let z0_secondary = vec![<E2 as Engine>::Scalar::zero()];
 
-    type C1 = MinRootCircuit<<E1 as Engine>::GE>;
-    type C2 = TrivialCircuit<<E2 as Engine>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<E1, C1, C2> = RecursiveSNARK::<E1, C1, C2>::new(
+    let mut recursive_snark = RecursiveSNARK::<E1>::new(
       &pp,
       &minroot_circuits[0],
       &circuit_secondary,
@@ -338,7 +335,7 @@ fn main() {
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with multilinear KZG...");
-    let (pk, vk) = CompressedSNARK::<_, _, S1, _, S2>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
     let start = Instant::now();
     type E1 = Bn256EngineKZG;
@@ -348,7 +345,7 @@ fn main() {
     type S1 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E1, EE1>; // non-preprocessing SNARK
     type S2 = arecibo::spartan::ppsnark::RelaxedR1CSSNARK<E2, EE2>; // non-preprocessing SNARK
 
-    let res = CompressedSNARK::<_, _, S1, _, S2>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark);
     println!(
       "CompressedSNARK::prove: {:?}, took {:?}",
       res.is_ok(),

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -372,30 +372,31 @@ mod tests {
     constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
     gadgets::utils::scalar_as_base,
     provider::{
-      poseidon::PoseidonConstantsCircuit,
-      {Bn256Engine, GrumpkinEngine}, {PallasEngine, VestaEngine},
-      {Secp256k1Engine, Secq256k1Engine},
+      poseidon::PoseidonConstantsCircuit, Bn256Engine, GrumpkinEngine, PallasEngine,
+      Secp256k1Engine, Secq256k1Engine, VestaEngine,
     },
-    traits::{circuit::TrivialCircuit, snark::default_ck_hint},
+    traits::{circuit::TrivialCircuit, snark::default_ck_hint, CurveCycleEquipped, SecEng},
   };
   use expect_test::{expect, Expect};
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
-  fn test_recursive_circuit_with<E1, E2>(
+  fn test_recursive_circuit_with<E1>(
     primary_params: &NovaAugmentedCircuitParams,
     secondary_params: &NovaAugmentedCircuitParams,
-    ro_consts1: ROConstantsCircuit<E2>,
+    ro_consts1: ROConstantsCircuit<SecEng<E1>>,
     ro_consts2: ROConstantsCircuit<E1>,
     expected_num_constraints_primary: &Expect,
     expected_num_constraints_secondary: &Expect,
   ) where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
+    E1: CurveCycleEquipped,
   {
     let tc1 = TrivialCircuit::default();
     // Initialize the shape and ck for the primary
-    let circuit1: NovaAugmentedCircuit<'_, E2, TrivialCircuit<<E2 as Engine>::Base>> =
-      NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
+    let circuit1: NovaAugmentedCircuit<
+      '_,
+      SecEng<E1>,
+      TrivialCircuit<<SecEng<E1> as Engine>::Base>,
+    > = NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<E1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
@@ -406,16 +407,16 @@ mod tests {
     // Initialize the shape and ck for the secondary
     let circuit2: NovaAugmentedCircuit<'_, E1, TrivialCircuit<<E1 as Engine>::Base>> =
       NovaAugmentedCircuit::new(secondary_params, None, &tc2, ro_consts2.clone());
-    let mut cs: TestShapeCS<E2> = TestShapeCS::new();
+    let mut cs: TestShapeCS<SecEng<E1>> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
 
     expected_num_constraints_secondary.assert_eq(&cs.num_constraints().to_string());
 
     // Execute the base case for the primary
-    let zero1 = <<E2 as Engine>::Base as Field>::ZERO;
+    let zero1 = <<SecEng<E1> as Engine>::Base as Field>::ZERO;
     let mut cs1 = SatisfyingAssignment::<E1>::new();
-    let inputs1: NovaAugmentedCircuitInputs<E2> = NovaAugmentedCircuitInputs::new(
+    let inputs1: NovaAugmentedCircuitInputs<SecEng<E1>> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<E1>(zero1), // pass zero for testing
       zero1,
       vec![zero1],
@@ -424,8 +425,11 @@ mod tests {
       None,
       None,
     );
-    let circuit1: NovaAugmentedCircuit<'_, E2, TrivialCircuit<<E2 as Engine>::Base>> =
-      NovaAugmentedCircuit::new(primary_params, Some(inputs1), &tc1, ro_consts1);
+    let circuit1: NovaAugmentedCircuit<
+      '_,
+      SecEng<E1>,
+      TrivialCircuit<<SecEng<E1> as Engine>::Base>,
+    > = NovaAugmentedCircuit::new(primary_params, Some(inputs1), &tc1, ro_consts1);
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable
@@ -433,9 +437,9 @@ mod tests {
 
     // Execute the base case for the secondary
     let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
-    let mut cs2 = SatisfyingAssignment::<E2>::new();
+    let mut cs2 = SatisfyingAssignment::<SecEng<E1>>::new();
     let inputs2: NovaAugmentedCircuitInputs<E1> = NovaAugmentedCircuitInputs::new(
-      scalar_as_base::<E2>(zero2), // pass zero for testing
+      scalar_as_base::<SecEng<E1>>(zero2), // pass zero for testing
       zero2,
       vec![zero2],
       None,
@@ -459,7 +463,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<VestaEngine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
 
-    test_recursive_circuit_with::<PallasEngine, VestaEngine>(
+    test_recursive_circuit_with::<PallasEngine>(
       &params1,
       &params2,
       ro_consts1,
@@ -476,7 +480,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<GrumpkinEngine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
 
-    test_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
+    test_recursive_circuit_with::<Bn256Engine>(
       &params1,
       &params2,
       ro_consts1,
@@ -493,7 +497,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<Secq256k1Engine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
 
-    test_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
+    test_recursive_circuit_with::<Secp256k1Engine>(
       &params1,
       &params2,
       ro_consts1,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -392,11 +392,8 @@ mod tests {
   {
     let tc1 = TrivialCircuit::default();
     // Initialize the shape and ck for the primary
-    let circuit1: NovaAugmentedCircuit<
-      '_,
-      Dual<E1>,
-      TrivialCircuit<<Dual<E1> as Engine>::Base>,
-    > = NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
+    let circuit1: NovaAugmentedCircuit<'_, Dual<E1>, TrivialCircuit<<Dual<E1> as Engine>::Base>> =
+      NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<E1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
@@ -425,11 +422,8 @@ mod tests {
       None,
       None,
     );
-    let circuit1: NovaAugmentedCircuit<
-      '_,
-      Dual<E1>,
-      TrivialCircuit<<Dual<E1> as Engine>::Base>,
-    > = NovaAugmentedCircuit::new(primary_params, Some(inputs1), &tc1, ro_consts1);
+    let circuit1: NovaAugmentedCircuit<'_, Dual<E1>, TrivialCircuit<<Dual<E1> as Engine>::Base>> =
+      NovaAugmentedCircuit::new(primary_params, Some(inputs1), &tc1, ro_consts1);
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,20 +985,17 @@ where
 ///
 /// Note for callers: This function should be called with its performance characteristics in mind.
 /// It will synthesize and digest the full `circuit` given.
-pub fn circuit_digest<
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C: StepCircuit<E1::Scalar>,
->(
+pub fn circuit_digest<E1: CurveCycleEquipped, C: StepCircuit<E1::Scalar>>(
   circuit: &C,
 ) -> E1::Scalar {
   let augmented_circuit_params = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
 
   // ro_consts_circuit are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
-  let ro_consts_circuit: ROConstantsCircuit<E2> = ROConstantsCircuit::<E2>::default();
+  let ro_consts_circuit: ROConstantsCircuit<SecEng<E1>> =
+    ROConstantsCircuit::<SecEng<E1>>::default();
 
   // Initialize ck for the primary
-  let augmented_circuit: NovaAugmentedCircuit<'_, E2, C> =
+  let augmented_circuit: NovaAugmentedCircuit<'_, SecEng<E1>, C> =
     NovaAugmentedCircuit::new(&augmented_circuit_params, None, circuit, ro_consts_circuit);
   let mut cs: ShapeCS<E1> = ShapeCS::new();
   let _ = augmented_circuit.synthesize(&mut cs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl<E: Engine> R1CSWithArity<E> {
 /// A type that holds public parameters of Nova
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct PublicParams<E1, E2, C1, C2>
+pub struct PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -130,7 +130,7 @@ where
   <E1::Scalar as PrimeField>::Repr: Abomonation,
   <E2::Scalar as PrimeField>::Repr: Abomonation,
 )]
-pub struct FlatPublicParams<E1, E2, C1, C2>
+pub struct FlatPublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -153,7 +153,7 @@ where
 }
 
 #[cfg(feature = "abomonate")]
-impl<E1, E2, C1, C2> TryFrom<PublicParams<E1, E2, C1, C2>> for FlatPublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> TryFrom<PublicParams<E1, C1, E2, C2>> for FlatPublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -162,7 +162,7 @@ where
 {
   type Error = &'static str;
 
-  fn try_from(value: PublicParams<E1, E2, C1, C2>) -> Result<Self, Self::Error> {
+  fn try_from(value: PublicParams<E1, C1, E2, C2>) -> Result<Self, Self::Error> {
     let ck_primary =
       Arc::try_unwrap(value.ck_primary).map_err(|_| "Failed to unwrap Arc for ck_primary")?;
     let ck_secondary =
@@ -186,14 +186,14 @@ where
 }
 
 #[cfg(feature = "abomonate")]
-impl<E1, E2, C1, C2> From<FlatPublicParams<E1, E2, C1, C2>> for PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> From<FlatPublicParams<E1, C1, E2, C2>> for PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
   C1: StepCircuit<E1::Scalar>,
   C2: StepCircuit<E2::Scalar>,
 {
-  fn from(value: FlatPublicParams<E1, E2, C1, C2>) -> Self {
+  fn from(value: FlatPublicParams<E1, C1, E2, C2>) -> Self {
     Self {
       F_arity_primary: value.F_arity_primary,
       F_arity_secondary: value.F_arity_secondary,
@@ -213,7 +213,7 @@ where
   }
 }
 
-impl<E1, E2, C1, C2> SimpleDigestible for PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> SimpleDigestible for PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -222,7 +222,7 @@ where
 {
 }
 
-impl<E1, E2, C1, C2> PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -381,7 +381,7 @@ pub struct ResourceBuffer<E: Engine> {
 /// A SNARK that proves the correct execution of an incremental computation
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RecursiveSNARK<E1, E2, C1, C2>
+pub struct RecursiveSNARK<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -408,7 +408,7 @@ where
   _p: PhantomData<(C1, C2)>,
 }
 
-impl<E1, E2, C1, C2> RecursiveSNARK<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> RecursiveSNARK<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -417,7 +417,7 @@ where
 {
   /// Create new instance of recursive SNARK
   pub fn new(
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     c_primary: &C1,
     c_secondary: &C2,
     z0_primary: &[E1::Scalar],
@@ -544,7 +544,7 @@ where
   #[tracing::instrument(skip_all, name = "nova::RecursiveSNARK::prove_step")]
   pub fn prove_step(
     &mut self,
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     c_primary: &C1,
     c_secondary: &C2,
   ) -> Result<(), NovaError> {
@@ -662,7 +662,7 @@ where
   /// Verify the correctness of the `RecursiveSNARK`
   pub fn verify(
     &self,
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     num_steps: usize,
     z0_primary: &[E1::Scalar],
     z0_secondary: &[E2::Scalar],
@@ -781,7 +781,7 @@ where
 
 /// A type that holds the prover key for `CompressedSNARK`
 #[derive(Clone, Debug)]
-pub struct ProverKey<E1, E2, C1, C2, S1, S2>
+pub struct ProverKey<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -798,7 +798,7 @@ where
 /// A type that holds the verifier key for `CompressedSNARK`
 #[derive(Debug, Clone, Serialize)]
 #[serde(bound = "")]
-pub struct VerifierKey<E1, E2, C1, C2, S1, S2>
+pub struct VerifierKey<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -820,7 +820,7 @@ where
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct CompressedSNARK<E1, E2, C1, C2, S1, S2>
+pub struct CompressedSNARK<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -843,7 +843,7 @@ where
   _p: PhantomData<(C1, C2)>,
 }
 
-impl<E1, E2, C1, C2, S1, S2> CompressedSNARK<E1, E2, C1, C2, S1, S2>
+impl<E1, C1, S1, E2, C2, S2> CompressedSNARK<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -854,11 +854,11 @@ where
 {
   /// Creates prover and verifier keys for `CompressedSNARK`
   pub fn setup(
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
   ) -> Result<
     (
-      ProverKey<E1, E2, C1, C2, S1, S2>,
-      VerifierKey<E1, E2, C1, C2, S1, S2>,
+      ProverKey<E1, C1, S1, E2, C2, S2>,
+      VerifierKey<E1, C1, S1, E2, C2, S2>,
     ),
     NovaError,
   > {
@@ -891,9 +891,9 @@ where
 
   /// Create a new `CompressedSNARK`
   pub fn prove(
-    pp: &PublicParams<E1, E2, C1, C2>,
-    pk: &ProverKey<E1, E2, C1, C2, S1, S2>,
-    recursive_snark: &RecursiveSNARK<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
+    pk: &ProverKey<E1, C1, S1, E2, C2, S2>,
+    recursive_snark: &RecursiveSNARK<E1, C1, E2, C2>,
   ) -> Result<Self, NovaError> {
     // fold the secondary circuit's instance with its running instance
     let (nifs_secondary, (f_U_secondary, f_W_secondary)) = NIFS::prove(
@@ -948,7 +948,7 @@ where
   /// Verify the correctness of the `CompressedSNARK`
   pub fn verify(
     &self,
-    vk: &VerifierKey<E1, E2, C1, C2, S1, S2>,
+    vk: &VerifierKey<E1, C1, S1, E2, C2, S2>,
     num_steps: usize,
     z0_primary: &[E1::Scalar],
     z0_secondary: &[E2::Scalar],
@@ -1153,7 +1153,7 @@ mod tests {
     // this tests public parameters with a size specifically intended for a spark-compressed SNARK
     let ck_hint1 = &*SPrime::<E1, EE1>::ck_floor();
     let ck_hint2 = &*SPrime::<E2, EE2>::ck_floor();
-    let pp = PublicParams::<E1, E2, T1, T2>::setup(circuit1, circuit2, ck_hint1, ck_hint2);
+    let pp = PublicParams::<E1, T1, E2, T2>::setup(circuit1, circuit2, ck_hint1, ck_hint2);
 
     let digest_str = pp
       .digest()
@@ -1241,8 +1241,8 @@ mod tests {
     // produce public parameters
     let pp = PublicParams::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       TrivialCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &test_circuit1,
@@ -1294,8 +1294,8 @@ mod tests {
     // produce public parameters
     let pp = PublicParams::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -1309,8 +1309,8 @@ mod tests {
     // produce a recursive SNARK
     let mut recursive_snark = RecursiveSNARK::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::new(
       &pp,
@@ -1379,8 +1379,8 @@ mod tests {
     // produce public parameters
     let pp = PublicParams::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -1394,8 +1394,8 @@ mod tests {
     // produce a recursive SNARK
     let mut recursive_snark = RecursiveSNARK::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::new(
       &pp,
@@ -1432,11 +1432,11 @@ mod tests {
     assert_eq!(zn_secondary, vec![<E2 as Engine>::Scalar::from(2460515u64)]);
 
     // produce the prover and verifier keys for compressed snark
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S<E1, EE1>, S<E2, EE2>>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, S<E1, EE1>, _, _, S<E2, EE2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
     let res =
-      CompressedSNARK::<_, _, _, _, S<E1, EE1>, S<E2, EE2>>::prove(&pp, &pk, &recursive_snark);
+      CompressedSNARK::<_, _, S<E1, EE1>, _, _, S<E2, EE2>>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 
@@ -1486,8 +1486,8 @@ mod tests {
     // produce public parameters, which we'll use with a spark-compressed SNARK
     let pp = PublicParams::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -1501,8 +1501,8 @@ mod tests {
     // produce a recursive SNARK
     let mut recursive_snark = RecursiveSNARK::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::new(
       &pp,
@@ -1541,10 +1541,10 @@ mod tests {
     // run the compressed snark with Spark compiler
     // produce the prover and verifier keys for compressed snark
     let (pk, vk) =
-      CompressedSNARK::<_, _, _, _, SPrime<E1, EE1>, SPrime<E2, EE2>>::setup(&pp).unwrap();
+      CompressedSNARK::<_, _, SPrime<E1, EE1>, _, _, SPrime<E2, EE2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res = CompressedSNARK::<_, _, _, _, SPrime<E1, EE1>, SPrime<E2, EE2>>::prove(
+    let res = CompressedSNARK::<_, _, SPrime<E1, EE1>, _, _, SPrime<E2, EE2>>::prove(
       &pp,
       &pk,
       &recursive_snark,
@@ -1652,8 +1652,8 @@ mod tests {
     // produce public parameters
     let pp = PublicParams::<
       E1,
-      E2,
       FifthRootCheckingCircuit<<E1 as Engine>::Scalar>,
+      E2,
       TrivialCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &circuit_primary,
@@ -1669,15 +1669,10 @@ mod tests {
     let z0_secondary = vec![<E2 as Engine>::Scalar::ZERO];
 
     // produce a recursive SNARK
-    let mut recursive_snark: RecursiveSNARK<
+    let mut recursive_snark = RecursiveSNARK::<
       E1,
-      E2,
       FifthRootCheckingCircuit<<E1 as Engine>::Scalar>,
-      TrivialCircuit<<E2 as Engine>::Scalar>,
-    > = RecursiveSNARK::<
-      E1,
       E2,
-      FifthRootCheckingCircuit<<E1 as Engine>::Scalar>,
       TrivialCircuit<<E2 as Engine>::Scalar>,
     >::new(
       &pp,
@@ -1698,11 +1693,11 @@ mod tests {
     assert!(res.is_ok());
 
     // produce the prover and verifier keys for compressed snark
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S<E1, EE1>, S<E2, EE2>>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, S<E1, EE1>, _, _, S<E2, EE2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
     let res =
-      CompressedSNARK::<_, _, _, _, S<E1, EE1>, S<E2, EE2>>::prove(&pp, &pk, &recursive_snark);
+      CompressedSNARK::<_, _, S<E1, EE1>, _, _, S<E2, EE2>>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 
@@ -1731,8 +1726,8 @@ mod tests {
     // produce public parameters
     let pp = PublicParams::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::setup(
       &test_circuit1,
@@ -1746,8 +1741,8 @@ mod tests {
     // produce a recursive SNARK
     let mut recursive_snark = RecursiveSNARK::<
       E1,
-      E2,
       TrivialCircuit<<E1 as Engine>::Scalar>,
+      E2,
       CubicCircuit<<E2 as Engine>::Scalar>,
     >::new(
       &pp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@ where
   circuit_shape_secondary: R1CSWithArity<SecEng<E1>>,
   augmented_circuit_params_primary: NovaAugmentedCircuitParams,
   augmented_circuit_params_secondary: NovaAugmentedCircuitParams,
-  _p: PhantomData<(C1, C2)>,
 }
 
 #[cfg(feature = "abomonate")]
@@ -167,7 +166,6 @@ where
       circuit_shape_secondary: value.circuit_shape_secondary,
       augmented_circuit_params_primary: value.augmented_circuit_params_primary,
       augmented_circuit_params_secondary: value.augmented_circuit_params_secondary,
-      _p: PhantomData,
     })
   }
 }
@@ -192,7 +190,6 @@ where
       augmented_circuit_params_primary: value.augmented_circuit_params_primary,
       augmented_circuit_params_secondary: value.augmented_circuit_params_secondary,
       digest: OnceCell::new(),
-      _p: PhantomData,
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,8 +451,7 @@ where
     let l_w_secondary = w_secondary;
     let l_u_secondary = u_secondary;
     let r_W_secondary = RelaxedR1CSWitness::<Dual<E1>>::default(r1cs_secondary);
-    let r_U_secondary =
-      RelaxedR1CSInstance::<Dual<E1>>::default(&pp.ck_secondary, r1cs_secondary);
+    let r_U_secondary = RelaxedR1CSInstance::<Dual<E1>>::default(&pp.ck_secondary, r1cs_secondary);
 
     assert!(
       !(zi_primary.len() != pp.F_arity_primary || zi_secondary.len() != pp.F_arity_secondary),
@@ -506,10 +505,7 @@ where
   /// Create a new `RecursiveSNARK` (or updates the provided `RecursiveSNARK`)
   /// by executing a step of the incremental computation
   #[tracing::instrument(skip_all, name = "nova::RecursiveSNARK::prove_step")]
-  pub fn prove_step<
-    C1: StepCircuit<E1::Scalar>,
-    C2: StepCircuit<<Dual<E1> as Engine>::Scalar>,
-  >(
+  pub fn prove_step<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<<Dual<E1> as Engine>::Scalar>>(
     &mut self,
     pp: &PublicParams<E1>,
     c_primary: &C1,
@@ -552,9 +548,7 @@ where
       Some(self.zi_primary.clone()),
       Some(r_U_secondary_i),
       Some(l_u_secondary_i),
-      Some(Commitment::<Dual<E1>>::decompress(
-        &nifs_secondary.comm_T,
-      )?),
+      Some(Commitment::<Dual<E1>>::decompress(&nifs_secondary.comm_T)?),
     );
 
     let circuit_primary: NovaAugmentedCircuit<'_, Dual<E1>, C1> = NovaAugmentedCircuit::new(
@@ -991,8 +985,7 @@ pub fn circuit_digest<E1: CurveCycleEquipped, C: StepCircuit<E1::Scalar>>(
   let augmented_circuit_params = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
 
   // ro_consts_circuit are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
-  let ro_consts_circuit: ROConstantsCircuit<Dual<E1>> =
-    ROConstantsCircuit::<Dual<E1>>::default();
+  let ro_consts_circuit: ROConstantsCircuit<Dual<E1>> = ROConstantsCircuit::<Dual<E1>>::default();
 
   // Initialize ck for the primary
   let augmented_circuit: NovaAugmentedCircuit<'_, Dual<E1>, C> =
@@ -1638,10 +1631,7 @@ mod tests {
     let (zn_primary, zn_secondary) = res.unwrap();
 
     assert_eq!(zn_primary, vec![<E1 as Engine>::Scalar::ONE]);
-    assert_eq!(
-      zn_secondary,
-      vec![<Dual<E1> as Engine>::Scalar::from(5u64)]
-    );
+    assert_eq!(zn_secondary, vec![<Dual<E1> as Engine>::Scalar::from(5u64)]);
   }
 
   #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     poseidon::{PoseidonRO, PoseidonROCircuit},
     secp_secq::{secp256k1, secq256k1},
   },
-  traits::Engine,
+  traits::{CurveCycleEquipped, Engine},
 };
 use halo2curves::bn256::Bn256;
 use pasta_curves::{pallas, vesta};
@@ -90,6 +90,18 @@ impl Engine for Bn256EngineKZG {
   type CE = KZGCommitmentEngine<Bn256>;
 }
 
+impl CurveCycleEquipped for Bn256Engine {
+  type Secondary = GrumpkinEngine;
+}
+
+impl CurveCycleEquipped for Bn256EngineKZG {
+  type Secondary = GrumpkinEngine;
+}
+
+impl CurveCycleEquipped for Bn256EngineZM {
+  type Secondary = GrumpkinEngine;
+}
+
 /// An implementation of the Nova `Engine` trait with Secp256k1 curve and Pedersen commitment scheme
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Secp256k1Engine;
@@ -118,6 +130,10 @@ impl Engine for Secq256k1Engine {
   type CE = PedersenCommitmentEngine<Self>;
 }
 
+impl CurveCycleEquipped for Secp256k1Engine {
+  type Secondary = Secq256k1Engine;
+}
+
 /// An implementation of the Nova `Engine` trait with Pallas curve and Pedersen commitment scheme
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PallasEngine;
@@ -144,6 +160,10 @@ impl Engine for VestaEngine {
   type ROCircuit = PoseidonROCircuit<Self::Base>;
   type TE = Keccak256Transcript<Self>;
   type CE = PedersenCommitmentEngine<Self>;
+}
+
+impl CurveCycleEquipped for PallasEngine {
+  type Secondary = VestaEngine;
 }
 
 #[cfg(test)]

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -713,7 +713,7 @@ mod tests {
       Secp256k1Engine, Secq256k1Engine, VestaEngine,
     },
     supernova::circuit::TrivialTestCircuit,
-    traits::{snark::default_ck_hint, CurveCycleEquipped, SecEng},
+    traits::{snark::default_ck_hint, CurveCycleEquipped, Dual},
   };
   use expect_test::{expect, Expect};
 
@@ -721,7 +721,7 @@ mod tests {
   fn test_supernova_recursive_circuit_with<E1>(
     primary_params: &SuperNovaAugmentedCircuitParams,
     secondary_params: &SuperNovaAugmentedCircuitParams,
-    ro_consts1: ROConstantsCircuit<SecEng<E1>>,
+    ro_consts1: ROConstantsCircuit<Dual<E1>>,
     ro_consts2: ROConstantsCircuit<E1>,
     num_constraints_primary: &Expect,
     num_constraints_secondary: &Expect,
@@ -733,8 +733,8 @@ mod tests {
     // Initialize the shape and ck for the primary
     let circuit1: SuperNovaAugmentedCircuit<
       '_,
-      SecEng<E1>,
-      TrivialTestCircuit<<SecEng<E1> as Engine>::Base>,
+      Dual<E1>,
+      TrivialTestCircuit<<Dual<E1> as Engine>::Base>,
     > = SuperNovaAugmentedCircuit::new(
       primary_params,
       None,
@@ -758,17 +758,17 @@ mod tests {
         ro_consts2.clone(),
         num_augmented_circuits,
       );
-    let mut cs: TestShapeCS<SecEng<E1>> = TestShapeCS::new();
+    let mut cs: TestShapeCS<Dual<E1>> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
 
     num_constraints_secondary.assert_eq(&cs.num_constraints().to_string());
 
     // Execute the base case for the primary
-    let zero1 = <<SecEng<E1> as Engine>::Base as Field>::ZERO;
+    let zero1 = <<Dual<E1> as Engine>::Base as Field>::ZERO;
     let mut cs1 = SatisfyingAssignment::<E1>::new();
     let vzero1 = vec![zero1];
-    let inputs1: SuperNovaAugmentedCircuitInputs<'_, SecEng<E1>> =
+    let inputs1: SuperNovaAugmentedCircuitInputs<'_, Dual<E1>> =
       SuperNovaAugmentedCircuitInputs::new(
         scalar_as_base::<E1>(zero1), // pass zero for testing
         zero1,
@@ -782,8 +782,8 @@ mod tests {
       );
     let circuit1: SuperNovaAugmentedCircuit<
       '_,
-      SecEng<E1>,
-      TrivialTestCircuit<<SecEng<E1> as Engine>::Base>,
+      Dual<E1>,
+      TrivialTestCircuit<<Dual<E1> as Engine>::Base>,
     > = SuperNovaAugmentedCircuit::new(
       primary_params,
       Some(inputs1),
@@ -798,10 +798,10 @@ mod tests {
 
     // Execute the base case for the secondary
     let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
-    let mut cs2 = SatisfyingAssignment::<SecEng<E1>>::new();
+    let mut cs2 = SatisfyingAssignment::<Dual<E1>>::new();
     let vzero2 = vec![zero2];
     let inputs2: SuperNovaAugmentedCircuitInputs<'_, E1> = SuperNovaAugmentedCircuitInputs::new(
-      scalar_as_base::<SecEng<E1>>(zero2), // pass zero for testing
+      scalar_as_base::<Dual<E1>>(zero2), // pass zero for testing
       zero2,
       &vzero2,
       None,

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -709,38 +709,39 @@ mod tests {
     constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
     gadgets::utils::scalar_as_base,
     provider::{
-      poseidon::PoseidonConstantsCircuit,
-      {Bn256Engine, GrumpkinEngine}, {PallasEngine, VestaEngine},
-      {Secp256k1Engine, Secq256k1Engine},
+      poseidon::PoseidonConstantsCircuit, Bn256Engine, GrumpkinEngine, PallasEngine,
+      Secp256k1Engine, Secq256k1Engine, VestaEngine,
     },
     supernova::circuit::TrivialTestCircuit,
-    traits::snark::default_ck_hint,
+    traits::{snark::default_ck_hint, CurveCycleEquipped, SecEng},
   };
   use expect_test::{expect, Expect};
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
-  fn test_supernova_recursive_circuit_with<E1, E2>(
+  fn test_supernova_recursive_circuit_with<E1>(
     primary_params: &SuperNovaAugmentedCircuitParams,
     secondary_params: &SuperNovaAugmentedCircuitParams,
-    ro_consts1: ROConstantsCircuit<E2>,
+    ro_consts1: ROConstantsCircuit<SecEng<E1>>,
     ro_consts2: ROConstantsCircuit<E1>,
     num_constraints_primary: &Expect,
     num_constraints_secondary: &Expect,
     num_augmented_circuits: usize,
   ) where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
+    E1: CurveCycleEquipped,
   {
     let tc1 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the primary
-    let circuit1: SuperNovaAugmentedCircuit<'_, E2, TrivialTestCircuit<<E2 as Engine>::Base>> =
-      SuperNovaAugmentedCircuit::new(
-        primary_params,
-        None,
-        &tc1,
-        ro_consts1.clone(),
-        num_augmented_circuits,
-      );
+    let circuit1: SuperNovaAugmentedCircuit<
+      '_,
+      SecEng<E1>,
+      TrivialTestCircuit<<SecEng<E1> as Engine>::Base>,
+    > = SuperNovaAugmentedCircuit::new(
+      primary_params,
+      None,
+      &tc1,
+      ro_consts1.clone(),
+      num_augmented_circuits,
+    );
     let mut cs: TestShapeCS<E1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape_and_key(&*default_ck_hint());
@@ -757,35 +758,39 @@ mod tests {
         ro_consts2.clone(),
         num_augmented_circuits,
       );
-    let mut cs: TestShapeCS<E2> = TestShapeCS::new();
+    let mut cs: TestShapeCS<SecEng<E1>> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape_and_key(&*default_ck_hint());
 
     num_constraints_secondary.assert_eq(&cs.num_constraints().to_string());
 
     // Execute the base case for the primary
-    let zero1 = <<E2 as Engine>::Base as Field>::ZERO;
+    let zero1 = <<SecEng<E1> as Engine>::Base as Field>::ZERO;
     let mut cs1 = SatisfyingAssignment::<E1>::new();
     let vzero1 = vec![zero1];
-    let inputs1: SuperNovaAugmentedCircuitInputs<'_, E2> = SuperNovaAugmentedCircuitInputs::new(
-      scalar_as_base::<E1>(zero1), // pass zero for testing
-      zero1,
-      &vzero1,
-      None,
-      None,
-      None,
-      None,
-      Some(zero1),
-      zero1,
-    );
-    let circuit1: SuperNovaAugmentedCircuit<'_, E2, TrivialTestCircuit<<E2 as Engine>::Base>> =
-      SuperNovaAugmentedCircuit::new(
-        primary_params,
-        Some(inputs1),
-        &tc1,
-        ro_consts1,
-        num_augmented_circuits,
+    let inputs1: SuperNovaAugmentedCircuitInputs<'_, SecEng<E1>> =
+      SuperNovaAugmentedCircuitInputs::new(
+        scalar_as_base::<E1>(zero1), // pass zero for testing
+        zero1,
+        &vzero1,
+        None,
+        None,
+        None,
+        None,
+        Some(zero1),
+        zero1,
       );
+    let circuit1: SuperNovaAugmentedCircuit<
+      '_,
+      SecEng<E1>,
+      TrivialTestCircuit<<SecEng<E1> as Engine>::Base>,
+    > = SuperNovaAugmentedCircuit::new(
+      primary_params,
+      Some(inputs1),
+      &tc1,
+      ro_consts1,
+      num_augmented_circuits,
+    );
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable
@@ -793,10 +798,10 @@ mod tests {
 
     // Execute the base case for the secondary
     let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
-    let mut cs2 = SatisfyingAssignment::<E2>::new();
+    let mut cs2 = SatisfyingAssignment::<SecEng<E1>>::new();
     let vzero2 = vec![zero2];
     let inputs2: SuperNovaAugmentedCircuitInputs<'_, E1> = SuperNovaAugmentedCircuitInputs::new(
-      scalar_as_base::<E2>(zero2), // pass zero for testing
+      scalar_as_base::<SecEng<E1>>(zero2), // pass zero for testing
       zero2,
       &vzero2,
       None,
@@ -828,7 +833,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<VestaEngine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
 
-    test_supernova_recursive_circuit_with::<PallasEngine, VestaEngine>(
+    test_supernova_recursive_circuit_with::<PallasEngine>(
       &params1,
       &params2,
       ro_consts1,
@@ -847,7 +852,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<GrumpkinEngine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
 
-    test_supernova_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
+    test_supernova_recursive_circuit_with::<Bn256Engine>(
       &params1,
       &params2,
       ro_consts1,
@@ -866,7 +871,7 @@ mod tests {
     let ro_consts1: ROConstantsCircuit<Secq256k1Engine> = PoseidonConstantsCircuit::default();
     let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
 
-    test_supernova_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
+    test_supernova_recursive_circuit_with::<Secp256k1Engine>(
       &params1,
       &params2,
       ro_consts1,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -14,7 +14,7 @@ use crate::{
   scalar_as_base,
   traits::{
     commitment::{CommitmentEngineTrait, CommitmentTrait},
-    AbsorbInROTrait, CurveCycleEquipped, Engine, ROConstants, ROConstantsCircuit, ROTrait, Dual,
+    AbsorbInROTrait, CurveCycleEquipped, Dual, Engine, ROConstants, ROConstantsCircuit, ROTrait,
   },
   Commitment, CommitmentKey, R1CSWithArity,
 };
@@ -717,10 +717,7 @@ where
   /// executing a step of the incremental computation
   #[allow(clippy::too_many_arguments)]
   #[tracing::instrument(skip_all, name = "supernova::RecursiveSNARK::prove_step")]
-  pub fn prove_step<
-    C1: StepCircuit<E1::Scalar>,
-    C2: StepCircuit<<Dual<E1> as Engine>::Scalar>,
-  >(
+  pub fn prove_step<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<<Dual<E1> as Engine>::Scalar>>(
     &mut self,
     pp: &PublicParams<E1>,
     c_primary: &C1,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -82,7 +82,7 @@ impl<E: Engine> CircuitDigests<E> {
 /// A vector of [`R1CSWithArity`] adjoined to a set of [`PublicParams`]
 #[derive(Debug, Serialize)]
 #[serde(bound = "")]
-pub struct PublicParams<E1, E2, C1, C2>
+pub struct PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -213,7 +213,7 @@ where
   }
 }
 
-impl<E1, E2, C1, C2> Index<usize> for PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> Index<usize> for PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -227,7 +227,7 @@ where
   }
 }
 
-impl<E1, E2, C1, C2> SimpleDigestible for PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> SimpleDigestible for PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -236,7 +236,7 @@ where
 {
 }
 
-impl<E1, E2, C1, C2> PublicParams<E1, E2, C1, C2>
+impl<E1, C1, E2, C2> PublicParams<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -261,7 +261,7 @@ where
   /// * `ck_hint1`: A `CommitmentKeyHint` for `E1`, which is a function that provides a hint
   ///    for the number of generators required in the commitment scheme for the primary circuit.
   /// * `ck_hint2`: A `CommitmentKeyHint` for `E2`, similar to `ck_hint1`, but for the secondary circuit.
-  pub fn setup<NC: NonUniformCircuit<E1, E2, C1, C2>>(
+  pub fn setup<NC: NonUniformCircuit<E1, C1, E2, C2>>(
     non_uniform_circuit: &NC,
     ck_hint1: &CommitmentKeyHint<E1>,
     ck_hint2: &CommitmentKeyHint<E2>,
@@ -538,11 +538,11 @@ where
   /// iterate base step to get new instance of recursive SNARK
   #[allow(clippy::too_many_arguments)]
   pub fn new<
-    C0: NonUniformCircuit<E1, E2, C1, C2>,
+    C0: NonUniformCircuit<E1, C1, E2, C2>,
     C1: StepCircuit<E1::Scalar>,
     C2: StepCircuit<E2::Scalar>,
   >(
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     non_uniform_circuit: &C0,
     c_primary: &C1,
     c_secondary: &C2,
@@ -746,7 +746,7 @@ where
   #[tracing::instrument(skip_all, name = "supernova::RecursiveSNARK::prove_step")]
   pub fn prove_step<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<E2::Scalar>>(
     &mut self,
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     c_primary: &C1,
     c_secondary: &C2,
   ) -> Result<(), SuperNovaError> {
@@ -933,7 +933,7 @@ where
   /// verify recursive snark
   pub fn verify<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<E2::Scalar>>(
     &self,
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
     z0_primary: &[E1::Scalar],
     z0_secondary: &[E2::Scalar],
   ) -> Result<(Vec<E1::Scalar>, Vec<E2::Scalar>), SuperNovaError> {
@@ -1131,7 +1131,7 @@ where
 /// SuperNova helper trait, for implementors that provide sets of sub-circuits to be proved via NIVC. `C1` must be a
 /// type (likely an `Enum`) for which a potentially-distinct instance can be supplied for each `index` below
 /// `self.num_circuits()`.
-pub trait NonUniformCircuit<E1, E2, C1, C2>
+pub trait NonUniformCircuit<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -1154,7 +1154,7 @@ where
 }
 
 /// Extension trait to simplify getting scalar form of initial circuit index.
-trait InitialProgramCounter<E1, E2, C1, C2>: NonUniformCircuit<E1, E2, C1, C2>
+trait InitialProgramCounter<E1, C1, E2, C2>: NonUniformCircuit<E1, C1, E2, C2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -1167,7 +1167,7 @@ where
   }
 }
 
-impl<E1, E2, C1, C2, T: NonUniformCircuit<E1, E2, C1, C2>> InitialProgramCounter<E1, E2, C1, C2>
+impl<E1, C1, E2, C2, T: NonUniformCircuit<E1, C1, E2, C2>> InitialProgramCounter<E1, C1, E2, C2>
   for T
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -1149,11 +1149,7 @@ impl<E1: CurveCycleEquipped, T: NonUniformCircuit<E1>> InitialProgramCounter<E1>
 ///
 /// Note for callers: This function should be called with its performance characteristics in mind.
 /// It will synthesize and digest the full `circuit` given.
-pub fn circuit_digest<
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C: StepCircuit<E1::Scalar>,
->(
+pub fn circuit_digest<E1: CurveCycleEquipped, C: StepCircuit<E1::Scalar>>(
   circuit: &C,
   num_augmented_circuits: usize,
 ) -> E1::Scalar {
@@ -1161,16 +1157,17 @@ pub fn circuit_digest<
     SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
 
   // ro_consts_circuit are parameterized by E2 because the type alias uses E2::Base = E1::Scalar
-  let ro_consts_circuit: ROConstantsCircuit<E2> = ROConstantsCircuit::<E2>::default();
+  let ro_consts_circuit = ROConstantsCircuit::<SecEng<E1>>::default();
 
   // Initialize ck for the primary
-  let augmented_circuit: SuperNovaAugmentedCircuit<'_, E2, C> = SuperNovaAugmentedCircuit::new(
-    &augmented_circuit_params,
-    None,
-    circuit,
-    ro_consts_circuit,
-    num_augmented_circuits,
-  );
+  let augmented_circuit: SuperNovaAugmentedCircuit<'_, SecEng<E1>, C> =
+    SuperNovaAugmentedCircuit::new(
+      &augmented_circuit_params,
+      None,
+      circuit,
+      ro_consts_circuit,
+      num_augmented_circuits,
+    );
   let mut cs: ShapeCS<E1> = ShapeCS::new();
   let _ = augmented_circuit.synthesize(&mut cs);
 

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("./Readme.md")]
 
-use std::marker::PhantomData;
 use std::ops::Index;
 
 use crate::{
@@ -15,7 +14,7 @@ use crate::{
   scalar_as_base,
   traits::{
     commitment::{CommitmentEngineTrait, CommitmentTrait},
-    AbsorbInROTrait, Engine, ROConstants, ROConstantsCircuit, ROTrait,
+    AbsorbInROTrait, CurveCycleEquipped, Engine, ROConstants, ROConstantsCircuit, ROTrait, SecEng,
   },
   Commitment, CommitmentKey, R1CSWithArity,
 };
@@ -82,31 +81,27 @@ impl<E: Engine> CircuitDigests<E> {
 /// A vector of [`R1CSWithArity`] adjoined to a set of [`PublicParams`]
 #[derive(Debug, Serialize)]
 #[serde(bound = "")]
-pub struct PublicParams<E1, C1, E2, C2>
+pub struct PublicParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
 {
   /// The internal circuit shapes
   circuit_shapes: Vec<R1CSWithArity<E1>>,
 
   ro_consts_primary: ROConstants<E1>,
-  ro_consts_circuit_primary: ROConstantsCircuit<E2>,
+  ro_consts_circuit_primary: ROConstantsCircuit<SecEng<E1>>,
   ck_primary: Arc<CommitmentKey<E1>>, // This is shared between all circuit params
   augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
 
-  ro_consts_secondary: ROConstants<E2>,
+  ro_consts_secondary: ROConstants<SecEng<E1>>,
   ro_consts_circuit_secondary: ROConstantsCircuit<E1>,
-  ck_secondary: Arc<CommitmentKey<E2>>,
-  circuit_shape_secondary: R1CSWithArity<E2>,
+  ck_secondary: Arc<CommitmentKey<SecEng<E1>>>,
+  circuit_shape_secondary: R1CSWithArity<SecEng<E1>>,
   augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
 
   /// Digest constructed from this `PublicParams`' parameters
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<E1::Scalar>,
-  _p: PhantomData<(C1, C2)>,
 }
 
 /// Auxiliary [`PublicParams`] information about the commitment keys and
@@ -114,20 +109,19 @@ where
 /// [`PublicParams`] downstream in lurk.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(bound = "")]
-pub struct AuxParams<E1, E2>
+pub struct AuxParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
   ro_consts_primary: ROConstants<E1>,
-  ro_consts_circuit_primary: ROConstantsCircuit<E2>,
+  ro_consts_circuit_primary: ROConstantsCircuit<SecEng<E1>>,
   ck_primary: Arc<CommitmentKey<E1>>, // This is shared between all circuit params
   augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
 
-  ro_consts_secondary: ROConstants<E2>,
+  ro_consts_secondary: ROConstants<SecEng<E1>>,
   ro_consts_circuit_secondary: ROConstantsCircuit<E1>,
-  ck_secondary: Arc<CommitmentKey<E2>>,
-  circuit_shape_secondary: R1CSWithArity<E2>,
+  ck_secondary: Arc<CommitmentKey<SecEng<E1>>>,
+  circuit_shape_secondary: R1CSWithArity<SecEng<E1>>,
   augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
 
   digest: E1::Scalar,
@@ -138,25 +132,23 @@ where
 #[derive(Debug, Clone, PartialEq, Abomonation)]
 #[abomonation_bounds(
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
   <E1::Scalar as PrimeField>::Repr: Abomonation,
-  <E2::Scalar as PrimeField>::Repr: Abomonation,
+  <<SecEng<E1> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
 )]
-pub struct FlatAuxParams<E1, E2>
+pub struct FlatAuxParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
   ro_consts_primary: ROConstants<E1>,
-  ro_consts_circuit_primary: ROConstantsCircuit<E2>,
+  ro_consts_circuit_primary: ROConstantsCircuit<SecEng<E1>>,
   ck_primary: CommitmentKey<E1>, // This is shared between all circuit params
   augmented_circuit_params_primary: SuperNovaAugmentedCircuitParams,
 
-  ro_consts_secondary: ROConstants<E2>,
+  ro_consts_secondary: ROConstants<SecEng<E1>>,
   ro_consts_circuit_secondary: ROConstantsCircuit<E1>,
-  ck_secondary: CommitmentKey<E2>,
-  circuit_shape_secondary: R1CSWithArity<E2>,
+  ck_secondary: CommitmentKey<SecEng<E1>>,
+  circuit_shape_secondary: R1CSWithArity<SecEng<E1>>,
   augmented_circuit_params_secondary: SuperNovaAugmentedCircuitParams,
 
   #[abomonate_with(<E1::Scalar as PrimeField>::Repr)]
@@ -164,14 +156,13 @@ where
 }
 
 #[cfg(feature = "abomonate")]
-impl<E1, E2> TryFrom<AuxParams<E1, E2>> for FlatAuxParams<E1, E2>
+impl<E1> TryFrom<AuxParams<E1>> for FlatAuxParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
   type Error = &'static str;
 
-  fn try_from(value: AuxParams<E1, E2>) -> Result<Self, Self::Error> {
+  fn try_from(value: AuxParams<E1>) -> Result<Self, Self::Error> {
     let ck_primary =
       Arc::try_unwrap(value.ck_primary).map_err(|_| "Failed to unwrap Arc for ck_primary")?;
     let ck_secondary =
@@ -192,12 +183,11 @@ where
 }
 
 #[cfg(feature = "abomonate")]
-impl<E1, E2> From<FlatAuxParams<E1, E2>> for AuxParams<E1, E2>
+impl<E1> From<FlatAuxParams<E1>> for AuxParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
-  fn from(value: FlatAuxParams<E1, E2>) -> Self {
+  fn from(value: FlatAuxParams<E1>) -> Self {
     Self {
       ro_consts_primary: value.ro_consts_primary,
       ro_consts_circuit_primary: value.ro_consts_circuit_primary,
@@ -213,12 +203,9 @@ where
   }
 }
 
-impl<E1, C1, E2, C2> Index<usize> for PublicParams<E1, C1, E2, C2>
+impl<E1> Index<usize> for PublicParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
 {
   type Output = R1CSWithArity<E1>;
 
@@ -227,21 +214,11 @@ where
   }
 }
 
-impl<E1, C1, E2, C2> SimpleDigestible for PublicParams<E1, C1, E2, C2>
-where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
-{
-}
+impl<E1> SimpleDigestible for PublicParams<E1> where E1: CurveCycleEquipped {}
 
-impl<E1, C1, E2, C2> PublicParams<E1, C1, E2, C2>
+impl<E1> PublicParams<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
 {
   /// Construct a new [`PublicParams`]
   ///
@@ -261,10 +238,10 @@ where
   /// * `ck_hint1`: A `CommitmentKeyHint` for `E1`, which is a function that provides a hint
   ///    for the number of generators required in the commitment scheme for the primary circuit.
   /// * `ck_hint2`: A `CommitmentKeyHint` for `E2`, similar to `ck_hint1`, but for the secondary circuit.
-  pub fn setup<NC: NonUniformCircuit<E1, C1, E2, C2>>(
+  pub fn setup<NC: NonUniformCircuit<E1>>(
     non_uniform_circuit: &NC,
     ck_hint1: &CommitmentKeyHint<E1>,
-    ck_hint2: &CommitmentKeyHint<E2>,
+    ck_hint2: &CommitmentKeyHint<SecEng<E1>>,
   ) -> Self {
     let num_circuits = non_uniform_circuit.num_circuits();
 
@@ -272,20 +249,22 @@ where
       SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let ro_consts_primary: ROConstants<E1> = ROConstants::<E1>::default();
     // ro_consts_circuit_primary are parameterized by E2 because the type alias uses E2::Base = E1::Scalar
-    let ro_consts_circuit_primary: ROConstantsCircuit<E2> = ROConstantsCircuit::<E2>::default();
+    let ro_consts_circuit_primary: ROConstantsCircuit<SecEng<E1>> =
+      ROConstantsCircuit::<SecEng<E1>>::default();
 
     let circuit_shapes = (0..num_circuits)
       .map(|i| {
         let c_primary = non_uniform_circuit.primary_circuit(i);
         let F_arity = c_primary.arity();
         // Initialize ck for the primary
-        let circuit_primary: SuperNovaAugmentedCircuit<'_, E2, C1> = SuperNovaAugmentedCircuit::new(
-          &augmented_circuit_params_primary,
-          None,
-          &c_primary,
-          ro_consts_circuit_primary.clone(),
-          num_circuits,
-        );
+        let circuit_primary: SuperNovaAugmentedCircuit<'_, SecEng<E1>, NC::C1> =
+          SuperNovaAugmentedCircuit::new(
+            &augmented_circuit_params_primary,
+            None,
+            &c_primary,
+            ro_consts_circuit_primary.clone(),
+            num_circuits,
+          );
         let mut cs: ShapeCS<E1> = ShapeCS::new();
         circuit_primary
           .synthesize(&mut cs)
@@ -302,19 +281,20 @@ where
 
     let augmented_circuit_params_secondary =
       SuperNovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
-    let ro_consts_secondary: ROConstants<E2> = ROConstants::<E2>::default();
+    let ro_consts_secondary = ROConstants::<SecEng<E1>>::default();
     let c_secondary = non_uniform_circuit.secondary_circuit();
     let F_arity_secondary = c_secondary.arity();
     let ro_consts_circuit_secondary: ROConstantsCircuit<E1> = ROConstantsCircuit::<E1>::default();
 
-    let circuit_secondary: SuperNovaAugmentedCircuit<'_, E1, C2> = SuperNovaAugmentedCircuit::new(
-      &augmented_circuit_params_secondary,
-      None,
-      &c_secondary,
-      ro_consts_circuit_secondary.clone(),
-      num_circuits,
-    );
-    let mut cs: ShapeCS<E2> = ShapeCS::new();
+    let circuit_secondary: SuperNovaAugmentedCircuit<'_, E1, NC::C2> =
+      SuperNovaAugmentedCircuit::new(
+        &augmented_circuit_params_secondary,
+        None,
+        &c_secondary,
+        ro_consts_circuit_secondary.clone(),
+        num_circuits,
+      );
+    let mut cs: ShapeCS<SecEng<E1>> = ShapeCS::new();
     circuit_secondary
       .synthesize(&mut cs)
       .expect("circuit synthesis failed");
@@ -334,7 +314,6 @@ where
       circuit_shape_secondary,
       augmented_circuit_params_secondary,
       digest: OnceCell::new(),
-      _p: PhantomData,
     };
 
     // make sure to initialize the `OnceCell` and compute the digest
@@ -344,7 +323,7 @@ where
   }
 
   /// Breaks down an instance of [`PublicParams`] into the circuit params and auxiliary params.
-  pub fn into_parts(self) -> (Vec<R1CSWithArity<E1>>, AuxParams<E1, E2>) {
+  pub fn into_parts(self) -> (Vec<R1CSWithArity<E1>>, AuxParams<E1>) {
     let digest = self.digest();
 
     let Self {
@@ -359,7 +338,6 @@ where
       circuit_shape_secondary,
       augmented_circuit_params_secondary,
       digest: _digest,
-      _p,
     } = self;
 
     let aux_params = AuxParams {
@@ -379,7 +357,7 @@ where
   }
 
   /// Create a [`PublicParams`] from a vector of raw [`R1CSWithArity`] and auxiliary params.
-  pub fn from_parts(circuit_shapes: Vec<R1CSWithArity<E1>>, aux_params: AuxParams<E1, E2>) -> Self {
+  pub fn from_parts(circuit_shapes: Vec<R1CSWithArity<E1>>, aux_params: AuxParams<E1>) -> Self {
     let pp = Self {
       circuit_shapes,
       ro_consts_primary: aux_params.ro_consts_primary,
@@ -392,7 +370,6 @@ where
       circuit_shape_secondary: aux_params.circuit_shape_secondary,
       augmented_circuit_params_secondary: aux_params.augmented_circuit_params_secondary,
       digest: OnceCell::new(),
-      _p: PhantomData,
     };
     assert_eq!(
       aux_params.digest,
@@ -406,7 +383,7 @@ where
   /// We don't check that the `aux_params.digest` is a valid digest for the created params.
   pub fn from_parts_unchecked(
     circuit_shapes: Vec<R1CSWithArity<E1>>,
-    aux_params: AuxParams<E1, E2>,
+    aux_params: AuxParams<E1>,
   ) -> Self {
     Self {
       circuit_shapes,
@@ -420,7 +397,6 @@ where
       circuit_shape_secondary: aux_params.circuit_shape_secondary,
       augmented_circuit_params_secondary: aux_params.augmented_circuit_params_secondary,
       digest: aux_params.digest.into(),
-      _p: PhantomData,
     }
   }
 
@@ -489,10 +465,9 @@ struct ResourceBuffer<E: Engine> {
 /// A SNARK that proves the correct execution of an non-uniform incremental computation
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RecursiveSNARK<E1, E2>
+pub struct RecursiveSNARK<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
   // Cached digest of the public parameters
   pp_digest: E1::Scalar,
@@ -512,7 +487,7 @@ where
   /// Buffer for memory needed by the primary fold-step
   buffer_primary: ResourceBuffer<E1>,
   /// Buffer for memory needed by the secondary fold-step
-  buffer_secondary: ResourceBuffer<E2>,
+  buffer_secondary: ResourceBuffer<SecEng<E1>>,
 
   // Relaxed instances for the primary circuits
   // Entries are `None` if the circuit has not been executed yet
@@ -520,34 +495,29 @@ where
   r_U_primary: Vec<Option<RelaxedR1CSInstance<E1>>>,
 
   // Inputs and outputs of the secondary circuit
-  z0_secondary: Vec<E2::Scalar>,
-  zi_secondary: Vec<E2::Scalar>,
+  z0_secondary: Vec<<SecEng<E1> as Engine>::Scalar>,
+  zi_secondary: Vec<<SecEng<E1> as Engine>::Scalar>,
   // Relaxed instance for the secondary circuit
-  r_W_secondary: RelaxedR1CSWitness<E2>,
-  r_U_secondary: RelaxedR1CSInstance<E2>,
+  r_W_secondary: RelaxedR1CSWitness<SecEng<E1>>,
+  r_U_secondary: RelaxedR1CSInstance<SecEng<E1>>,
   // Proof for the secondary circuit to be accumulated into r_secondary in the next iteration
-  l_w_secondary: R1CSWitness<E2>,
-  l_u_secondary: R1CSInstance<E2>,
+  l_w_secondary: R1CSWitness<SecEng<E1>>,
+  l_u_secondary: R1CSInstance<SecEng<E1>>,
 }
 
-impl<E1, E2> RecursiveSNARK<E1, E2>
+impl<E1> RecursiveSNARK<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
+  E1: CurveCycleEquipped,
 {
   /// iterate base step to get new instance of recursive SNARK
   #[allow(clippy::too_many_arguments)]
-  pub fn new<
-    C0: NonUniformCircuit<E1, C1, E2, C2>,
-    C1: StepCircuit<E1::Scalar>,
-    C2: StepCircuit<E2::Scalar>,
-  >(
-    pp: &PublicParams<E1, C1, E2, C2>,
+  pub fn new<C0: NonUniformCircuit<E1>>(
+    pp: &PublicParams<E1>,
     non_uniform_circuit: &C0,
-    c_primary: &C1,
-    c_secondary: &C2,
+    c_primary: &C0::C1,
+    c_secondary: &C0::C2,
     z0_primary: &[E1::Scalar],
-    z0_secondary: &[E2::Scalar],
+    z0_secondary: &[<SecEng<E1> as Engine>::Scalar],
   ) -> Result<Self, SuperNovaError> {
     let num_augmented_circuits = non_uniform_circuit.num_circuits();
     let circuit_index = non_uniform_circuit.initial_circuit_index();
@@ -574,7 +544,7 @@ where
     // base case for the primary
     let mut cs_primary = SatisfyingAssignment::<E1>::new();
     let program_counter = E1::Scalar::from(circuit_index as u64);
-    let inputs_primary: SuperNovaAugmentedCircuitInputs<'_, E2> =
+    let inputs_primary: SuperNovaAugmentedCircuitInputs<'_, SecEng<E1>> =
       SuperNovaAugmentedCircuitInputs::new(
         scalar_as_base::<E1>(pp.digest()),
         E1::Scalar::ZERO,
@@ -587,13 +557,14 @@ where
         E1::Scalar::ZERO,      // u_index is always zero for the primary circuit
       );
 
-    let circuit_primary: SuperNovaAugmentedCircuit<'_, E2, C1> = SuperNovaAugmentedCircuit::new(
-      &pp.augmented_circuit_params_primary,
-      Some(inputs_primary),
-      c_primary,
-      pp.ro_consts_circuit_primary.clone(),
-      num_augmented_circuits,
-    );
+    let circuit_primary: SuperNovaAugmentedCircuit<'_, SecEng<E1>, C0::C1> =
+      SuperNovaAugmentedCircuit::new(
+        &pp.augmented_circuit_params_primary,
+        Some(inputs_primary),
+        c_primary,
+        pp.ro_consts_circuit_primary.clone(),
+        num_augmented_circuits,
+      );
 
     let (zi_primary_pc_next, zi_primary) =
       circuit_primary.synthesize(&mut cs_primary).map_err(|err| {
@@ -613,12 +584,12 @@ where
       })?;
 
     // base case for the secondary
-    let mut cs_secondary = SatisfyingAssignment::<E2>::new();
-    let u_primary_index = E2::Scalar::from(circuit_index as u64);
+    let mut cs_secondary = SatisfyingAssignment::<SecEng<E1>>::new();
+    let u_primary_index = <SecEng<E1> as Engine>::Scalar::from(circuit_index as u64);
     let inputs_secondary: SuperNovaAugmentedCircuitInputs<'_, E1> =
       SuperNovaAugmentedCircuitInputs::new(
         pp.digest(),
-        E2::Scalar::ZERO,
+        <SecEng<E1> as Engine>::Scalar::ZERO,
         z0_secondary,
         None,             // zi = None for basecase
         None,             // U = Empty list of accumulators for the primary circuits
@@ -627,13 +598,15 @@ where
         None,             // program_counter is always None for secondary circuit
         u_primary_index,  // index of the circuit proof u_primary
       );
-    let circuit_secondary: SuperNovaAugmentedCircuit<'_, E1, C2> = SuperNovaAugmentedCircuit::new(
-      &pp.augmented_circuit_params_secondary,
-      Some(inputs_secondary),
-      c_secondary,
-      pp.ro_consts_circuit_secondary.clone(),
-      num_augmented_circuits,
-    );
+
+    let circuit_secondary: SuperNovaAugmentedCircuit<'_, E1, C0::C2> =
+      SuperNovaAugmentedCircuit::new(
+        &pp.augmented_circuit_params_secondary,
+        Some(inputs_secondary),
+        c_secondary,
+        pp.ro_consts_circuit_secondary.clone(),
+        num_augmented_circuits,
+      );
     let (_, zi_secondary) = circuit_secondary
       .synthesize(&mut cs_secondary)
       .map_err(NovaError::from)?;
@@ -661,7 +634,7 @@ where
     let l_u_secondary = u_secondary;
 
     // Initialize relaxed instance/witness pair for the secondary circuit proofs
-    let r_W_secondary: RelaxedR1CSWitness<E2> = RelaxedR1CSWitness::<E2>::default(r1cs_secondary);
+    let r_W_secondary = RelaxedR1CSWitness::<SecEng<E1>>::default(r1cs_secondary);
     let r_U_secondary = RelaxedR1CSInstance::default(&*pp.ck_secondary, r1cs_secondary);
 
     // Outputs of the two circuits and next program counter thus far.
@@ -682,7 +655,7 @@ where
         v.get_value()
           .ok_or(NovaError::from(SynthesisError::AssignmentMissing).into())
       })
-      .collect::<Result<Vec<<E2 as Engine>::Scalar>, SuperNovaError>>()?;
+      .collect::<Result<Vec<<SecEng<E1> as Engine>::Scalar>, SuperNovaError>>()?;
 
     // handle the base case by initialize U_next in next round
     let r_W_primary_initial_list = (0..num_augmented_circuits)
@@ -714,7 +687,7 @@ where
       l_u: None,
       ABC_Z_1: R1CSResult::default(r1cs_secondary.num_cons),
       ABC_Z_2: R1CSResult::default(r1cs_secondary.num_cons),
-      T: r1cs::default_T::<E2>(r1cs_secondary.num_cons),
+      T: r1cs::default_T::<SecEng<E1>>(r1cs_secondary.num_cons),
     };
 
     Ok(Self {
@@ -744,9 +717,12 @@ where
   /// executing a step of the incremental computation
   #[allow(clippy::too_many_arguments)]
   #[tracing::instrument(skip_all, name = "supernova::RecursiveSNARK::prove_step")]
-  pub fn prove_step<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<E2::Scalar>>(
+  pub fn prove_step<
+    C1: StepCircuit<E1::Scalar>,
+    C2: StepCircuit<<SecEng<E1> as Engine>::Scalar>,
+  >(
     &mut self,
-    pp: &PublicParams<E1, C1, E2, C2>,
+    pp: &PublicParams<E1>,
     c_primary: &C1,
     c_secondary: &C2,
   ) -> Result<(), SuperNovaError> {
@@ -785,9 +761,9 @@ where
       pp[circuit_index].r1cs_shape.num_io + 1,
       pp[circuit_index].r1cs_shape.num_vars,
     );
-    let T: <<E2 as Engine>::CE as CommitmentEngineTrait<E2>>::Commitment =
-      Commitment::<E2>::decompress(&nifs_secondary.comm_T).map_err(SuperNovaError::NovaError)?;
-    let inputs_primary: SuperNovaAugmentedCircuitInputs<'_, E2> =
+    let T = Commitment::<SecEng<E1>>::decompress(&nifs_secondary.comm_T)
+      .map_err(SuperNovaError::NovaError)?;
+    let inputs_primary: SuperNovaAugmentedCircuitInputs<'_, SecEng<E1>> =
       SuperNovaAugmentedCircuitInputs::new(
         scalar_as_base::<E1>(self.pp_digest),
         E1::Scalar::from(self.i as u64),
@@ -800,13 +776,14 @@ where
         E1::Scalar::ZERO,
       );
 
-    let circuit_primary: SuperNovaAugmentedCircuit<'_, E2, C1> = SuperNovaAugmentedCircuit::new(
-      &pp.augmented_circuit_params_primary,
-      Some(inputs_primary),
-      c_primary,
-      pp.ro_consts_circuit_primary.clone(),
-      self.num_augmented_circuits,
-    );
+    let circuit_primary: SuperNovaAugmentedCircuit<'_, SecEng<E1>, C1> =
+      SuperNovaAugmentedCircuit::new(
+        &pp.augmented_circuit_params_primary,
+        Some(inputs_primary),
+        c_primary,
+        pp.ro_consts_circuit_primary.clone(),
+        self.num_augmented_circuits,
+      );
 
     let (zi_primary_pc_next, zi_primary) = circuit_primary
       .synthesize(&mut cs_primary)
@@ -854,7 +831,7 @@ where
     )
     .map_err(SuperNovaError::NovaError)?;
 
-    let mut cs_secondary = SatisfyingAssignment::<E2>::with_capacity(
+    let mut cs_secondary = SatisfyingAssignment::<SecEng<E1>>::with_capacity(
       pp.circuit_shape_secondary.r1cs_shape.num_io + 1,
       pp.circuit_shape_secondary.r1cs_shape.num_vars,
     );
@@ -863,14 +840,14 @@ where
     let inputs_secondary: SuperNovaAugmentedCircuitInputs<'_, E1> =
       SuperNovaAugmentedCircuitInputs::new(
         self.pp_digest,
-        E2::Scalar::from(self.i as u64),
+        <SecEng<E1> as Engine>::Scalar::from(self.i as u64),
         &self.z0_secondary,
         Some(&self.zi_secondary),
         Some(&r_U_primary_i),
         Some(&l_u_primary),
         Some(&binding),
         None, // pc is always None for secondary circuit
-        E2::Scalar::from(circuit_index as u64),
+        <SecEng<E1> as Engine>::Scalar::from(circuit_index as u64),
       );
 
     let circuit_secondary: SuperNovaAugmentedCircuit<'_, E1, C2> = SuperNovaAugmentedCircuit::new(
@@ -910,7 +887,7 @@ where
         v.get_value()
           .ok_or(NovaError::from(SynthesisError::AssignmentMissing).into())
       })
-      .collect::<Result<Vec<<E2 as Engine>::Scalar>, SuperNovaError>>()?;
+      .collect::<Result<Vec<<SecEng<E1> as Engine>::Scalar>, SuperNovaError>>()?;
 
     if zi_primary.len() != pp[circuit_index].F_arity
       || zi_secondary.len() != pp.circuit_shape_secondary.F_arity
@@ -931,12 +908,12 @@ where
   }
 
   /// verify recursive snark
-  pub fn verify<C1: StepCircuit<E1::Scalar>, C2: StepCircuit<E2::Scalar>>(
+  pub fn verify(
     &self,
-    pp: &PublicParams<E1, C1, E2, C2>,
+    pp: &PublicParams<E1>,
     z0_primary: &[E1::Scalar],
-    z0_secondary: &[E2::Scalar],
-  ) -> Result<(Vec<E1::Scalar>, Vec<E2::Scalar>), SuperNovaError> {
+    z0_secondary: &[<SecEng<E1> as Engine>::Scalar],
+  ) -> Result<(Vec<E1::Scalar>, Vec<<SecEng<E1> as Engine>::Scalar>), SuperNovaError> {
     // number of steps cannot be zero
     if self.i == 0 {
       debug!("must verify on valid RecursiveSNARK where i > 0");
@@ -1016,7 +993,7 @@ where
         true, // is_primary
       );
 
-      let mut hasher = <E2 as Engine>::RO::new(pp.ro_consts_secondary.clone(), num_absorbs);
+      let mut hasher = <SecEng<E1> as Engine>::RO::new(pp.ro_consts_secondary.clone(), num_absorbs);
       hasher.absorb(self.pp_digest);
       hasher.absorb(E1::Scalar::from(self.i as u64));
       hasher.absorb(self.program_counter);
@@ -1041,7 +1018,7 @@ where
       );
       let mut hasher = <E1 as Engine>::RO::new(pp.ro_consts_primary.clone(), num_absorbs);
       hasher.absorb(scalar_as_base::<E1>(self.pp_digest));
-      hasher.absorb(E2::Scalar::from(self.i as u64));
+      hasher.absorb(<SecEng<E1> as Engine>::Scalar::from(self.i as u64));
 
       for e in z0_secondary {
         hasher.absorb(*e);
@@ -1068,7 +1045,7 @@ where
       );
       return Err(SuperNovaError::NovaError(NovaError::ProofVerifyError));
     }
-    if hash_secondary != scalar_as_base::<E2>(self.l_u_secondary.X[1]) {
+    if hash_secondary != scalar_as_base::<SecEng<E1>>(self.l_u_secondary.X[1]) {
       debug!(
         "hash_secondary {:?} not equal l_u_secondary.X[1] {:?}",
         hash_secondary, self.l_u_secondary.X[1]
@@ -1131,13 +1108,15 @@ where
 /// SuperNova helper trait, for implementors that provide sets of sub-circuits to be proved via NIVC. `C1` must be a
 /// type (likely an `Enum`) for which a potentially-distinct instance can be supplied for each `index` below
 /// `self.num_circuits()`.
-pub trait NonUniformCircuit<E1, C1, E2, C2>
+pub trait NonUniformCircuit<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
 {
+  /// The type of the step-circuits on the primary
+  type C1: StepCircuit<E1::Scalar>;
+  /// The type of the step-circuits on the secondary
+  type C2: StepCircuit<<SecEng<E1> as Engine>::Scalar>;
+
   /// Initial circuit index, defaults to zero.
   fn initial_circuit_index(&self) -> usize {
     0
@@ -1147,19 +1126,16 @@ where
   fn num_circuits(&self) -> usize;
 
   /// Return a new instance of the primary circuit at `index`.
-  fn primary_circuit(&self, circuit_index: usize) -> C1;
+  fn primary_circuit(&self, circuit_index: usize) -> Self::C1;
 
   /// Return a new instance of the secondary circuit.
-  fn secondary_circuit(&self) -> C2;
+  fn secondary_circuit(&self) -> Self::C2;
 }
 
 /// Extension trait to simplify getting scalar form of initial circuit index.
-trait InitialProgramCounter<E1, C1, E2, C2>: NonUniformCircuit<E1, C1, E2, C2>
+trait InitialProgramCounter<E1>: NonUniformCircuit<E1>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
 {
   /// Initial program counter is the initial circuit index as a `Scalar`.
   fn initial_program_counter(&self) -> E1::Scalar {
@@ -1167,15 +1143,7 @@ where
   }
 }
 
-impl<E1, C1, E2, C2, T: NonUniformCircuit<E1, C1, E2, C2>> InitialProgramCounter<E1, C1, E2, C2>
-  for T
-where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
-{
-}
+impl<E1: CurveCycleEquipped, T: NonUniformCircuit<E1>> InitialProgramCounter<E1> for T {}
 
 /// Compute the circuit digest of a supernova [`StepCircuit`].
 ///

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 
 /// A type that holds the prover key for `CompressedSNARK`
 #[derive(Debug)]
-pub struct ProverKey<E1, E2, C1, C2, S1, S2>
+pub struct ProverKey<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -34,7 +34,7 @@ where
 
 /// A type that holds the verifier key for `CompressedSNARK`
 #[derive(Debug)]
-pub struct VerifierKey<E1, E2, C1, C2, S1, S2>
+pub struct VerifierKey<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -51,7 +51,7 @@ where
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct CompressedSNARK<E1, E2, C1, C2, S1, S2>
+pub struct CompressedSNARK<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -73,10 +73,10 @@ where
 
   zn_primary: Vec<E1::Scalar>,
   zn_secondary: Vec<E2::Scalar>,
-  _p: PhantomData<(E1, E2, C1, C2, S1, S2)>,
+  _p: PhantomData<(E1, C1, S1, E2, C2, S2)>,
 }
 
-impl<E1, E2, C1, C2, S1, S2> CompressedSNARK<E1, E2, C1, C2, S1, S2>
+impl<E1, C1, S1, E2, C2, S2> CompressedSNARK<E1, C1, S1, E2, C2, S2>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
@@ -87,11 +87,11 @@ where
 {
   /// Creates prover and verifier keys for `CompressedSNARK`
   pub fn setup(
-    pp: &PublicParams<E1, E2, C1, C2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
   ) -> Result<
     (
-      ProverKey<E1, E2, C1, C2, S1, S2>,
-      VerifierKey<E1, E2, C1, C2, S1, S2>,
+      ProverKey<E1, C1, S1, E2, C2, S2>,
+      VerifierKey<E1, C1, S1, E2, C2, S2>,
     ),
     SuperNovaError,
   > {
@@ -118,8 +118,8 @@ where
 
   /// Create a new `CompressedSNARK`
   pub fn prove(
-    pp: &PublicParams<E1, E2, C1, C2>,
-    pk: &ProverKey<E1, E2, C1, C2, S1, S2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
+    pk: &ProverKey<E1, C1, S1, E2, C2, S2>,
     recursive_snark: &RecursiveSNARK<E1, E2>,
   ) -> Result<Self, SuperNovaError> {
     // fold the secondary circuit's instance
@@ -204,8 +204,8 @@ where
   /// Verify the correctness of the `CompressedSNARK`
   pub fn verify(
     &self,
-    pp: &PublicParams<E1, E2, C1, C2>,
-    vk: &VerifierKey<E1, E2, C1, C2, S1, S2>,
+    pp: &PublicParams<E1, C1, E2, C2>,
+    vk: &VerifierKey<E1, C1, S1, E2, C2, S2>,
     z0_primary: &[E1::Scalar],
     z0_secondary: &[E2::Scalar],
   ) -> Result<(Vec<E1::Scalar>, Vec<E2::Scalar>), SuperNovaError> {
@@ -466,7 +466,7 @@ mod test {
     }
   }
 
-  impl<E1, E2> NonUniformCircuit<E1, E2, Self, TrivialSecondaryCircuit<E2::Scalar>>
+  impl<E1, E2> NonUniformCircuit<E1, Self, E2, TrivialSecondaryCircuit<E2::Scalar>>
     for TestCircuit<E1>
   where
     E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -527,7 +527,7 @@ mod test {
       assert!(verify_res.is_ok());
     }
 
-    let (prover_key, verifier_key) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+    let (prover_key, verifier_key) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
 
     let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
 
@@ -652,7 +652,7 @@ mod test {
     }
   }
 
-  impl<E1, E2> NonUniformCircuit<E1, E2, Self, TrivialSecondaryCircuit<E2::Scalar>>
+  impl<E1, E2> NonUniformCircuit<E1, Self, E2, TrivialSecondaryCircuit<E2::Scalar>>
     for BigTestCircuit<E1>
   where
     E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -713,7 +713,7 @@ mod test {
       assert!(verify_res.is_ok());
     }
 
-    let (prover_key, verifier_key) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
+    let (prover_key, verifier_key) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
 
     let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
 

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -6,7 +6,7 @@ use crate::{
   r1cs::{R1CSInstance, RelaxedR1CSWitness},
   traits::{
     snark::{BatchedRelaxedR1CSSNARKTrait, RelaxedR1CSSNARKTrait},
-    AbsorbInROTrait, CurveCycleEquipped, Engine, ROTrait, Dual,
+    AbsorbInROTrait, CurveCycleEquipped, Dual, Engine, ROTrait,
   },
 };
 use crate::{errors::NovaError, scalar_as_base, RelaxedR1CSInstance, NIFS};

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -4,97 +4,74 @@ use super::{error::SuperNovaError, PublicParams, RecursiveSNARK};
 use crate::{
   constants::NUM_HASH_BITS,
   r1cs::{R1CSInstance, RelaxedR1CSWitness},
-  supernova::StepCircuit,
   traits::{
     snark::{BatchedRelaxedR1CSSNARKTrait, RelaxedR1CSSNARKTrait},
-    AbsorbInROTrait, Engine, ROTrait,
+    AbsorbInROTrait, CurveCycleEquipped, Engine, ROTrait, SecEng,
   },
 };
 use crate::{errors::NovaError, scalar_as_base, RelaxedR1CSInstance, NIFS};
 
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
 
 /// A type that holds the prover key for `CompressedSNARK`
 #[derive(Debug)]
-pub struct ProverKey<E1, C1, S1, E2, C2, S2>
+pub struct ProverKey<E1, S1, S2>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
   S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-  S2: RelaxedR1CSSNARKTrait<E2>,
+  S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
 {
   pk_primary: S1::ProverKey,
   pk_secondary: S2::ProverKey,
-  _p: PhantomData<(C1, C2)>,
 }
 
 /// A type that holds the verifier key for `CompressedSNARK`
 #[derive(Debug)]
-pub struct VerifierKey<E1, C1, S1, E2, C2, S2>
+pub struct VerifierKey<E1, S1, S2>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
   S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-  S2: RelaxedR1CSSNARKTrait<E2>,
+  S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
 {
   vk_primary: S1::VerifierKey,
   vk_secondary: S2::VerifierKey,
-  _p: PhantomData<(C1, C2)>,
 }
 
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct CompressedSNARK<E1, C1, S1, E2, C2, S2>
+pub struct CompressedSNARK<E1, S1, S2>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
   S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-  S2: RelaxedR1CSSNARKTrait<E2>,
+  S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
 {
   r_U_primary: Vec<RelaxedR1CSInstance<E1>>,
   r_W_snark_primary: S1,
 
-  r_U_secondary: RelaxedR1CSInstance<E2>,
-  l_u_secondary: R1CSInstance<E2>,
-  nifs_secondary: NIFS<E2>,
+  r_U_secondary: RelaxedR1CSInstance<SecEng<E1>>,
+  l_u_secondary: R1CSInstance<SecEng<E1>>,
+  nifs_secondary: NIFS<SecEng<E1>>,
   f_W_snark_secondary: S2,
 
   num_steps: usize,
   program_counter: E1::Scalar,
 
   zn_primary: Vec<E1::Scalar>,
-  zn_secondary: Vec<E2::Scalar>,
-  _p: PhantomData<(E1, C1, S1, E2, C2, S2)>,
+  zn_secondary: Vec<<SecEng<E1> as Engine>::Scalar>,
 }
 
-impl<E1, C1, S1, E2, C2, S2> CompressedSNARK<E1, C1, S1, E2, C2, S2>
+impl<E1, S1, S2> CompressedSNARK<E1, S1, S2>
 where
-  E1: Engine<Base = <E2 as Engine>::Scalar>,
-  E2: Engine<Base = <E1 as Engine>::Scalar>,
-  C1: StepCircuit<E1::Scalar>,
-  C2: StepCircuit<E2::Scalar>,
+  E1: CurveCycleEquipped,
   S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-  S2: RelaxedR1CSSNARKTrait<E2>,
+  S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
 {
   /// Creates prover and verifier keys for `CompressedSNARK`
   pub fn setup(
-    pp: &PublicParams<E1, C1, E2, C2>,
-  ) -> Result<
-    (
-      ProverKey<E1, C1, S1, E2, C2, S2>,
-      VerifierKey<E1, C1, S1, E2, C2, S2>,
-    ),
-    SuperNovaError,
-  > {
+    pp: &PublicParams<E1>,
+  ) -> Result<(ProverKey<E1, S1, S2>, VerifierKey<E1, S1, S2>), SuperNovaError> {
     let (pk_primary, vk_primary) = S1::setup(pp.ck_primary.clone(), pp.primary_r1cs_shapes())?;
 
     let (pk_secondary, vk_secondary) = S2::setup(
@@ -105,12 +82,10 @@ where
     let prover_key = ProverKey {
       pk_primary,
       pk_secondary,
-      _p: PhantomData,
     };
     let verifier_key = VerifierKey {
       vk_primary,
       vk_secondary,
-      _p: PhantomData,
     };
 
     Ok((prover_key, verifier_key))
@@ -118,9 +93,9 @@ where
 
   /// Create a new `CompressedSNARK`
   pub fn prove(
-    pp: &PublicParams<E1, C1, E2, C2>,
-    pk: &ProverKey<E1, C1, S1, E2, C2, S2>,
-    recursive_snark: &RecursiveSNARK<E1, E2>,
+    pp: &PublicParams<E1>,
+    pk: &ProverKey<E1, S1, S2>,
+    recursive_snark: &RecursiveSNARK<E1>,
   ) -> Result<Self, SuperNovaError> {
     // fold the secondary circuit's instance
     let res_secondary = NIFS::prove(
@@ -194,8 +169,6 @@ where
 
       zn_primary: recursive_snark.zi_primary.clone(),
       zn_secondary: recursive_snark.zi_secondary.clone(),
-
-      _p: PhantomData,
     };
 
     Ok(compressed_snark)
@@ -204,11 +177,11 @@ where
   /// Verify the correctness of the `CompressedSNARK`
   pub fn verify(
     &self,
-    pp: &PublicParams<E1, C1, E2, C2>,
-    vk: &VerifierKey<E1, C1, S1, E2, C2, S2>,
+    pp: &PublicParams<E1>,
+    vk: &VerifierKey<E1, S1, S2>,
     z0_primary: &[E1::Scalar],
-    z0_secondary: &[E2::Scalar],
-  ) -> Result<(Vec<E1::Scalar>, Vec<E2::Scalar>), SuperNovaError> {
+    z0_secondary: &[<SecEng<E1> as Engine>::Scalar],
+  ) -> Result<(Vec<E1::Scalar>, Vec<<SecEng<E1> as Engine>::Scalar>), SuperNovaError> {
     let last_circuit_idx = field_as_usize(self.program_counter);
 
     let num_field_primary_ro = 3 // params_next, i_new, program_counter_new
@@ -226,7 +199,7 @@ where
     // witnesses provided by the prover
     let (hash_primary, hash_secondary) = {
       let mut hasher =
-        <E2 as Engine>::RO::new(pp.ro_consts_secondary.clone(), num_field_primary_ro);
+        <SecEng<E1> as Engine>::RO::new(pp.ro_consts_secondary.clone(), num_field_primary_ro);
 
       hasher.absorb(pp.digest());
       hasher.absorb(E1::Scalar::from(self.num_steps as u64));
@@ -246,7 +219,7 @@ where
         <E1 as Engine>::RO::new(pp.ro_consts_primary.clone(), num_field_secondary_ro);
 
       hasher2.absorb(scalar_as_base::<E1>(pp.digest()));
-      hasher2.absorb(E2::Scalar::from(self.num_steps as u64));
+      hasher2.absorb(<SecEng<E1> as Engine>::Scalar::from(self.num_steps as u64));
 
       for e in z0_secondary {
         hasher2.absorb(*e);
@@ -271,7 +244,7 @@ where
       return Err(NovaError::ProofVerifyError.into());
     }
 
-    if hash_secondary != scalar_as_base::<E2>(self.l_u_secondary.X[1]) {
+    if hash_secondary != scalar_as_base::<SecEng<E1>>(self.l_u_secondary.X[1]) {
       return Err(NovaError::ProofVerifyError.into());
     }
 
@@ -309,17 +282,15 @@ fn field_as_usize<F: PrimeField>(x: F) -> usize {
 mod test {
   use super::*;
   use crate::{
-    provider::{
-      ipa_pc, Bn256Engine, GrumpkinEngine, PallasEngine, Secp256k1Engine, Secq256k1Engine,
-      VestaEngine,
-    },
+    provider::{ipa_pc, Bn256Engine, PallasEngine, Secp256k1Engine},
     spartan::{batched, batched_ppsnark, snark::RelaxedR1CSSNARK},
-    supernova::{circuit::TrivialSecondaryCircuit, NonUniformCircuit},
+    supernova::{circuit::TrivialSecondaryCircuit, NonUniformCircuit, StepCircuit},
   };
 
   use abomonation::Abomonation;
   use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
+  use std::marker::PhantomData;
 
   type EE<E> = ipa_pc::EvaluationEngine<E>;
   type S1<E> = batched::BatchedRelaxedR1CSSNARK<E, EE<E>>;
@@ -466,12 +437,10 @@ mod test {
     }
   }
 
-  impl<E1, E2> NonUniformCircuit<E1, Self, E2, TrivialSecondaryCircuit<E2::Scalar>>
-    for TestCircuit<E1>
-  where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
-  {
+  impl<E1: CurveCycleEquipped> NonUniformCircuit<E1> for TestCircuit<E1> {
+    type C1 = Self;
+    type C2 = TrivialSecondaryCircuit<<SecEng<E1> as Engine>::Scalar>;
+
     fn num_circuits(&self) -> usize {
       2
     }
@@ -484,19 +453,18 @@ mod test {
       }
     }
 
-    fn secondary_circuit(&self) -> TrivialSecondaryCircuit<E2::Scalar> {
+    fn secondary_circuit(&self) -> Self::C2 {
       Default::default()
     }
   }
 
-  fn test_nivc_trivial_with_compression_with<E1, E2, S1, S2>()
+  fn test_nivc_trivial_with_compression_with<E1, S1, S2>()
   where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
+    E1: CurveCycleEquipped,
     S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-    S2: RelaxedR1CSSNARKTrait<E2>,
+    S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
     <E1::Scalar as PrimeField>::Repr: Abomonation,
-    <E2::Scalar as PrimeField>::Repr: Abomonation,
+    <<SecEng<E1> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
   {
     const NUM_STEPS: usize = 6;
 
@@ -506,7 +474,7 @@ mod test {
     let pp = PublicParams::setup(&test_circuits[0], &*S1::ck_floor(), &*S2::ck_floor());
 
     let z0_primary = vec![E1::Scalar::from(17u64)];
-    let z0_secondary = vec![<E2 as Engine>::Scalar::ZERO];
+    let z0_secondary = vec![<SecEng<E1> as Engine>::Scalar::ZERO];
 
     let mut recursive_snark = RecursiveSNARK::new(
       &pp,
@@ -527,7 +495,7 @@ mod test {
       assert!(verify_res.is_ok());
     }
 
-    let (prover_key, verifier_key) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
+    let (prover_key, verifier_key) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
     let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
 
@@ -544,13 +512,13 @@ mod test {
   #[test]
   fn test_nivc_trivial_with_compression() {
     // ppSNARK
-    test_nivc_trivial_with_compression_with::<PallasEngine, VestaEngine, S1PP<_>, S2<_>>();
-    test_nivc_trivial_with_compression_with::<Bn256Engine, GrumpkinEngine, S1PP<_>, S2<_>>();
-    test_nivc_trivial_with_compression_with::<Secp256k1Engine, Secq256k1Engine, S1PP<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<PallasEngine, S1PP<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<Bn256Engine, S1PP<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<Secp256k1Engine, S1PP<_>, S2<_>>();
     // classic SNARK
-    test_nivc_trivial_with_compression_with::<PallasEngine, VestaEngine, S1<_>, S2<_>>();
-    test_nivc_trivial_with_compression_with::<Bn256Engine, GrumpkinEngine, S1<_>, S2<_>>();
-    test_nivc_trivial_with_compression_with::<Secp256k1Engine, Secq256k1Engine, S1<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<PallasEngine, S1<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<Bn256Engine, S1<_>, S2<_>>();
+    test_nivc_trivial_with_compression_with::<Secp256k1Engine, S1<_>, S2<_>>();
   }
 
   #[derive(Clone)]
@@ -652,12 +620,10 @@ mod test {
     }
   }
 
-  impl<E1, E2> NonUniformCircuit<E1, Self, E2, TrivialSecondaryCircuit<E2::Scalar>>
-    for BigTestCircuit<E1>
-  where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
-  {
+  impl<E1: CurveCycleEquipped> NonUniformCircuit<E1> for BigTestCircuit<E1> {
+    type C1 = Self;
+    type C2 = TrivialSecondaryCircuit<<SecEng<E1> as Engine>::Scalar>;
+
     fn num_circuits(&self) -> usize {
       2
     }
@@ -670,19 +636,18 @@ mod test {
       }
     }
 
-    fn secondary_circuit(&self) -> TrivialSecondaryCircuit<E2::Scalar> {
+    fn secondary_circuit(&self) -> Self::C2 {
       Default::default()
     }
   }
 
-  fn test_compression_with_circuit_size_difference_with<E1, E2, S1, S2>()
+  fn test_compression_with_circuit_size_difference_with<E1, S1, S2>()
   where
-    E1: Engine<Base = <E2 as Engine>::Scalar>,
-    E2: Engine<Base = <E1 as Engine>::Scalar>,
+    E1: CurveCycleEquipped,
     S1: BatchedRelaxedR1CSSNARKTrait<E1>,
-    S2: RelaxedR1CSSNARKTrait<E2>,
+    S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
     <E1::Scalar as PrimeField>::Repr: Abomonation,
-    <E2::Scalar as PrimeField>::Repr: Abomonation,
+    <<SecEng<E1> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
   {
     const NUM_STEPS: usize = 4;
 
@@ -692,7 +657,7 @@ mod test {
     let pp = PublicParams::setup(&test_circuits[0], &*S1::ck_floor(), &*S2::ck_floor());
 
     let z0_primary = vec![E1::Scalar::from(17u64)];
-    let z0_secondary = vec![<E2 as Engine>::Scalar::ZERO];
+    let z0_secondary = vec![<SecEng<E1> as Engine>::Scalar::ZERO];
 
     let mut recursive_snark = RecursiveSNARK::new(
       &pp,
@@ -713,7 +678,7 @@ mod test {
       assert!(verify_res.is_ok());
     }
 
-    let (prover_key, verifier_key) = CompressedSNARK::<_, _, S1, _, _, S2>::setup(&pp).unwrap();
+    let (prover_key, verifier_key) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
     let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
 
@@ -730,25 +695,12 @@ mod test {
   #[test]
   fn test_compression_with_circuit_size_difference() {
     // ppSNARK
-    test_compression_with_circuit_size_difference_with::<PallasEngine, VestaEngine, S1PP<_>, S2<_>>(
-    );
-    test_compression_with_circuit_size_difference_with::<Bn256Engine, GrumpkinEngine, S1PP<_>, S2<_>>(
-    );
-    test_compression_with_circuit_size_difference_with::<
-      Secp256k1Engine,
-      Secq256k1Engine,
-      S1PP<_>,
-      S2<_>,
-    >();
+    test_compression_with_circuit_size_difference_with::<PallasEngine, S1PP<_>, S2<_>>();
+    test_compression_with_circuit_size_difference_with::<Bn256Engine, S1PP<_>, S2<_>>();
+    test_compression_with_circuit_size_difference_with::<Secp256k1Engine, S1PP<_>, S2<_>>();
     // classic SNARK
-    test_compression_with_circuit_size_difference_with::<PallasEngine, VestaEngine, S1<_>, S2<_>>();
-    test_compression_with_circuit_size_difference_with::<Bn256Engine, GrumpkinEngine, S1<_>, S2<_>>(
-    );
-    test_compression_with_circuit_size_difference_with::<
-      Secp256k1Engine,
-      Secq256k1Engine,
-      S1<_>,
-      S2<_>,
-    >();
+    test_compression_with_circuit_size_difference_with::<PallasEngine, S1<_>, S2<_>>();
+    test_compression_with_circuit_size_difference_with::<Bn256Engine, S1<_>, S2<_>>();
+    test_compression_with_circuit_size_difference_with::<Secp256k1Engine, S1<_>, S2<_>>();
   }
 }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -226,9 +226,9 @@ where
   }
 }
 
-fn print_constraints_name_on_error_index<E1, E2, C1, C2>(
+fn print_constraints_name_on_error_index<E1, C1, E2, C2>(
   err: &SuperNovaError,
-  pp: &PublicParams<E1, E2, C1, C2>,
+  pp: &PublicParams<E1, C1, E2, C2>,
   c_primary: &C1,
   c_secondary: &C2,
   num_augmented_circuits: usize,
@@ -318,7 +318,7 @@ impl<F: PrimeField> StepCircuit<F> for TestROMCircuit<F> {
 }
 
 impl<E1, E2>
-  NonUniformCircuit<E1, E2, TestROMCircuit<E1::Scalar>, TrivialSecondaryCircuit<E2::Scalar>>
+  NonUniformCircuit<E1, TestROMCircuit<E1::Scalar>, E2, TrivialSecondaryCircuit<E2::Scalar>>
   for TestROM<E1, E2, TrivialSecondaryCircuit<E2::Scalar>>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -575,19 +575,19 @@ fn test_recursive_circuit() {
   );
 }
 
-fn test_pp_digest_with<E1, E2, T1, T2, NC>(non_uniform_circuit: &NC, expected: &Expect)
+fn test_pp_digest_with<E1, E2, C1, C2, NC>(non_uniform_circuit: &NC, expected: &Expect)
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
   E2: Engine<Base = <E1 as Engine>::Scalar>,
-  T1: StepCircuit<E1::Scalar>,
-  T2: StepCircuit<E2::Scalar>,
-  NC: NonUniformCircuit<E1, E2, T1, T2>,
+  C1: StepCircuit<E1::Scalar>,
+  C2: StepCircuit<E2::Scalar>,
+  NC: NonUniformCircuit<E1, C1, E2, C2>,
 {
   // TODO: add back in https://github.com/lurk-lab/arecibo/issues/53
   // // this tests public parameters with a size specifically intended for a spark-compressed SNARK
   // let pp_hint1 = Some(SPrime::<G1>::commitment_key_floor());
   // let pp_hint2 = Some(SPrime::<G2>::commitment_key_floor());
-  let pp = PublicParams::<E1, E2, T1, T2>::setup(
+  let pp = PublicParams::<E1, C1, E2, C2>::setup(
     non_uniform_circuit,
     &*default_ck_hint(),
     &*default_ck_hint(),
@@ -816,7 +816,7 @@ where
   }
 }
 
-impl<E1, E2> NonUniformCircuit<E1, E2, Self, TrivialSecondaryCircuit<E1::Base>>
+impl<E1, E2> NonUniformCircuit<E1, Self, E2, TrivialSecondaryCircuit<E1::Base>>
   for RootCheckingCircuit<E1::Scalar>
 where
   E1: Engine<Base = <E2 as Engine>::Scalar>,
@@ -859,8 +859,8 @@ where
   // produce public parameters
   let pp = PublicParams::<
     E1,
-    E2,
     RootCheckingCircuit<<E1 as Engine>::Scalar>,
+    E2,
     TrivialSecondaryCircuit<<E2 as Engine>::Scalar>,
   >::setup(&roots[0], &*default_ck_hint(), &*default_ck_hint());
   // produce a recursive SNARK

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -496,18 +496,17 @@ fn test_recursive_circuit_with<E1>(
   let zero1 = <<Dual<E1> as Engine>::Base as Field>::ZERO;
   let z0 = vec![zero1; arity1];
   let mut cs1 = SatisfyingAssignment::<E1>::new();
-  let inputs1: SuperNovaAugmentedCircuitInputs<'_, Dual<E1>> =
-    SuperNovaAugmentedCircuitInputs::new(
-      scalar_as_base::<E1>(zero1), // pass zero for testing
-      zero1,
-      &z0,
-      None,
-      None,
-      None,
-      None,
-      Some(zero1),
-      zero1,
-    );
+  let inputs1: SuperNovaAugmentedCircuitInputs<'_, Dual<E1>> = SuperNovaAugmentedCircuitInputs::new(
+    scalar_as_base::<E1>(zero1), // pass zero for testing
+    zero1,
+    &z0,
+    None,
+    None,
+    None,
+    None,
+    Some(zero1),
+    zero1,
+  );
   let step_circuit = TrivialTestCircuit::default();
   let circuit1: SuperNovaAugmentedCircuit<
     '_,

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -57,11 +57,11 @@ pub trait Engine: Clone + Copy + Debug + Send + Sync + Sized + Eq + PartialEq {
 
 /// This is a convenience trait to pair engines which fields are in a curve cycle relationship
 pub trait CurveCycleEquipped: Engine {
-  /// The secondary Engine of `Self`
+  /// The secondary `Engine` of `Self`
   type Secondary: Engine<Base = <Self as Engine>::Scalar, Scalar = <Self as Engine>::Base>;
 }
 
-/// Convenience projection to the Secondary Engine of a CurveCycleEquipped
+/// Convenience projection to the secondary `Engine` of a `CurveCycleEquipped`
 pub type Dual<E> = <E as CurveCycleEquipped>::Secondary;
 
 /// A helper trait to absorb different objects in RO

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -62,7 +62,7 @@ pub trait CurveCycleEquipped: Engine {
 }
 
 /// Convenience projection to the Secondary Engine of a CurveCycleEquipped
-pub type SecEng<E> = <E as CurveCycleEquipped>::Secondary;
+pub type Dual<E> = <E as CurveCycleEquipped>::Secondary;
 
 /// A helper trait to absorb different objects in RO
 pub trait AbsorbInROTrait<E: Engine> {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -55,6 +55,15 @@ pub trait Engine: Clone + Copy + Debug + Send + Sync + Sized + Eq + PartialEq {
   type CE: CommitmentEngineTrait<Self>;
 }
 
+/// This is a convenience trait to pair engines which fields are in a curve cycle relationship
+pub trait CurveCycleEquipped: Engine {
+  /// The secondary Engine of `Self`
+  type Secondary: Engine<Base = <Self as Engine>::Scalar, Scalar = <Self as Engine>::Base>;
+}
+
+/// Convenience projection to the Secondary Engine of a CurveCycleEquipped
+pub type SecEngine<E> = <<E as CurveCycleEquipped>::Secondary as Engine>::Scalar;
+
 /// A helper trait to absorb different objects in RO
 pub trait AbsorbInROTrait<E: Engine> {
   /// Absorbs the value in the provided RO

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -62,7 +62,7 @@ pub trait CurveCycleEquipped: Engine {
 }
 
 /// Convenience projection to the Secondary Engine of a CurveCycleEquipped
-pub type SecEngine<E> = <<E as CurveCycleEquipped>::Secondary as Engine>::Scalar;
+pub type SecEng<E> = <E as CurveCycleEquipped>::Secondary;
 
 /// A helper trait to absorb different objects in RO
 pub trait AbsorbInROTrait<E: Engine> {


### PR DESCRIPTION
```rust
E1: Engine<Base = E2::Scalar>,
E2: Engine<Base = E1::Scalar>,
C1: StepCircuit<E1::Scalar>,
C2: StepCircuit<E2::Scalar>,
```
Becomes 
`E1: CurveCycleEquiped`

And 
```rust
E1: Engine<Base = E2::Scalar>,
E2: Engine<Base = E1::Scalar>,
C1: StepCircuit<E1::Scalar>,
C2: StepCircuit<E2::Scalar>,
S1: RelaxedR1CSSNARKTrait<E1>,
S2: RelaxedR1CSSNARKTrait<E2>,
```
becomes
```rust
E1: CurveCycleEquipped
S1: RelaxedR1CSSNARKTrait<E1>,
S2: RelaxedR1CSSNARKTrait<SecEng<E1>>,
```

> [!NOTE]
> Lurk is not expected to compile on top of this, Companion PR at https://github.com/lurk-lab/lurk-rs/pull/1092