### PR TITLE
IO getters for `RecursiveSnark`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,6 +502,16 @@ where
     })
   }
 
+  /// Inputs of the primary circuits
+  pub fn z0_primary(&self) -> &Vec<E1::Scalar> {
+    &self.z0_primary
+  }
+
+  /// Outputs of the primary circuits
+  pub fn zi_primary(&self) -> &Vec<E1::Scalar> {
+    &self.zi_primary
+  }
+
   /// Create a new `RecursiveSNARK` (or updates the provided `RecursiveSNARK`)
   /// by executing a step of the incremental computation
   #[tracing::instrument(skip_all, name = "nova::RecursiveSNARK::prove_step")]

--- a/src/supernova/mod.rs
+++ b/src/supernova/mod.rs
@@ -714,6 +714,16 @@ where
     })
   }
 
+  /// Inputs of the primary circuits
+  pub fn z0_primary(&self) -> &Vec<E1::Scalar> {
+    &self.z0_primary
+  }
+
+  /// Outputs of the primary circuits
+  pub fn zi_primary(&self) -> &Vec<E1::Scalar> {
+    &self.zi_primary
+  }
+
   /// executing a step of the incremental computation
   #[allow(clippy::too_many_arguments)]
   #[tracing::instrument(skip_all, name = "supernova::RecursiveSNARK::prove_step")]


### PR DESCRIPTION
This PR just adds simple getter methods for recursive SNARKs. (Maybe we should do the same for compressed SNARKs).

The reasoning behind this is that it simplifies Lurk's Prover trait. See [L#1115](https://github.com/lurk-lab/lurk-rs/pull/1115)