### PR TITLE
Rewire batched SNARK to act as a regular SNARK

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -37,13 +37,13 @@ cfg_if::cfg_if! {
     criterion_group! {
       name = compressed_snark;
       config = Criterion::default().warm_up_time(Duration::from_millis(3000)).with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
-      targets = bench_compressed_snark, bench_compressed_snark_with_computational_commitments
+      targets = bench_compressed_snark, bench_compressed_snark_with_computational_commitments, bench_compressed_batched_snark, bench_compressed_batched_snark_with_computational_commitments
     }
   } else {
     criterion_group! {
       name = compressed_snark;
       config = Criterion::default().warm_up_time(Duration::from_millis(3000));
-      targets = bench_compressed_snark, bench_compressed_snark_with_computational_commitments
+      targets = bench_compressed_snark, bench_compressed_snark_with_computational_commitments, bench_compressed_batched_snark, bench_compressed_batched_snark_with_computational_commitments
     }
   }
 }
@@ -181,6 +181,65 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     group.noise_threshold(noise_threshold_env().unwrap_or(0.05));
 
     bench_compressed_snark_internal::<SS1, SS2>(&mut group, num_cons);
+
+    group.finish();
+  }
+}
+
+// SNARKs without computation commitmnets
+type BS1 = arecibo::spartan::batched::BatchedRelaxedR1CSSNARK<E1, EE1>;
+type BS2 = arecibo::spartan::batched::BatchedRelaxedR1CSSNARK<E2, EE2>;
+// SNARKs with computation commitmnets
+type BSS1 = arecibo::spartan::batched_ppsnark::BatchedRelaxedR1CSSNARK<E1, EE1>;
+type BSS2 = arecibo::spartan::batched_ppsnark::BatchedRelaxedR1CSSNARK<E2, EE2>;
+
+fn bench_compressed_batched_snark(c: &mut Criterion) {
+  // we vary the number of constraints in the step circuit
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+  ]
+  .iter()
+  {
+    // number of constraints in the step circuit
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
+
+    let mut group = c.benchmark_group("BatchedCompressedSNARK");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(NUM_SAMPLES);
+    group.noise_threshold(noise_threshold_env().unwrap_or(0.05));
+
+    bench_compressed_snark_internal::<BS1, BS2>(&mut group, num_cons);
+
+    group.finish();
+  }
+}
+
+fn bench_compressed_batched_snark_with_computational_commitments(c: &mut Criterion) {
+  // we vary the number of constraints in the step circuit
+  for &num_cons_in_augmented_circuit in [
+    NUM_CONS_VERIFIER_CIRCUIT_PRIMARY,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+  ]
+  .iter()
+  {
+    // number of constraints in the step circuit
+    let num_cons = num_cons_in_augmented_circuit - NUM_CONS_VERIFIER_CIRCUIT_PRIMARY;
+
+    let mut group = c.benchmark_group("BatchedCompressedSNARK-Commitments");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(NUM_SAMPLES);
+    group.noise_threshold(noise_threshold_env().unwrap_or(0.05));
+
+    bench_compressed_snark_internal::<BSS1, BSS2>(&mut group, num_cons);
 
     group.finish();
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1397,6 +1397,63 @@ mod tests {
     >();
   }
 
+  type BatchedS<E, EE> = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE>;
+  type BatchedSPrime<E, EE> = spartan::batched::BatchedRelaxedR1CSSNARK<E, EE>;
+
+  fn test_ivc_nontrivial_with_batched_compression_with<E1, EE1, EE2>()
+  where
+    E1: CurveCycleEquipped,
+    EE1: EvaluationEngineTrait<E1>,
+    EE2: EvaluationEngineTrait<Dual<E1>>,
+    // this is due to the reliance on Abomonation
+    <E1::Scalar as PrimeField>::Repr: Abomonation,
+    <<Dual<E1> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
+  {
+    // this tests compatibility of the batched workflow with the non-batched one
+    test_ivc_nontrivial_with_some_compression_with::<E1, BatchedS<_, EE1>, BatchedS<_, EE2>>()
+  }
+
+  #[test]
+  fn test_ivc_nontrivial_with_batched_compression() {
+    test_ivc_nontrivial_with_batched_compression_with::<PallasEngine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_compression_with::<Bn256Engine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_compression_with::<Secp256k1Engine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_compression_with::<Bn256EngineZM, ZMPCS<Bn256, _>, EE<_>>();
+    test_ivc_nontrivial_with_batched_compression_with::<
+      Bn256EngineKZG,
+      provider::hyperkzg::EvaluationEngine<Bn256, _>,
+      EE<_>,
+    >();
+  }
+
+  fn test_ivc_nontrivial_with_batched_spark_compression_with<E1, EE1, EE2>()
+  where
+    E1: CurveCycleEquipped,
+    EE1: EvaluationEngineTrait<E1>,
+    EE2: EvaluationEngineTrait<Dual<E1>>,
+    // this is due to the reliance on Abomonation
+    <E1::Scalar as PrimeField>::Repr: Abomonation,
+    <<Dual<E1> as Engine>::Scalar as PrimeField>::Repr: Abomonation,
+  {
+    // this tests compatibility of the batched workflow with the non-batched one
+    test_ivc_nontrivial_with_some_compression_with::<E1, BatchedSPrime<_, EE1>, BatchedSPrime<_, EE2>>(
+    )
+  }
+
+  #[test]
+  fn test_ivc_nontrivial_with_batched_spark_compression() {
+    test_ivc_nontrivial_with_batched_spark_compression_with::<PallasEngine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_spark_compression_with::<Bn256Engine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_spark_compression_with::<Secp256k1Engine, EE<_>, EE<_>>();
+    test_ivc_nontrivial_with_batched_spark_compression_with::<Bn256EngineZM, ZMPCS<Bn256, _>, EE<_>>(
+    );
+    test_ivc_nontrivial_with_batched_spark_compression_with::<
+      Bn256EngineKZG,
+      provider::hyperkzg::EvaluationEngine<Bn256, _>,
+      EE<_>,
+    >();
+  }
+
   fn test_ivc_nondet_with_compression_with<E1, EE1, EE2>()
   where
     E1: CurveCycleEquipped,

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -6,6 +6,7 @@
 use ff::Field;
 use serde::{Deserialize, Serialize};
 
+use core::slice;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
@@ -31,7 +32,7 @@ use crate::{
   },
   traits::{
     evaluation::EvaluationEngineTrait,
-    snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait},
+    snark::{BatchedRelaxedR1CSSNARKTrait, DigestHelperTrait, RelaxedR1CSSNARKTrait},
     Engine, TranscriptEngineTrait,
   },
   zip_with, CommitmentKey,
@@ -586,5 +587,48 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     )?;
 
     Ok(())
+  }
+}
+
+impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E>
+  for BatchedRelaxedR1CSSNARK<E, EE>
+{
+  type ProverKey = ProverKey<E, EE>;
+
+  type VerifierKey = VerifierKey<E, EE>;
+
+  fn ck_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<E>) -> usize> {
+    <Self as BatchedRelaxedR1CSSNARKTrait<E>>::ck_floor()
+  }
+
+  fn setup(
+    ck: Arc<CommitmentKey<E>>,
+    S: &R1CSShape<E>,
+  ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
+    <Self as BatchedRelaxedR1CSSNARKTrait<E>>::setup(ck, vec![S])
+  }
+
+  fn prove(
+    ck: &CommitmentKey<E>,
+    pk: &Self::ProverKey,
+    S: &R1CSShape<E>,
+    U: &RelaxedR1CSInstance<E>,
+    W: &RelaxedR1CSWitness<E>,
+  ) -> Result<Self, NovaError> {
+    // We manifest a slice for the single element U
+    let ptr_U = U as *const _;
+    let slice_U = unsafe { slice::from_raw_parts(ptr_U, 1) };
+    // We manifest a slice for the single element W
+    let ptr_W = W as *const _;
+    let slice_W = unsafe { slice::from_raw_parts(ptr_W, 1) };
+
+    <Self as BatchedRelaxedR1CSSNARKTrait<E>>::prove(ck, pk, vec![S], slice_U, slice_W)
+  }
+
+  fn verify(&self, vk: &Self::VerifierKey, U: &RelaxedR1CSInstance<E>) -> Result<(), NovaError> {
+    // We manifest a slice for the single element U
+    let ptr = U as *const _;
+    let slice = unsafe { slice::from_raw_parts(ptr, 1) };
+    <Self as BatchedRelaxedR1CSSNARKTrait<E>>::verify(self, vk, slice)
   }
 }

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -615,20 +615,13 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E>
     U: &RelaxedR1CSInstance<E>,
     W: &RelaxedR1CSWitness<E>,
   ) -> Result<Self, NovaError> {
-    // We manifest a slice for the single element U
-    let ptr_U = U as *const _;
-    let slice_U = unsafe { slice::from_raw_parts(ptr_U, 1) };
-    // We manifest a slice for the single element W
-    let ptr_W = W as *const _;
-    let slice_W = unsafe { slice::from_raw_parts(ptr_W, 1) };
-
+    let slice_U = slice::from_ref(U);
+    let slice_W = slice::from_ref(W);
     <Self as BatchedRelaxedR1CSSNARKTrait<E>>::prove(ck, pk, vec![S], slice_U, slice_W)
   }
 
   fn verify(&self, vk: &Self::VerifierKey, U: &RelaxedR1CSInstance<E>) -> Result<(), NovaError> {
-    // We manifest a slice for the single element U
-    let ptr = U as *const _;
-    let slice = unsafe { slice::from_raw_parts(ptr, 1) };
+    let slice = slice::from_ref(U);
     <Self as BatchedRelaxedR1CSSNARKTrait<E>>::verify(self, vk, slice)
   }
 }

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -1365,20 +1365,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E>
     U: &RelaxedR1CSInstance<E>,
     W: &RelaxedR1CSWitness<E>,
   ) -> Result<Self, NovaError> {
-    // We manifest a slice for the single element U
-    let ptr_U = U as *const _;
-    let slice_U = unsafe { slice::from_raw_parts(ptr_U, 1) };
-    // We manifest a slice for the single element W
-    let ptr_W = W as *const _;
-    let slice_W = unsafe { slice::from_raw_parts(ptr_W, 1) };
+    let slice_U = slice::from_ref(U);
+    let slice_W = slice::from_ref(W);
 
     <Self as BatchedRelaxedR1CSSNARKTrait<E>>::prove(ck, pk, vec![S], slice_U, slice_W)
   }
 
   fn verify(&self, vk: &Self::VerifierKey, U: &RelaxedR1CSInstance<E>) -> Result<(), NovaError> {
-    // We manifest a slice for the single element U
-    let ptr = U as *const _;
-    let slice = unsafe { slice::from_raw_parts(ptr, 1) };
+    let slice = slice::from_ref(U);
     <Self as BatchedRelaxedR1CSSNARKTrait<E>>::verify(self, vk, slice)
   }
 }


### PR DESCRIPTION
## What's in this PR?

- The obvious things that should be in the code base on the way to solving a#191,
- This does **not** include a replacement of the `snark::RelaxedR1CSSNark` or `ppsnark::RelaxedR1CSSNark` by their batched variants, just additions,
- This does **not** include tests that compare the I/O of each proof (`snark` vs `batched`, `ppsnark` vs `batched_ppsnark`) very carefully at each stage, that's for later.
- This does include benchmarks that allow us to gain confidence that the performance cost of batching is minimal.
- Incidentally, look at that variance on verification of compressed pre-processing SNARKs 🙀 

### CompressedSNARK

|                              | `ref=95714b1`             | `ref=26fd303`                     |
|:-----------------------------|:--------------------------|:--------------------------------- |
| **`Prove-NumCons-0`**        | `355.21 ms` (✅ **1.00x**) | `355.42 ms` (✅ **1.00x slower**)  |
| **`Verify-NumCons-0`**       | `27.75 ms` (✅ **1.00x**)  | `27.73 ms` (✅ **1.00x faster**)   |
| **`Prove-NumCons-6559`**     | `367.26 ms` (✅ **1.00x**) | `367.29 ms` (✅ **1.00x slower**)  |
| **`Verify-NumCons-6559`**    | `27.54 ms` (✅ **1.00x**)  | `27.62 ms` (✅ **1.00x slower**)   |
| **`Prove-NumCons-22943`**    | `532.88 ms` (✅ **1.00x**) | `530.84 ms` (✅ **1.00x faster**)  |
| **`Verify-NumCons-22943`**   | `38.66 ms` (✅ **1.00x**)  | `38.62 ms` (✅ **1.00x faster**)   |
| **`Prove-NumCons-55711`**    | `867.06 ms` (✅ **1.00x**) | `866.68 ms` (✅ **1.00x faster**)  |
| **`Verify-NumCons-55711`**   | `22.35 ms` (✅ **1.00x**)  | `22.57 ms` (✅ **1.01x slower**)   |
| **`Prove-NumCons-121247`**   | `1.46 s` (✅ **1.00x**)    | `1.44 s` (✅ **1.01x faster**)     |
| **`Verify-NumCons-121247`**  | `29.44 ms` (✅ **1.00x**)  | `29.26 ms` (✅ **1.01x faster**)   |
| **`Prove-NumCons-252319`**   | `2.60 s` (✅ **1.00x**)    | `2.60 s` (✅ **1.00x faster**)     |
| **`Verify-NumCons-252319`**  | `42.87 ms` (✅ **1.00x**)  | `42.55 ms` (✅ **1.01x faster**)   |
| **`Prove-NumCons-514463`**   | `4.97 s` (✅ **1.00x**)    | `4.97 s` (✅ **1.00x faster**)     |
| **`Verify-NumCons-514463`**  | `63.44 ms` (✅ **1.00x**)  | `63.32 ms` (✅ **1.00x faster**)   |
| **`Prove-NumCons-1038751`**  | `9.50 s` (✅ **1.00x**)    | `9.49 s` (✅ **1.00x faster**)     |
| **`Verify-NumCons-1038751`** | `108.90 ms` (✅ **1.00x**) | `110.37 ms` (✅ **1.01x slower**)  |

### CompressedSNARK-Commitments

|                             | `ref=95714b1`            | `ref=26fd303`                    |
|:----------------------------|:-------------------------|:-------------------------------- |
| **`Prove-NumCons-0`**       | `2.81 s` (✅ **1.00x**)   | `2.82 s` (✅ **1.00x slower**)    |
| **`Verify-NumCons-0`**      | `23.16 ms` (✅ **1.00x**) | `25.94 ms` (❌ *1.12x slower*)    |
| **`Prove-NumCons-6559`**    | `5.24 s` (✅ **1.00x**)   | `5.30 s` (✅ **1.01x slower**)    |
| **`Verify-NumCons-6559`**   | `26.54 ms` (✅ **1.00x**) | `29.69 ms` (❌ *1.12x slower*)    |
| **`Prove-NumCons-22943`**   | `4.78 s` (✅ **1.00x**)   | `4.69 s` (✅ **1.02x faster**)    |
| **`Verify-NumCons-22943`**  | `26.41 ms` (✅ **1.00x**) | `29.43 ms` (❌ *1.11x slower*)    |
| **`Prove-NumCons-55711`**   | `9.36 s` (✅ **1.00x**)   | `9.35 s` (✅ **1.00x faster**)    |
| **`Verify-NumCons-55711`**  | `41.18 ms` (✅ **1.00x**) | `48.20 ms` (❌ *1.17x slower*)    |
| **`Prove-NumCons-121247`**  | `7.07 s` (✅ **1.00x**)   | `6.93 s` (✅ **1.02x faster**)    |
| **`Verify-NumCons-121247`** | `40.91 ms` (✅ **1.00x**) | `48.34 ms` (❌ *1.18x slower*)    |
| **`Prove-NumCons-252319`**  | `13.64 s` (✅ **1.00x**)  | `13.70 s` (✅ **1.01x slower**)   |
| **`Verify-NumCons-252319`** | `76.59 ms` (✅ **1.00x**) | `82.58 ms` (✅ **1.08x slower**)  |

### BatchedCompressedSNARK

|                             | `ref=95714b1`              |
|:----------------------------|:-------------------------- |
| **`Prove-NumCons-0`**       | `366.25 ms` (✅ **1.00x**)  |
| **`Verify-NumCons-0`**      | `29.53 ms` (✅ **1.00x**)   |
| **`Prove-NumCons-6559`**    | `369.01 ms` (✅ **1.00x**)  |
| **`Verify-NumCons-6559`**   | `29.56 ms` (✅ **1.00x**)   |
| **`Prove-NumCons-22943`**   | `532.42 ms` (✅ **1.00x**)  |
| **`Verify-NumCons-22943`**  | `40.97 ms` (✅ **1.00x**)   |
| **`Prove-NumCons-55711`**   | `864.41 ms` (✅ **1.00x**)  |
| **`Verify-NumCons-55711`**  | `25.25 ms` (✅ **1.00x**)   |
| **`Prove-NumCons-121247`**  | `1.45 s` (✅ **1.00x**)     |
| **`Verify-NumCons-121247`** | `33.91 ms` (✅ **1.00x**)   |
| **`Prove-NumCons-252319`**  | `2.62 s` (✅ **1.00x**)     |
| **`Verify-NumCons-252319`** | `48.41 ms` (✅ **1.00x**)   |

### BatchedCompressedSNARK-Commitments

|                             | `ref=95714b1`             |
|:----------------------------|:------------------------- |
| **`Prove-NumCons-0`**       | `2.80 s` (✅ **1.00x**)    |
| **`Verify-NumCons-0`**      | `25.89 ms` (✅ **1.00x**)  |
| **`Prove-NumCons-6559`**    | `5.32 s` (✅ **1.00x**)    |
| **`Verify-NumCons-6559`**   | `28.99 ms` (✅ **1.00x**)  |
| **`Prove-NumCons-22943`**   | `4.73 s` (✅ **1.00x**)    |
| **`Verify-NumCons-22943`**  | `28.98 ms` (✅ **1.00x**)  |
| **`Prove-NumCons-55711`**   | `9.56 s` (✅ **1.00x**)    |
| **`Verify-NumCons-55711`**  | `44.85 ms` (✅ **1.00x**)  |
| **`Prove-NumCons-121247`**  | `6.87 s` (✅ **1.00x**)    |
| **`Verify-NumCons-121247`** | `44.86 ms` (✅ **1.00x**)  |
| **`Prove-NumCons-252319`**  | `13.61 s` (✅ **1.00x**)   |
| **`Verify-NumCons-252319`** | `79.39 ms` (✅ **1.00x**)  |