### PR TITLE
Refactor Polyeval{Instance, Witness}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng" }
 tracing = "0.1.37"
 cfg-if = "1.0.0"
 once_cell = "1.18.0"
-itertools = "0.12.0"
+itertools = "0.12.0" # zip_eq
 rand = "0.8.5"
-ref-cast = "1.0.20"
-derive_more = "0.99.17"
+ref-cast = "1.0.20" # allocation-less conversion in multilinear polys
+derive_more = "0.99.17" # lightens impl macros for pasta
 static_assertions = "1.1.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
@@ -57,6 +57,7 @@ getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1.2.0"
+proptest-derive = "0.4.0"
 pprof = { version = "0.13" }
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,10 @@ grumpkin-msm = { git = "https://github.com/lurk-lab/grumpkin-msm", branch = "dev
 # see https://github.com/rust-random/rand/pull/948
 getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 proptest = "1.2.0"
-proptest-derive = "0.4.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 pprof = { version = "0.13" }
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,6 +1,5 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 mod sparse;
-#[cfg(test)]
 pub(crate) mod util;
 
 use crate::{

--- a/src/r1cs/util.rs
+++ b/src/r1cs/util.rs
@@ -24,3 +24,26 @@ impl<F: PrimeField> Arbitrary for FWrap<F> {
     strategy.boxed()
   }
 }
+
+/// Wrapper struct around a Group element that implements additional traits
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GWrap<G>(pub G);
+
+impl<G: Group> Copy for GWrap<G> {}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Trait implementation for generating `GWrap<F>` instances with proptest
+impl<G: Group> Arbitrary for GWrap<G> {
+  type Parameters = ();
+  type Strategy = BoxedStrategy<Self>;
+
+  fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+    use rand::rngs::StdRng;
+    use rand_core::SeedableRng;
+
+    let strategy = any::<[u8; 32]>()
+      .prop_map(|seed| Self(G::random(StdRng::from_seed(seed))))
+      .no_shrink();
+    strategy.boxed()
+  }
+}

--- a/src/r1cs/util.rs
+++ b/src/r1cs/util.rs
@@ -1,4 +1,5 @@
 use ff::PrimeField;
+use group::Group;
 #[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;
 

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -347,7 +347,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     };
 
     let (batched_u, batched_w, sc_proof_batch, claims_batch_left) =
-      batch_eval_prove(u_vec, w_vec, &mut transcript)?;
+      batch_eval_prove(u_vec, &w_vec, &mut transcript)?;
 
     let eval_arg = EE::prove(
       ck,

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -375,7 +375,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       |comm_Az_Bz_Cz, evals_Az_Bz_Cz_at_tau| {
         let u = PolyEvalInstance::<E>::batch(
           comm_Az_Bz_Cz.as_slice(),
-          &[], // ignored by the function
+          vec![], // ignored by the function
           evals_Az_Bz_Cz_at_tau.as_slice(),
           &c,
         );
@@ -819,7 +819,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
       |comm_Az_Bz_Cz, evals_Az_Bz_Cz_at_tau| {
         let u = PolyEvalInstance::<E>::batch(
           comm_Az_Bz_Cz.as_slice(),
-          &tau_coords,
+          tau_coords.clone(),
           evals_Az_Bz_Cz_at_tau.as_slice(),
           &c,
         );

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -701,7 +701,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     let num_vars_u = w_vec.iter().map(|w| w.p.len().log_2()).collect::<Vec<_>>();
     let u_batch =
       PolyEvalInstance::<E>::batch_diff_size(&comms_vec, &evals_vec, &num_vars_u, rand_sc, c);
-    let w_batch = PolyEvalWitness::<E>::batch_diff_size(w_vec, c);
+    let w_batch =
+      PolyEvalWitness::<E>::batch_diff_size(&w_vec.iter().by_ref().collect::<Vec<_>>(), c);
 
     let eval_arg = EE::prove(
       ck,

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -167,7 +167,7 @@ impl<E: Engine> PolyEvalInstance<E> {
     }
   }
 
-  fn batch(c_vec: &[Commitment<E>], x: &[E::Scalar], e_vec: &[E::Scalar], s: &E::Scalar) -> Self {
+  fn batch(c_vec: &[Commitment<E>], x: Vec<E::Scalar>, e_vec: &[E::Scalar], s: &E::Scalar) -> Self {
     let num_instances = c_vec.len();
     assert_eq!(e_vec.len(), num_instances);
 
@@ -180,7 +180,7 @@ impl<E: Engine> PolyEvalInstance<E> {
 
     Self {
       c,
-      x: x.to_vec(),
+      x,
       e,
     }
   }
@@ -287,7 +287,7 @@ mod tests {
         // when poly evals are all for the max # of variables, batch_diff_size and batch agree
         let res = PolyEvalInstance::<PallasEngine>::batch(
           &c_vecs, 
-          &x_vec, 
+          x_vec.clone(), 
           &e_vec, 
           &s.0);
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -580,7 +580,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let poly_vec = vec![&Az, &Bz, &Cz];
     let c = transcript.squeeze(b"c")?;
     let w: PolyEvalWitness<E> = PolyEvalWitness::batch(&poly_vec, &c);
-    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
+    let u: PolyEvalInstance<E> =
+      PolyEvalInstance::batch(&comm_vec, tau_coords.clone(), &eval_vec, &c);
 
     // we now need to prove three claims
     // (1) 0 = \sum_x poly_tau(x) * (poly_Az(x) * poly_Bz(x) - poly_uCz_E(x)), and eval_Az_at_tau + r * eval_Bz_at_tau + r^2 * eval_Cz_at_tau = (Az+r*Bz+r^2*Cz)(tau)
@@ -769,7 +770,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let w: PolyEvalWitness<E> = PolyEvalWitness::batch(&poly_vec, &c);
-    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &rand_sc, &eval_vec, &c);
+    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, rand_sc.clone(), &eval_vec, &c);
 
     let eval_arg = EE::prove(ck, &pk.pk_ee, &mut transcript, &u.c, &w.p, &rand_sc, &u.e)?;
 
@@ -855,7 +856,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     transcript.absorb(b"e", &vec![comm_L_row, comm_L_col].as_slice());
     let comm_vec = vec![comm_Az, comm_Bz, comm_Cz];
     let c = transcript.squeeze(b"c")?;
-    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
+    let u: PolyEvalInstance<E> =
+      PolyEvalInstance::batch(&comm_vec, tau_coords.clone(), &eval_vec, &c);
     let claim = u.e;
 
     let gamma = transcript.squeeze(b"g")?;
@@ -1032,7 +1034,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     ];
     transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
-    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &rand_sc, &eval_vec, &c);
+    let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, rand_sc.clone(), &eval_vec, &c);
 
     // verify
     EE::verify(

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -493,7 +493,7 @@ pub(in crate::spartan) fn batch_eval_prove<E: Engine>(
     PolyEvalInstance::batch_diff_size(&comms, &claims_batch_left, &num_rounds, r, gamma);
 
   // P = ∑ᵢ γⁱ⋅Pᵢ
-  let w_joint = PolyEvalWitness::batch_diff_size(w_vec, gamma);
+  let w_joint = PolyEvalWitness::batch_diff_size(&w_vec.iter().by_ref().collect::<Vec<_>>(), gamma);
 
   Ok((u_joint, w_joint, sc_proof_batch, claims_batch_left))
 }

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -245,7 +245,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     ];
 
     let (batched_u, batched_w, sc_proof_batch, claims_batch_left) =
-      batch_eval_prove(u_vec, w_vec, &mut transcript)?;
+      batch_eval_prove(u_vec, &w_vec, &mut transcript)?;
 
     let eval_arg = EE::prove(
       ck,
@@ -428,7 +428,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 /// the claims and resulting evaluations from Sumcheck.
 pub(in crate::spartan) fn batch_eval_prove<E: Engine>(
   u_vec: Vec<PolyEvalInstance<E>>,
-  w_vec: Vec<PolyEvalWitness<E>>,
+  w_vec: &[PolyEvalWitness<E>],
   transcript: &mut E::TE,
 ) -> Result<
   (


### PR DESCRIPTION
After #305 (which it includes, so go review there plz)

Refactors Polynomial evaluation instances / witnesses to express the specialized functions in terms of the general ones.

For review: the refactoring of `PolyEvalInstance::batch_diff_size`, which is strict about the size of its arguments and inspects it ,to be the implementation of `PolyEvalInstance::batch`, has revealed the later call sites are *not* rigorous about the size of their arguments, nor do they inspect them.

I've patched call-sites to be compliant with the rigor of `batch_diff_size`, but there's another "looser" variant of this PR that would eliminate `x` from the `PolyEvalInstance`.