### PR TITLE
chore: Update `rust-version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/lurk-lab/arecibo"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
-rust-version="1.70.0"
+rust-version="1.71.0"
 
 [dependencies]
 bellpepper-core = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }


### PR DESCRIPTION
Fixes e.g. https://github.com/lurk-lab/arecibo/actions/runs/7902971912/job/21576950128?pr=292

1.71.0 required by Neptune: https://github.com/lurk-lab/neptune/blob/main/Cargo.toml#L9