### PR TITLE
Rework batches in ppsnark

### DIFF
--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -68,7 +68,7 @@ pub mod test_utils {
       .collect::<Vec<_>>();
 
     // Calculation evaluation of point over polynomial.
-    let eval = MultilinearPolynomial::evaluate_with(poly.evaluations(), &point);
+    let eval = poly.evaluate(&point);
 
     (poly, point, eval)
   }

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -135,6 +135,12 @@ impl<F: PrimeField> SparseMatrix<F> {
     name = "SparseMatrix::multiply_vec_unchecked"
   )]
   pub fn multiply_vec_unchecked(&self, vector: &[F]) -> Vec<F> {
+    let mut sink: Vec<F> = Vec::with_capacity(self.indptr.len() - 1);
+    self.multiply_vec_into_unchecked(vector, &mut sink);
+    sink
+  }
+
+  pub fn multiply_vec_into_unchecked(&self, vector: &[F], sink: &mut Vec<F>) {
     self
       .indptr
       .par_windows(2)
@@ -144,7 +150,7 @@ impl<F: PrimeField> SparseMatrix<F> {
           .map(|(val, col_idx)| *val * vector[*col_idx])
           .sum()
       })
-      .collect()
+      .collect_into_vec(sink);
   }
 
   /// Multiply by a witness representing a dense vector; uses rayon to parallelize.

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -403,14 +403,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     let num_rounds_y_max = *num_rounds_y.iter().max().unwrap();
 
     // Define τ polynomials of the appropriate size for each instance
-    let polys_tau = {
-      let tau = transcript.squeeze(b"t")?;
+    let tau = transcript.squeeze(b"t")?;
+    let all_taus = PowPolynomial::squares(&tau, num_rounds_x_max);
 
-      num_rounds_x
-        .iter()
-        .map(|&num_rounds| PowPolynomial::new(&tau, num_rounds))
-        .collect::<Vec<_>>()
-    };
+    let polys_tau = num_rounds_x
+      .iter()
+      .map(|&num_rounds_x| PowPolynomial::evals_with_powers(&all_taus, num_rounds_x))
+      .map(MultilinearPolynomial::new)
+      .collect::<Vec<_>>();
 
     // Sample challenge for random linear-combination of outer claims
     let outer_r = transcript.squeeze(b"out_r")?;

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -156,9 +156,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       let num_instances_field = E::Scalar::from(num_instances as u64);
       transcript.absorb(b"n", &num_instances_field);
     }
-    for u in U.iter() {
-      transcript.absorb(b"U", u);
-    }
+    transcript.absorb(b"U", &U);
 
     let (polys_W, polys_E): (Vec<_>, Vec<_>) = W.into_iter().map(|w| (w.W, w.E)).unzip();
 
@@ -395,9 +393,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       let num_instances_field = E::Scalar::from(num_instances as u64);
       transcript.absorb(b"n", &num_instances_field);
     }
-    for u in U.iter() {
-      transcript.absorb(b"U", u);
-    }
+    transcript.absorb(b"U", &U);
 
     let num_instances = U.len();
 
@@ -468,14 +464,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     // Compute expected claim for all instances ∑ᵢ rⁱ⋅τ(rₓ)⋅(Azᵢ⋅Bzᵢ − uᵢ⋅Czᵢ − Eᵢ)
     let claim_outer_final_expected = zip_with!(
       (
-        ABCE_evals.iter().copied(),
+        ABCE_evals.iter(),
         U.iter(),
         evals_tau,
         outer_r_powers.iter()
       ),
       |ABCE_eval, u, eval_tau, r| {
         let (claim_Az, claim_Bz, claim_Cz, eval_E) = ABCE_eval;
-        *r * eval_tau * (claim_Az * claim_Bz - u.u * claim_Cz - eval_E)
+        *r * eval_tau * (*claim_Az * claim_Bz - u.u * claim_Cz - eval_E)
       }
     )
     .sum::<E::Scalar>();

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -134,17 +134,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
   ) -> Result<Self, NovaError> {
     let num_instances = U.len();
     // Pad shapes and ensure their sizes are correct
-    let S = S
-      .iter()
-      .map(|s| {
-        let s = s.pad();
-        if s.is_regular_shape() {
-          Ok(s)
-        } else {
-          Err(NovaError::InternalError)
-        }
-      })
-      .collect::<Result<Vec<_>, _>>()?;
+    let S = S.iter().map(|s| s.pad()).collect::<Vec<_>>();
 
     // Pad (W,E) for each instance
     let W = zip_with!(iter, (W, S), |w, s| w.pad(s)).collect::<Vec<RelaxedR1CSWitness<E>>>();

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -937,13 +937,15 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
 
           let X = {
             // constant term
-            let mut poly_X = vec![(0, U.u)];
-            //remaining inputs
-            poly_X.extend(
-              (0..U.X.len())
-                .map(|i| (i + 1, U.X[i]))
-                .collect::<Vec<(usize, E::Scalar)>>(),
-            );
+            let poly_X = std::iter::once((0, U.u))
+              .chain(
+                //remaining inputs
+                (0..U.X.len())
+                // filter_map uses the sparsity of the polynomial, if irrelevant
+                // we should replace by UniPoly
+                .filter_map(|i| (!U.X[i].is_zero_vartime()).then_some((i + 1, U.X[i]))),
+              )
+              .collect();
             SparsePolynomial::new(num_vars_log, poly_X).evaluate(&rand_sc_unpad[1..])
           };
 

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -208,9 +208,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       let num_instances_field = E::Scalar::from(num_instances as u64);
       transcript.absorb(b"n", &num_instances_field);
     }
-    for u in U.iter() {
-      transcript.absorb(b"U", u);
-    }
+    transcript.absorb(b"U", &U);
 
     // Append public inputs to Wᵢ: Zᵢ = [Wᵢ, uᵢ, Xᵢ]
     let polys_Z = zip_with!(par_iter, (W, U, N), |W, U, Ni| {
@@ -765,9 +763,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       let num_instances_field = E::Scalar::from(num_instances as u64);
       transcript.absorb(b"n", &num_instances_field);
     }
-    for u in U.iter() {
-      transcript.absorb(b"U", u);
-    }
+    transcript.absorb(b"U", &U);
 
     // Decompress commitments
     let comms_Az_Bz_Cz = self

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -903,14 +903,10 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
         let num_rounds_i = rand_sc.len();
         let num_vars_log = num_vars.log_2();
 
-        let eq_rho = {
-          let rho_coords = PowPolynomial::new(&rho, num_rounds_i).coordinates();
-          EqPolynomial::new(rho_coords).evaluate(rand_sc)
-        };
+        let eq_rho = PowPolynomial::new(&rho, num_rounds_i).evaluate(rand_sc);
 
         let (eq_tau, eq_masked_tau) = {
-          let tau_coords = PowPolynomial::new(&tau, num_rounds_i).coordinates();
-          let eq_tau = EqPolynomial::new(tau_coords);
+          let eq_tau: EqPolynomial<_> = PowPolynomial::new(&tau, num_rounds_i).into();
 
           let eq_tau_at_rand = eq_tau.evaluate(rand_sc);
           let eq_masked_tau = MaskedEqPolynomial::new(&eq_tau, num_vars_log).evaluate(rand_sc);

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -85,8 +85,7 @@ impl<E: Engine> PolyEvalWitness<E> {
   }
 
   /// Given a set of polynomials \[Pᵢ\] and a scalar `s`, this method computes the weighted sum
-  /// of the polynomials, where each polynomial Pᵢ is scaled by sⁱ. The method handles polynomials
-  /// of different sizes by padding smaller ones with zeroes up to the size of the largest polynomial.
+  /// of the polynomials, where each polynomial Pᵢ is scaled by sⁱ.
   ///
   /// # Panics
   ///
@@ -94,6 +93,7 @@ impl<E: Engine> PolyEvalWitness<E> {
   fn batch(p_vec: &[&Vec<E::Scalar>], s: &E::Scalar) -> Self {
     p_vec
       .iter()
+      .skip(1)
       .for_each(|p| assert_eq!(p.len(), p_vec[0].len()));
 
     let powers_of_s = powers::<E>(s, p_vec.len());
@@ -186,7 +186,7 @@ impl<E: Engine> PolyEvalInstance<E> {
   }
 }
 
-/// Bounds "row" variables of (A, B, C) matrices viewed as 2d multilinear polynomials
+/// Binds "row" variables of (A, B, C) matrices viewed as 2d multilinear polynomials
 fn compute_eval_table_sparse<E: Engine>(
   S: &R1CSShape<E>,
   rx: &[E::Scalar],

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -16,7 +16,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, Parall
 /// For instance, for e = 6 (with a binary representation of 0b110), the vector r would be [1, 1, 0].
 #[derive(Debug)]
 pub struct EqPolynomial<Scalar> {
-  pub(crate) r: Vec<Scalar>,
+  pub(in crate::spartan) r: Vec<Scalar>,
 }
 
 impl<Scalar: PrimeField> EqPolynomial<Scalar> {
@@ -43,6 +43,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
   ///
   /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
+  #[must_use = "this returns an expensive vector and leaves self unchanged"]
   pub fn evals(&self) -> Vec<Scalar> {
     Self::evals_from_points(&self.r)
   }

--- a/src/spartan/polys/eq.rs
+++ b/src/spartan/polys/eq.rs
@@ -37,7 +37,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
     assert_eq!(self.r.len(), rx.len());
     (0..rx.len())
       .map(|i| self.r[i] * rx[i] + (Scalar::ONE - self.r[i]) * (Scalar::ONE - rx[i]))
-      .fold(Scalar::ONE, |acc, item| acc * item)
+      .product()
   }
 
   /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.

--- a/src/spartan/polys/identity.rs
+++ b/src/spartan/polys/identity.rs
@@ -24,6 +24,6 @@ impl<Scalar: PrimeField> IdentityPolynomial<Scalar> {
         power_of_two *= 2;
         result
       })
-      .fold(Scalar::ZERO, |acc, item| acc + item)
+      .sum()
   }
 }

--- a/src/spartan/polys/power.rs
+++ b/src/spartan/polys/power.rs
@@ -61,3 +61,9 @@ impl<Scalar: PrimeField> PowPolynomial<Scalar> {
     self.eq.evals()
   }
 }
+
+impl<Scalar: PrimeField> From<PowPolynomial<Scalar>> for EqPolynomial<Scalar> {
+  fn from(polynomial: PowPolynomial<Scalar>) -> Self {
+    polynomial.eq
+  }
+}

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -885,12 +885,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
     // verify claim_sc_final
     let claim_sc_final_expected = {
-      let rand_eq_bound_rand_sc = {
-        let poly_eq_coords = PowPolynomial::new(&rho, num_rounds_sc).coordinates();
-        EqPolynomial::new(poly_eq_coords).evaluate(&rand_sc)
-      };
-      let taus_coords = PowPolynomial::new(&tau, num_rounds_sc).coordinates();
-      let eq_tau = EqPolynomial::new(taus_coords);
+      let rand_eq_bound_rand_sc = PowPolynomial::new(&rho, num_rounds_sc).evaluate(&rand_sc);
+      let eq_tau: EqPolynomial<_> = PowPolynomial::new(&tau, num_rounds_sc).into();
 
       let taus_bound_rand_sc = eq_tau.evaluate(&rand_sc);
       let taus_masked_bound_rand_sc =

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -927,13 +927,15 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
           let eval_X = {
             // constant term
-            let mut poly_X = vec![(0, U.u)];
-            //remaining inputs
-            poly_X.extend(
-              (0..U.X.len())
-                .map(|i| (i + 1, U.X[i]))
-                .collect::<Vec<(usize, E::Scalar)>>(),
-            );
+            let poly_X = std::iter::once((0, U.u))
+              .chain(
+                //remaining inputs
+                (0..U.X.len())
+                // filter_map uses the sparsity of the polynomial, if irrelevant
+                // we should replace by UniPoly
+                .filter_map(|i| (!U.X[i].is_zero_vartime()).then_some((i + 1, U.X[i]))),
+              )
+              .collect();
             SparsePolynomial::new(vk.num_vars.log_2(), poly_X).evaluate(&rand_sc_unpad[1..])
           };
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -604,14 +604,12 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
         );
 
         // a sum-check instance to prove the second claim
-        let val = pk
-          .S_repr
-          .val_A
-          .par_iter()
-          .zip_eq(pk.S_repr.val_B.par_iter())
-          .zip_eq(pk.S_repr.val_C.par_iter())
-          .map(|((v_a, v_b), v_c)| *v_a + c * *v_b + c * c * *v_c)
-          .collect::<Vec<E::Scalar>>();
+        let val = zip_with!(
+          par_iter,
+          (pk.S_repr.val_A, pk.S_repr.val_B, pk.S_repr.val_C),
+          |v_a, v_b, v_c| *v_a + c * *v_b + c * c * *v_c
+        )
+        .collect::<Vec<E::Scalar>>();
         let inner_sc_inst = InnerSumcheckInstance {
           claim: eval_Az_at_tau + c * eval_Bz_at_tau + c * c * eval_Cz_at_tau,
           poly_L_row: MultilinearPolynomial::new(L_row.clone()),

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -444,10 +444,10 @@ pub(in crate::spartan) fn batch_eval_prove<E: Engine>(
   let num_rounds = u_vec.iter().map(|u| u.x.len()).collect::<Vec<_>>();
 
   // Check polynomials match number of variables, i.e. |Pᵢ| = 2^nᵢ
-  w_vec
-    .iter()
-    .zip_eq(num_rounds.iter())
-    .for_each(|(w, num_vars)| assert_eq!(w.p.len(), 1 << num_vars));
+  zip_with_for_each!(iter, (w_vec, num_rounds), |w, num_vars| assert_eq!(
+    w.p.len(),
+    1 << num_vars
+  ));
 
   // generate a challenge, and powers of it for random linear combination
   let rho = transcript.squeeze(b"r")?;


### PR DESCRIPTION
## TL;DR

This is streamlining of the batched snark/ppsnark made on the way to resolving the perf difference found in #281 

Differential bench (with `--features "cuda"`) for this PR reveals high variance 🤷 

## Benchmark Results

### CompressedSNARK-NIVC-1

|                              | `ref=13ff737`             | `ref=7a5d7bf`                     |
|:-----------------------------|:--------------------------|:--------------------------------- |
| **`Prove-NumCons-6540`**     | `378.03 ms` (✅ **1.00x**) | `384.75 ms` (✅ **1.02x slower**)  |
| **`Verify-NumCons-6540`**    | `29.71 ms` (✅ **1.00x**)  | `29.00 ms` (✅ **1.02x faster**)   |
| **`Prove-NumCons-1038732`**  | `9.42 s` (✅ **1.00x**)    | `9.42 s` (✅ **1.00x slower**)     |
| **`Verify-NumCons-1038732`** | `132.44 ms` (✅ **1.00x**) | `115.03 ms` (✅ **1.15x faster**)  |

### CompressedSNARK-NIVC-2

|                              | `ref=13ff737`             | `ref=7a5d7bf`                     |
|:-----------------------------|:--------------------------|:--------------------------------- |
| **`Prove-NumCons-6540`**     | `384.48 ms` (✅ **1.00x**) | `388.90 ms` (✅ **1.01x slower**)  |
| **`Verify-NumCons-6540`**    | `31.16 ms` (✅ **1.00x**)  | `29.68 ms` (✅ **1.05x faster**)   |
| **`Prove-NumCons-1038732`**  | `9.73 s` (✅ **1.00x**)    | `10.03 s` (✅ **1.03x slower**)    |
| **`Verify-NumCons-1038732`** | `182.09 ms` (✅ **1.00x**) | `149.88 ms` (✅ **1.21x faster**)  |

### CompressedSNARK-NIVC-Commitments-2

|                              | `ref=13ff737`             | `ref=7a5d7bf`                     |
|:-----------------------------|:--------------------------|:--------------------------------- |
| **`Prove-NumCons-6540`**     | `9.30 s` (✅ **1.00x**)    | `9.41 s` (✅ **1.01x slower**)     |
| **`Verify-NumCons-6540`**    | `57.65 ms` (✅ **1.00x**)  | `57.70 ms` (✅ **1.00x slower**)   |
| **`Prove-NumCons-1038732`**  | `70.85 s` (✅ **1.00x**)   | `70.12 s` (✅ **1.01x faster**)    |
| **`Verify-NumCons-1038732`** | `299.04 ms` (✅ **1.00x**) | `300.82 ms` (✅ **1.01x slower**)  |

