### PR TITLE
refactor: enhance safety of Abomonation annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ itertools = "0.12.0"
 rand = "0.8.5"
 ref-cast = "1.0.20"
 derive_more = "0.99.17"
+static_assertions = "1.1.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -10,12 +10,16 @@ use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves
-use halo2curves::{CurveAffine, CurveExt};
+use halo2curves::{bn256::G2Affine, CurveAffine, CurveExt};
 use num_bigint::BigInt;
 use num_traits::Num;
 use rayon::prelude::*;
 use sha3::Shake256;
 use std::io::Read;
+
+// Thus compile-time assertions checks important assumptions in the memory representation
+// of group data that supports the use of Abomonation.
+static_assertions::assert_eq_size!(G2Affine, [u64; 16]);
 
 /// Re-exports that give access to the standard aliases used in the code base, for bn256
 pub mod bn256 {

--- a/src/provider/non_hiding_kzg.rs
+++ b/src/provider/non_hiding_kzg.rs
@@ -27,11 +27,15 @@ use crate::{
 pub struct UniversalKZGParam<E: Engine> {
   /// Group elements of the form `{ β^i G }`, where `i` ranges from 0 to
   /// `degree`.
-  #[abomonate_with(Vec<[u64; 8]>)] // // this is a hack; we just assume the size of the element.
+  // this is a hack; we just assume the size of the element.
+  // Look for the static assertions in provider macros for a justification
+  #[abomonate_with(Vec<[u64; 8]>)]
   pub powers_of_g: Vec<E::G1Affine>,
   /// Group elements of the form `{ β^i H }`, where `i` ranges from 0 to
   /// `degree`.
-  #[abomonate_with(Vec<[u64; 16]>)] // this is a hack; we just assume the size of the element.
+  // this is a hack; we just assume the size of the element.
+  // Look for the static assertions in provider macros for a justification
+  #[abomonate_with(Vec<[u64; 16]>)]
   pub powers_of_h: Vec<E::G2Affine>,
 }
 

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -34,6 +34,11 @@ macro_rules! impl_traits {
     $order_str:literal,
     $base_str:literal
   ) => {
+    // These compile-time assertions check important assumptions in the memory representation
+    // of group data that supports the use of Abomonation.
+    static_assertions::assert_eq_size!($name::Affine, [u64; 8]);
+    static_assertions::assert_eq_size!($name::Point, [u64; 12]);
+
     impl Group for $name::Point {
       type Base = $name::Base;
       type Scalar = $name::Scalar;

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -30,7 +30,9 @@ where
   E: Engine,
   E::GE: DlogGroup<ScalarExt = E::Scalar>,
 {
-  #[abomonate_with(Vec<[u64; 8]>)] // this is a hack; we just assume the size of the element.
+  // this is a hack; we just assume the size of the element.
+  // Look for the static assertions in provider macros for a justification
+  #[abomonate_with(Vec<[u64; 8]>)]
   ck: Vec<<E::GE as PrimeCurve>::Affine>,
 }
 
@@ -49,7 +51,9 @@ where
 #[serde(bound = "")]
 #[abomonation_omit_bounds]
 pub struct Commitment<E: Engine> {
-  #[abomonate_with(Vec<[u64; 12]>)] // this is a hack; we just assume the size of the element.
+  // this is a hack; we just assume the size of the element.
+  // Look for the static assertions in provider macros for a justification
+  #[abomonate_with(Vec<[u64; 12]>)]
   pub(crate) comm: E::GE,
 }
 

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -63,6 +63,11 @@ macro_rules! impl_traits {
     $base_str:literal,
     $large_msm_method: ident
   ) => {
+    // These compile-time assertions check important assumptions in the memory representation
+    // of group data that supports the use of Abomonation.
+    static_assertions::assert_eq_size!($name::Affine, [u64; 8]);
+    static_assertions::assert_eq_size!($name::Point, [u64; 12]);
+
     impl Group for $name::Point {
       type Base = $name::Base;
       type Scalar = $name::Scalar;


### PR DESCRIPTION
- Added comments in `non_hiding_kzg.rs` and `pedersen.rs` files for explanation of abomonation annotations
- Updated `traits.rs` and `pasta.rs` with compile-time assertions for group data memory representation
- Included a new dependency on `static_assertions` version `1.1.0` in `Cargo.toml`.