### PR TITLE
Eliminate hard-coded `BN_N_LIMBS` and `BN_LIMB_WIDTH` dependency.

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,7 +3,7 @@
 pub(crate) const NUM_CHALLENGE_BITS: usize = 128;
 pub(crate) const BN_LIMB_WIDTH: usize = 64;
 pub(crate) const BN_N_LIMBS: usize = 4;
-pub(crate) const NUM_FE_WITHOUT_IO_FOR_CRHF: usize = 17;
+pub(crate) const NUM_FE_WITHOUT_IO_FOR_CRHF: usize = 9 + NIO_NOVA_FOLD * BN_N_LIMBS;
 pub(crate) const NUM_FE_FOR_RO: usize = 9;
 pub(crate) const NIO_NOVA_FOLD: usize = 2;
 

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -444,7 +444,11 @@ impl<Scalar: PrimeField> BigNat<Scalar> {
     let carry_bits = (((max_word.to_f64().unwrap() * 2.0).log2() - self.params.limb_width as f64)
       .ceil()
       + 0.1) as usize;
-    let limbs_per_group = (Scalar::CAPACITY as usize - carry_bits) / self.params.limb_width;
+    let limbs_per_group = max(
+      (Scalar::CAPACITY as usize - carry_bits) / self.params.limb_width,
+      1,
+    );
+
     let self_grouped = self.group_limbs(limbs_per_group);
     let other_grouped = other.group_limbs(limbs_per_group);
     self_grouped.equal_when_carried(cs.namespace(|| "grouped"), &other_grouped)


### PR DESCRIPTION
In an attempt to see what would happen to the number of constraints if we changed the parameters `BN_N_LIMBS` and `BN_LIMB_WIDTH`, I found a couple places where the arithmetic inadvertently was dependent on the values being hardcoded as 4 and 64 respectively.

I believe this PR makes the necessary changes to make the codebase general enough to allow for varying these parameters. The expect tests expectedly (:drum: haha) fail when changing these two constants, but everything else passes.