### PR TITLE
add preallocated and indexed MSMs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ static_assertions = "1.1.0"
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle
 # see: https://github.com/lurk-lab/grumpkin-msm/pull/3
-grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev" }
+grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "indices" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # see https://github.com/rust-random/rand/pull/948

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -8,7 +8,7 @@ use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
+use grumpkin_msm::{bn256::msm as bn256_msm, grumpkin::msm as grumpkin_msm};
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves
 use halo2curves::{bn256::G2Affine, CurveAffine, CurveExt};
 use num_bigint::BigInt;

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -66,7 +66,7 @@ macro_rules! impl_traits {
       fn vartime_multiscalar_mul(scalars: &[Self::ScalarExt], bases: &[Self::Affine]) -> Self {
         #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         if scalars.len() >= 128 {
-          grumpkin_msm::pasta::$name(bases, scalars)
+          grumpkin_msm::pasta::$name::msm(bases, scalars)
         } else {
           cpu_best_msm(bases, scalars)
         }


### PR DESCRIPTION
Upstream fixes for https://github.com/lurk-lab/grumpkin-msm/pull/13, just matching the names and benchmarking