### PR TITLE
ci: Add nightly typo checker workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,3 +16,6 @@ jobs:
 
   rust-version-check:
     uses: lurk-lab/ci-workflows/.github/workflows/rust-version-check.yml@main
+
+  typos:
+    uses: lurk-lab/ci-workflows/.github/workflows/typos.yml@main


### PR DESCRIPTION
Uses the typo checker workflow added in https://github.com/lurk-lab/ci-workflows/pull/29, which opens a PR with typo fixes and comments unsolvable typos in the PR description.

I tested the output of `typos --write-changes` locally and it seems to work quite well, no false positives that I could see. If merged, we should get a nice-looking PR on the next morning.