### PR TITLE
Make `AllocatedR1CSInstance` and `AllocatedRelaxedR1CSInstance` generic in the size of IO

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -5,7 +5,7 @@
 //! Each circuit folds the last invocation of the other into the running instance
 
 use crate::{
-  constants::{NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS, NUM_IO_IN_NOVA},
+  constants::{NIO_NOVA_FOLD, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS},
   gadgets::{
     ecc::AllocatedPoint,
     r1cs::{AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance},
@@ -117,8 +117,8 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
       AllocatedNum<E::Base>,
       Vec<AllocatedNum<E::Base>>,
       Vec<AllocatedNum<E::Base>>,
-      AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
-      AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+      AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>,
+      AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
       AllocatedPoint<E::GE>,
     ),
     SynthesisError,
@@ -152,7 +152,7 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
       .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
 
     // Allocate the running instance
-    let U: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> = AllocatedRelaxedR1CSInstance::alloc(
+    let U: AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD> = AllocatedRelaxedR1CSInstance::alloc(
       cs.namespace(|| "Allocate U"),
       self.inputs.as_ref().and_then(|inputs| inputs.U.as_ref()),
       self.params.limb_width,
@@ -182,9 +182,9 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
   fn synthesize_base_case<CS: ConstraintSystem<<E as Engine>::Base>>(
     &self,
     mut cs: CS,
-    u: AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
-  ) -> Result<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>, SynthesisError> {
-    let U_default: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> =
+    u: AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
+  ) -> Result<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>, SynthesisError> {
+    let U_default: AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD> =
       if self.params.is_primary_circuit {
         // The primary circuit just returns the default R1CS instance
         AllocatedRelaxedR1CSInstance::default(
@@ -213,17 +213,11 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
     i: &AllocatedNum<E::Base>,
     z_0: &[AllocatedNum<E::Base>],
     z_i: &[AllocatedNum<E::Base>],
-    U: &AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
-    u: &AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+    U: &AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>,
+    u: &AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
     T: &AllocatedPoint<E::GE>,
     arity: usize,
-  ) -> Result<
-    (
-      AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
-      AllocatedBit,
-    ),
-    SynthesisError,
-  > {
+  ) -> Result<(AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>, AllocatedBit), SynthesisError> {
     // Check that u.x[0] = Hash(params, U, i, z0, zi)
     let mut ro = E::ROCircuit::new(
       self.ro_consts.clone(),

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -5,7 +5,7 @@
 //! Each circuit folds the last invocation of the other into the running instance
 
 use crate::{
-  constants::{NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS},
+  constants::{NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS, NUM_IO_IN_NOVA},
   gadgets::{
     ecc::AllocatedPoint,
     r1cs::{AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance},
@@ -117,8 +117,8 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
       AllocatedNum<E::Base>,
       Vec<AllocatedNum<E::Base>>,
       Vec<AllocatedNum<E::Base>>,
-      AllocatedRelaxedR1CSInstance<E>,
-      AllocatedR1CSInstance<E>,
+      AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
+      AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
       AllocatedPoint<E::GE>,
     ),
     SynthesisError,
@@ -152,7 +152,7 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
       .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
 
     // Allocate the running instance
-    let U: AllocatedRelaxedR1CSInstance<E> = AllocatedRelaxedR1CSInstance::alloc(
+    let U: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> = AllocatedRelaxedR1CSInstance::alloc(
       cs.namespace(|| "Allocate U"),
       self.inputs.as_ref().and_then(|inputs| inputs.U.as_ref()),
       self.params.limb_width,
@@ -182,24 +182,25 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
   fn synthesize_base_case<CS: ConstraintSystem<<E as Engine>::Base>>(
     &self,
     mut cs: CS,
-    u: AllocatedR1CSInstance<E>,
-  ) -> Result<AllocatedRelaxedR1CSInstance<E>, SynthesisError> {
-    let U_default: AllocatedRelaxedR1CSInstance<E> = if self.params.is_primary_circuit {
-      // The primary circuit just returns the default R1CS instance
-      AllocatedRelaxedR1CSInstance::default(
-        cs.namespace(|| "Allocate U_default"),
-        self.params.limb_width,
-        self.params.n_limbs,
-      )?
-    } else {
-      // The secondary circuit returns the incoming R1CS instance
-      AllocatedRelaxedR1CSInstance::from_r1cs_instance(
-        cs.namespace(|| "Allocate U_default"),
-        u,
-        self.params.limb_width,
-        self.params.n_limbs,
-      )?
-    };
+    u: AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+  ) -> Result<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>, SynthesisError> {
+    let U_default: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> =
+      if self.params.is_primary_circuit {
+        // The primary circuit just returns the default R1CS instance
+        AllocatedRelaxedR1CSInstance::default(
+          cs.namespace(|| "Allocate U_default"),
+          self.params.limb_width,
+          self.params.n_limbs,
+        )?
+      } else {
+        // The secondary circuit returns the incoming R1CS instance
+        AllocatedRelaxedR1CSInstance::from_r1cs_instance(
+          cs.namespace(|| "Allocate U_default"),
+          u,
+          self.params.limb_width,
+          self.params.n_limbs,
+        )?
+      };
     Ok(U_default)
   }
 
@@ -212,11 +213,17 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
     i: &AllocatedNum<E::Base>,
     z_0: &[AllocatedNum<E::Base>],
     z_i: &[AllocatedNum<E::Base>],
-    U: &AllocatedRelaxedR1CSInstance<E>,
-    u: &AllocatedR1CSInstance<E>,
+    U: &AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
+    u: &AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
     T: &AllocatedPoint<E::GE>,
     arity: usize,
-  ) -> Result<(AllocatedRelaxedR1CSInstance<E>, AllocatedBit), SynthesisError> {
+  ) -> Result<
+    (
+      AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>,
+      AllocatedBit,
+    ),
+    SynthesisError,
+  > {
     // Check that u.x[0] = Hash(params, U, i, z0, zi)
     let mut ro = E::ROCircuit::new(
       self.ro_consts.clone(),
@@ -236,7 +243,7 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
     let hash = le_bits_to_num(cs.namespace(|| "bits to hash"), &hash_bits)?;
     let check_pass = alloc_num_equals(
       cs.namespace(|| "check consistency of u.X[0] with H(params, U, i, z0, zi)"),
-      &u.X0,
+      &u.X[0],
       &hash,
     )?;
 
@@ -352,8 +359,7 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
     let hash = le_bits_to_num(cs.namespace(|| "convert hash to num"), &hash_bits)?;
 
     // Outputs the computed hash and u.X[1] that corresponds to the hash of the other circuit
-    u.X1
-      .inputize(cs.namespace(|| "Output unmodified hash of the other circuit"))?;
+    u.X[1].inputize(cs.namespace(|| "Output unmodified hash of the other circuit"))?;
     hash.inputize(cs.namespace(|| "output new hash of this circuit"))?;
 
     Ok(z_next)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ pub(crate) const BN_LIMB_WIDTH: usize = 64;
 pub(crate) const BN_N_LIMBS: usize = 4;
 pub(crate) const NUM_FE_WITHOUT_IO_FOR_CRHF: usize = 17;
 pub(crate) const NUM_FE_FOR_RO: usize = 9;
-pub(crate) const NUM_IO_IN_NOVA: usize = 2;
+pub(crate) const NIO_NOVA_FOLD: usize = 2;
 
 /// Bit size of Nova field element hashes
 pub const NUM_HASH_BITS: usize = 250;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,7 @@ pub(crate) const BN_LIMB_WIDTH: usize = 64;
 pub(crate) const BN_N_LIMBS: usize = 4;
 pub(crate) const NUM_FE_WITHOUT_IO_FOR_CRHF: usize = 17;
 pub(crate) const NUM_FE_FOR_RO: usize = 9;
+pub(crate) const NUM_IO_IN_NOVA: usize = 2;
 
 /// Bit size of Nova field element hashes
 pub const NUM_HASH_BITS: usize = 250;

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -22,13 +22,12 @@ use itertools::Itertools as _;
 
 /// An Allocated R1CS Instance
 #[derive(Clone)]
-pub struct AllocatedR1CSInstance<E: Engine> {
+pub struct AllocatedR1CSInstance<E: Engine, const N: usize> {
   pub(crate) W: AllocatedPoint<E::GE>,
-  pub(crate) X0: AllocatedNum<E::Base>,
-  pub(crate) X1: AllocatedNum<E::Base>,
+  pub(crate) X: [AllocatedNum<E::Base>; N],
 }
 
-impl<E: Engine> AllocatedR1CSInstance<E> {
+impl<E: Engine, const N: usize> AllocatedR1CSInstance<E, N> {
   /// Takes the r1cs instance and creates a new allocated r1cs instance
   pub fn alloc<CS: ConstraintSystem<<E as Engine>::Base>>(
     mut cs: CS,
@@ -40,10 +39,25 @@ impl<E: Engine> AllocatedR1CSInstance<E> {
     )?;
     W.check_on_curve(cs.namespace(|| "check W on curve"))?;
 
-    let X0 = alloc_scalar_as_base::<E, _>(cs.namespace(|| "allocate X[0]"), u.map(|u| u.X[0]))?;
-    let X1 = alloc_scalar_as_base::<E, _>(cs.namespace(|| "allocate X[1]"), u.map(|u| u.X[1]))?;
+    let X: [AllocatedNum<E::Base>; N] = u
+      .map(|u| {
+        u.X
+          .iter()
+          .enumerate()
+          .map(|(idx, x)| {
+            alloc_scalar_as_base::<E, _>(cs.namespace(|| format!("allocate X[{}]", idx)), Some(*x))
+          })
+          .collect::<Result<Vec<_>, _>>()
+          .map(|vec| {
+            let len = vec.len();
+            vec
+              .try_into()
+              .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{len} != {N}")))
+          })
+      })
+      .unwrap_or_else(|| Err(SynthesisError::AssignmentMissing))??;
 
-    Ok(Self { W, X0, X1 })
+    Ok(Self { W, X })
   }
 
   /// Absorb the provided instance in the RO
@@ -51,22 +65,20 @@ impl<E: Engine> AllocatedR1CSInstance<E> {
     ro.absorb(&self.W.x);
     ro.absorb(&self.W.y);
     ro.absorb(&self.W.is_infinity);
-    ro.absorb(&self.X0);
-    ro.absorb(&self.X1);
+    self.X.iter().for_each(|x| ro.absorb(&x));
   }
 }
 
 /// An Allocated Relaxed R1CS Instance
 #[derive(Clone)]
-pub struct AllocatedRelaxedR1CSInstance<E: Engine> {
+pub struct AllocatedRelaxedR1CSInstance<E: Engine, const N: usize> {
   pub(crate) W: AllocatedPoint<E::GE>,
   pub(crate) E: AllocatedPoint<E::GE>,
   pub(crate) u: AllocatedNum<E::Base>,
-  pub(crate) X0: BigNat<E::Base>,
-  pub(crate) X1: BigNat<E::Base>,
+  pub(crate) X: [BigNat<E::Base>; N],
 }
 
-impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
+impl<E: Engine, const N: usize> AllocatedRelaxedR1CSInstance<E, N> {
   /// Allocates the given `RelaxedR1CSInstance` as a witness of the circuit
   pub fn alloc<CS: ConstraintSystem<<E as Engine>::Base>>(
     mut cs: CS,
@@ -91,22 +103,25 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     // So we parse all of its bytes as a E::Base element
     let u = alloc_scalar_as_base::<E, _>(cs.namespace(|| "allocate u"), inst.map(|inst| inst.u))?;
 
-    // Allocate X0 and X1. If the input instance is None, then allocate default values 0.
-    let X0 = BigNat::alloc_from_nat(
-      cs.namespace(|| "allocate X[0]"),
-      || Ok(f_to_nat(&inst.map_or(E::Scalar::ZERO, |inst| inst.X[0]))),
-      limb_width,
-      n_limbs,
-    )?;
+    // Allocate X. If the input instance is None then allocate components as zero.
+    let X = (0..N)
+      .map(|idx| {
+        BigNat::alloc_from_nat(
+          cs.namespace(|| format!("allocate X[{idx}]")),
+          || Ok(f_to_nat(&inst.map_or(E::Scalar::ZERO, |inst| inst.X[idx]))),
+          limb_width,
+          n_limbs,
+        )
+      })
+      .collect::<Result<Vec<_>, _>>()
+      .map(|vec| {
+        let len = vec.len();
+        vec
+          .try_into()
+          .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{len} != {N}")))
+      })??;
 
-    let X1 = BigNat::alloc_from_nat(
-      cs.namespace(|| "allocate X[1]"),
-      || Ok(f_to_nat(&inst.map_or(E::Scalar::ZERO, |inst| inst.X[1]))),
-      limb_width,
-      n_limbs,
-    )?;
-
-    Ok(Self { W, E, u, X0, X1 })
+    Ok(Self { W, E, u, X })
   }
 
   /// Allocates the hardcoded default `RelaxedR1CSInstance` in the circuit.
@@ -121,31 +136,35 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
 
     let u = W.x.clone(); // In the default case, W.x = u = 0
 
-    // X0 and X1 are allocated and in the honest prover case set to zero
+    // X is allocated and in the honest prover case set to zero
     // If the prover is malicious, it can set to arbitrary values, but the resulting
     // relaxed R1CS instance with the the checked default values of W, E, and u must still be satisfying
-    let X0 = BigNat::alloc_from_nat(
-      cs.namespace(|| "allocate x_default[0]"),
-      || Ok(f_to_nat(&E::Scalar::ZERO)),
-      limb_width,
-      n_limbs,
-    )?;
 
-    let X1 = BigNat::alloc_from_nat(
-      cs.namespace(|| "allocate x_default[1]"),
-      || Ok(f_to_nat(&E::Scalar::ZERO)),
-      limb_width,
-      n_limbs,
-    )?;
+    let X = (0..N)
+      .map(|idx| {
+        BigNat::alloc_from_nat(
+          cs.namespace(|| format!("allocate X_default[{idx}]")),
+          || Ok(f_to_nat(&E::Scalar::ZERO)),
+          limb_width,
+          n_limbs,
+        )
+      })
+      .collect::<Result<Vec<_>, _>>()
+      .map(|vec| {
+        let len = vec.len();
+        vec
+          .try_into()
+          .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{len} != {N}")))
+      })??;
 
-    Ok(Self { W, E, u, X0, X1 })
+    Ok(Self { W, E, u, X })
   }
 
   /// Allocates the R1CS Instance as a `RelaxedR1CSInstance` in the circuit.
   /// E = 0, u = 1
   pub fn from_r1cs_instance<CS: ConstraintSystem<<E as Engine>::Base>>(
     mut cs: CS,
-    inst: AllocatedR1CSInstance<E>,
+    inst: AllocatedR1CSInstance<E, N>,
     limb_width: usize,
     n_limbs: usize,
   ) -> Result<Self, SynthesisError> {
@@ -153,27 +172,27 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
 
     let u = alloc_one(cs.namespace(|| "one"));
 
-    let X0 = BigNat::from_num(
-      cs.namespace(|| "allocate X0 from relaxed r1cs"),
-      &Num::from(inst.X0),
-      limb_width,
-      n_limbs,
-    )?;
+    let X = inst
+      .X
+      .into_iter()
+      .enumerate()
+      .map(|(idx, x)| {
+        BigNat::from_num(
+          cs.namespace(|| format!("allocate X[{idx}] from relaxed r1cs")),
+          &Num::from(x),
+          limb_width,
+          n_limbs,
+        )
+      })
+      .collect::<Result<Vec<_>, _>>()
+      .map(|vec| {
+        let len = vec.len();
+        vec
+          .try_into()
+          .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{len} != {N}")))
+      })??;
 
-    let X1 = BigNat::from_num(
-      cs.namespace(|| "allocate X1 from relaxed r1cs"),
-      &Num::from(inst.X1),
-      limb_width,
-      n_limbs,
-    )?;
-
-    Ok(Self {
-      W: inst.W,
-      E,
-      u,
-      X0,
-      X1,
-    })
+    Ok(Self { W: inst.W, E, u, X })
   }
 
   /// Absorb the provided instance in the RO
@@ -190,36 +209,19 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     ro.absorb(&self.E.is_infinity);
     ro.absorb(&self.u);
 
-    // Analyze X0 as limbs
-    let X0_bn = self
-      .X0
-      .as_limbs()
-      .iter()
-      .enumerate()
-      .map(|(i, limb)| {
-        limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[0] to num")))
-      })
-      .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
+    for X in self.X.iter() {
+      let X_bn = X
+        .as_limbs()
+        .iter()
+        .enumerate()
+        .map(|(i, limb)| {
+          limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[0] to num")))
+        })
+        .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
 
-    // absorb each of the limbs of X[0]
-    for limb in X0_bn {
-      ro.absorb(&limb);
-    }
-
-    // Analyze X1 as limbs
-    let X1_bn = self
-      .X1
-      .as_limbs()
-      .iter()
-      .enumerate()
-      .map(|(i, limb)| {
-        limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[1] to num")))
-      })
-      .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
-
-    // absorb each of the limbs of X[1]
-    for limb in X1_bn {
-      ro.absorb(&limb);
+      for limb in X_bn {
+        ro.absorb(&limb);
+      }
     }
 
     Ok(())
@@ -230,7 +232,7 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     &self,
     mut cs: CS,
     params: &AllocatedNum<E::Base>, // hash of R1CSShape of F'
-    u: &AllocatedR1CSInstance<E>,
+    u: &AllocatedR1CSInstance<E, N>,
     T: &AllocatedPoint<E::GE>,
     ro_consts: ROConstantsCircuit<E>,
     limb_width: usize,
@@ -285,42 +287,33 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
       n_limbs,
     )?;
 
-    // Analyze X0 to bignat
-    let X0_bn = BigNat::from_num(
-      cs.namespace(|| "allocate X0_bn"),
-      &Num::from(u.X0.clone()),
-      limb_width,
-      n_limbs,
-    )?;
+    let mut X_fold = vec![];
 
-    // Fold self.X[0] + r * X[0]
-    let (_, r_0) = X0_bn.mult_mod(cs.namespace(|| "r*X[0]"), &r_bn, &m_bn)?;
-    // add X_r[0]
-    let r_new_0 = self.X0.add(&r_0)?;
-    // Now reduce
-    let X0_fold = r_new_0.red_mod(cs.namespace(|| "reduce folded X[0]"), &m_bn)?;
+    for (idx, (X, x)) in self.X.iter().zip_eq(u.X.iter()).enumerate() {
+      let x_bn = BigNat::from_num(
+        cs.namespace(|| format!("allocate u.X[{idx}]_bn")),
+        &Num::from(x.clone()),
+        limb_width,
+        n_limbs,
+      )?;
 
-    // Analyze X1 to bignat
-    let X1_bn = BigNat::from_num(
-      cs.namespace(|| "allocate X1_bn"),
-      &Num::from(u.X1.clone()),
-      limb_width,
-      n_limbs,
-    )?;
+      let (_, r) = x_bn.mult_mod(cs.namespace(|| format!("r*u.X[{idx}]")), &r_bn, &m_bn)?;
+      let r_new = X.add(&r)?;
+      let X_i_fold = r_new.red_mod(cs.namespace(|| format!("reduce folded X[{idx}]")), &m_bn)?;
+      X_fold.push(X_i_fold);
+    }
 
-    // Fold self.X[1] + r * X[1]
-    let (_, r_1) = X1_bn.mult_mod(cs.namespace(|| "r*X[1]"), &r_bn, &m_bn)?;
-    // add X_r[1]
-    let r_new_1 = self.X1.add(&r_1)?;
-    // Now reduce
-    let X1_fold = r_new_1.red_mod(cs.namespace(|| "reduce folded X[1]"), &m_bn)?;
+    let X_fold_len = X_fold.len();
+
+    let X_fold = X_fold
+      .try_into()
+      .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{X_fold_len} != {N}")))?;
 
     Ok(Self {
       W: W_fold,
       E: E_fold,
       u: u_fold,
-      X0: X0_fold,
-      X1: X1_fold,
+      X: X_fold,
     })
   }
 
@@ -339,12 +332,34 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
 pub fn conditionally_select_alloc_relaxed_r1cs<
   E: Engine,
   CS: ConstraintSystem<<E as Engine>::Base>,
+  const N: usize,
 >(
   mut cs: CS,
-  a: &AllocatedRelaxedR1CSInstance<E>,
-  b: &AllocatedRelaxedR1CSInstance<E>,
+  a: &AllocatedRelaxedR1CSInstance<E, N>,
+  b: &AllocatedRelaxedR1CSInstance<E, N>,
   condition: &Boolean,
-) -> Result<AllocatedRelaxedR1CSInstance<E>, SynthesisError> {
+) -> Result<AllocatedRelaxedR1CSInstance<E, N>, SynthesisError> {
+  let c_X = a
+    .X
+    .iter()
+    .zip_eq(b.X.iter())
+    .enumerate()
+    .map(|(idx, (a, b))| {
+      conditionally_select_bignat(
+        cs.namespace(|| format!("X[{idx}] = cond ? a.X[{idx}] : b.X[{idx}]")),
+        a,
+        b,
+        condition,
+      )
+    })
+    .collect::<Result<Vec<_>, _>>()?;
+
+  let c_X_len = c_X.len();
+
+  let c_X = c_X
+    .try_into()
+    .map_err(|_| SynthesisError::IncompatibleLengthVector(format!("{c_X_len} != {N}")))?;
+
   let c = AllocatedRelaxedR1CSInstance {
     W: conditionally_select_point(
       cs.namespace(|| "W = cond ? a.W : b.W"),
@@ -364,18 +379,7 @@ pub fn conditionally_select_alloc_relaxed_r1cs<
       &b.u,
       condition,
     )?,
-    X0: conditionally_select_bignat(
-      cs.namespace(|| "X[0] = cond ? a.X[0] : b.X[0]"),
-      &a.X0,
-      &b.X0,
-      condition,
-    )?,
-    X1: conditionally_select_bignat(
-      cs.namespace(|| "X[1] = cond ? a.X[1] : b.X[1]"),
-      &a.X1,
-      &b.X1,
-      condition,
-    )?,
+    X: c_X,
   };
   Ok(c)
 }
@@ -384,12 +388,13 @@ pub fn conditionally_select_alloc_relaxed_r1cs<
 pub fn conditionally_select_vec_allocated_relaxed_r1cs_instance<
   E: Engine,
   CS: ConstraintSystem<<E as Engine>::Base>,
+  const N: usize,
 >(
   mut cs: CS,
-  a: &[AllocatedRelaxedR1CSInstance<E>],
-  b: &[AllocatedRelaxedR1CSInstance<E>],
+  a: &[AllocatedRelaxedR1CSInstance<E, N>],
+  b: &[AllocatedRelaxedR1CSInstance<E, N>],
   condition: &Boolean,
-) -> Result<Vec<AllocatedRelaxedR1CSInstance<E>>, SynthesisError> {
+) -> Result<Vec<AllocatedRelaxedR1CSInstance<E, N>>, SynthesisError> {
   a.iter()
     .enumerate()
     .zip_eq(b.iter())
@@ -400,7 +405,7 @@ pub fn conditionally_select_vec_allocated_relaxed_r1cs_instance<
         condition,
       )
     })
-    .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E>>, _>>()
+    .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, N>>, _>>()
 }
 
 /// c = cond ? a: b, where a, b: `AllocatedPoint`

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -62,7 +62,7 @@ impl<E: Engine, const N: usize> AllocatedR1CSInstance<E, N> {
     ro.absorb(&self.W.x);
     ro.absorb(&self.W.y);
     ro.absorb(&self.W.is_infinity);
-    self.X.iter().for_each(|x| ro.absorb(&x));
+    self.X.iter().for_each(|x| ro.absorb(x));
   }
 }
 

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -206,13 +206,13 @@ impl<E: Engine, const N: usize> AllocatedRelaxedR1CSInstance<E, N> {
     ro.absorb(&self.E.is_infinity);
     ro.absorb(&self.u);
 
-    for X in self.X.iter() {
+    for (idx, X) in self.X.iter().enumerate() {
       let X_bn = X
         .as_limbs()
         .iter()
         .enumerate()
         .map(|(i, limb)| {
-          limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[0] to num")))
+          limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[{idx}] to num")))
         })
         .collect::<Result<Vec<AllocatedNum<E::Base>>, _>>()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1115,36 +1115,36 @@ mod tests {
     test_pp_digest_with::<PallasEngine, _, _, EE<_>, EE<_>>(
       &TrivialCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["492fd902cd7174159bc9a6f827d92eb54ff25efa9d0673dffdb0efd02995df01"],
+      &expect!["582db42439c0dcfc60d24b023ab83d81d97382ac2efa883c6f23147345efeb01"],
     );
 
     test_pp_digest_with::<PallasEngine, _, _, EE<_>, EE<_>>(
       &CubicCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["9b0701d9422658e3f74a85ab3e485c06f3ecca9c2b1800aab80004034d754f01"],
+      &expect!["83ef7f741c983bfc9193f1ba387b4966ca8d0818acac65583e30d72593b0f600"],
     );
 
     test_pp_digest_with::<Bn256Engine, _, _, EE<_>, EE<_>>(
       &TrivialCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["1267235eb3d139e466dd9c814eaf73f01b063ccb4cad04848c0eb62f079a9601"],
+      &expect!["09e1cc324b4469aec5abc55d48d8add5d161cbb70aa023f78e171c58e3199600"],
     );
 
     test_pp_digest_with::<Bn256Engine, _, _, EE<_>, EE<_>>(
       &CubicCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["57afac2edd20d39b202151906e41154ba186c9dde497448d1332dc6de2f76302"],
+      &expect!["7602bf1fdf3d86b8a7228de4c163e11cc3908b93412548f8cf3ebc1bc638fd00"],
     );
 
     test_pp_digest_with::<Secp256k1Engine, _, _, EE<_>, EE<_>>(
       &TrivialCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["04b5d1798be6d74b3701390b87078e70ebf3ddaad80c375319f320cedf8bca00"],
+      &expect!["dbbfd46ea48118694ec96631015c41cccc721c4f3aaf5b542bf18cca37878b02"],
     );
     test_pp_digest_with::<Secp256k1Engine, _, _, EE<_>, EE<_>>(
       &CubicCircuit::default(),
       &TrivialCircuit::default(),
-      &expect!["346b5f27cf24c79386f4de7a8bfb58970181ae7f0de7d2e3f10ad5dfd8fc2302"],
+      &expect!["c71fd5e574129205426e07edcb5fd0b26f78991d1ab883b1dfb7e82844480801"],
     );
   }
 

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -12,7 +12,7 @@
 //!    3. (optional by F logic) F circuit might check `program_counter_{i}` invoked current F circuit is legal or not.
 //!    3. F circuit produce `program_counter_{i+1}` and sent to next round for optionally constraint the next F' argumented circuit.
 use crate::{
-  constants::{NUM_HASH_BITS, NUM_IO_IN_NOVA},
+  constants::{NIO_NOVA_FOLD, NUM_HASH_BITS},
   gadgets::{
     ecc::AllocatedPoint,
     r1cs::{
@@ -270,8 +270,8 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
       AllocatedNum<E::Base>,
       Vec<AllocatedNum<E::Base>>,
       Vec<AllocatedNum<E::Base>>,
-      Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>,
-      AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+      Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>,
+      AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
       AllocatedPoint<E::GE>,
       Option<AllocatedNum<E::Base>>,
       Vec<Boolean>,
@@ -342,7 +342,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
           self.params.n_limbs,
         )
       })
-      .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>, _>>()?;
+      .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>, _>>()?;
 
     // Allocate the r1cs instance to be folded in
     let u = AllocatedR1CSInstance::alloc(
@@ -384,9 +384,9 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
   fn synthesize_base_case<CS: ConstraintSystem<<E as Engine>::Base>>(
     &self,
     mut cs: CS,
-    u: AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+    u: AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
     last_augmented_circuit_selector: &[Boolean],
-  ) -> Result<Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>, SynthesisError> {
+  ) -> Result<Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>, SynthesisError> {
     let mut cs = cs.namespace(|| "alloc U_i default");
 
     // Allocate a default relaxed r1cs instance
@@ -421,7 +421,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
             equal_bit,
           )
         })
-        .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>, _>>()?
+        .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>, _>>()?
     };
     Ok(U_default)
   }
@@ -435,15 +435,15 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
     i: &AllocatedNum<E::Base>,
     z_0: &[AllocatedNum<E::Base>],
     z_i: &[AllocatedNum<E::Base>],
-    U: &[AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>],
-    u: &AllocatedR1CSInstance<E, NUM_IO_IN_NOVA>,
+    U: &[AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>],
+    u: &AllocatedR1CSInstance<E, NIO_NOVA_FOLD>,
     T: &AllocatedPoint<E::GE>,
     arity: usize,
     last_augmented_circuit_selector: &[Boolean],
     program_counter: &Option<AllocatedNum<E::Base>>,
   ) -> Result<
     (
-      Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>,
+      Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>,
       AllocatedBit,
     ),
     SynthesisError,
@@ -505,7 +505,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
     )?;
 
     // update AllocatedRelaxedR1CSInstance on index match augmented circuit index
-    let U_next: Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>> = U
+    let U_next: Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>> = U
       .iter()
       .zip_eq(last_augmented_circuit_selector.iter())
       .map(|(U, equal_bit)| {
@@ -516,7 +516,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
           equal_bit,
         )
       })
-      .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>>, _>>()?;
+      .collect::<Result<Vec<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>>, _>>()?;
 
     Ok((U_next, check_pass))
   }

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -606,7 +606,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<PallasEngine, _>(
     &test_rom,
-    &expect!["95f57227c5d62d13b9fe55deac13b8bd099b068bcc785d7b3a054bf376f68e00"],
+    &expect!["2cd90507c9e6ae5e9afeec3dfd1544884436737d8c4f92abff0053c361fa6102"],
   );
 
   let rom = vec![
@@ -617,7 +617,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<Bn256Engine, _>(
     &test_rom_grumpkin,
-    &expect!["d439e957618eb071360f9c87c0014fd0cfa21f1271813004d18f967355912a01"],
+    &expect!["c335819a49075ca959121d1dd016f944ee742c61122074be7a487ba814c40f00"],
   );
 
   let rom = vec![
@@ -628,7 +628,7 @@ fn test_supernova_pp_digest() {
 
   test_pp_digest_with::<Secp256k1Engine, _>(
     &test_rom_secp,
-    &expect!["5dfc2cc21f0a29a67ec3b3cbb7fbff535c876ef51e655f4abf4c00e058175103"],
+    &expect!["828b9e470907cb133898186d56a14e6644cd2005cb07dd6c7e947f32831b8c02"],
   );
 }
 

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -7,13 +7,14 @@ use ff::PrimeField;
 use itertools::Itertools as _;
 
 use crate::{
+  constants::NUM_IO_IN_NOVA,
   gadgets::r1cs::{conditionally_select_alloc_relaxed_r1cs, AllocatedRelaxedR1CSInstance},
   traits::Engine,
 };
 
 /// Return the element of `a` given by the indicator bit in `selector_vec`.
 ///
-/// This function assumes `selector_vec` has been properly constrained", i.e. that exactly one entry is equal to 1.  
+/// This function assumes `selector_vec` has been properly constrained", i.e. that exactly one entry is equal to 1.
 //
 // NOTE: When `a` is greater than 5 (estimated), it will be cheaper to use a multicase gadget.
 //
@@ -22,13 +23,13 @@ use crate::{
 // larger the elements, the fewer are needed before multicase becomes cost-effective.
 pub fn get_from_vec_alloc_relaxed_r1cs<E: Engine, CS: ConstraintSystem<<E as Engine>::Base>>(
   mut cs: CS,
-  a: &[AllocatedRelaxedR1CSInstance<E>],
+  a: &[AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>],
   selector_vec: &[Boolean],
-) -> Result<AllocatedRelaxedR1CSInstance<E>, SynthesisError> {
+) -> Result<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>, SynthesisError> {
   assert_eq!(a.len(), selector_vec.len());
 
   // Compare all instances in `a` to the first one
-  let first: AllocatedRelaxedR1CSInstance<E> = a
+  let first: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> = a
     .first()
     .cloned()
     .ok_or_else(|| SynthesisError::IncompatibleLengthVector("empty vec length".to_string()))?;
@@ -127,7 +128,7 @@ mod test {
 
       let vec = (0..n)
         .map(|i| {
-          AllocatedRelaxedR1CSInstance::<PallasEngine>::default(
+          AllocatedRelaxedR1CSInstance::<PallasEngine, NUM_IO_IN_NOVA>::default(
             &mut cs.namespace(|| format!("elt-{i}")),
             4,
             64,

--- a/src/supernova/utils.rs
+++ b/src/supernova/utils.rs
@@ -7,7 +7,7 @@ use ff::PrimeField;
 use itertools::Itertools as _;
 
 use crate::{
-  constants::NUM_IO_IN_NOVA,
+  constants::NIO_NOVA_FOLD,
   gadgets::r1cs::{conditionally_select_alloc_relaxed_r1cs, AllocatedRelaxedR1CSInstance},
   traits::Engine,
 };
@@ -23,13 +23,13 @@ use crate::{
 // larger the elements, the fewer are needed before multicase becomes cost-effective.
 pub fn get_from_vec_alloc_relaxed_r1cs<E: Engine, CS: ConstraintSystem<<E as Engine>::Base>>(
   mut cs: CS,
-  a: &[AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>],
+  a: &[AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>],
   selector_vec: &[Boolean],
-) -> Result<AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA>, SynthesisError> {
+) -> Result<AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD>, SynthesisError> {
   assert_eq!(a.len(), selector_vec.len());
 
   // Compare all instances in `a` to the first one
-  let first: AllocatedRelaxedR1CSInstance<E, NUM_IO_IN_NOVA> = a
+  let first: AllocatedRelaxedR1CSInstance<E, NIO_NOVA_FOLD> = a
     .first()
     .cloned()
     .ok_or_else(|| SynthesisError::IncompatibleLengthVector("empty vec length".to_string()))?;
@@ -128,7 +128,7 @@ mod test {
 
       let vec = (0..n)
         .map(|i| {
-          AllocatedRelaxedR1CSInstance::<PallasEngine, NUM_IO_IN_NOVA>::default(
+          AllocatedRelaxedR1CSInstance::<PallasEngine, NIO_NOVA_FOLD>::default(
             &mut cs.namespace(|| format!("elt-{i}")),
             4,
             64,


### PR DESCRIPTION
This PR resolves #321.

The solution adds a const generic parameter to the two structs, and a new constant that is used in both the Nova and SuperNova augmented circuits where the instances are known to have IO of length 2.