### PR TITLE
refactor: Optimize polynomial operations with parallel scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rand = "0.8.5"
 ref-cast = "1.0.20" # allocation-less conversion in multilinear polys
 derive_more = "0.99.17" # lightens impl macros for pasta
 static_assertions = "1.1.0"
+rayon-scan = "0.1.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # grumpkin-msm has been patched to support MSMs for the pasta curve cycle

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -13,9 +13,9 @@ use crate::{
     non_hiding_kzg::{trim, KZGProverKey, KZGVerifierKey, UniversalKZGParam},
     pedersen::Commitment,
     traits::DlogGroup,
-    util::iterators::DoubleEndedIteratorExt as _,
+    util::iterators::IndexedParallelIteratorExt as _,
   },
-  spartan::polys::univariate::UniPoly,
+  spartan::{polys::univariate::UniPoly, powers},
   traits::{
     commitment::{CommitmentEngineTrait, Len},
     evaluation::EvaluationEngineTrait,
@@ -92,9 +92,7 @@ where
 
   /// Compute powers of q : (1, q, q^2, ..., q^(k-1))
   pub fn batch_challenge_powers(q: E::Fr, k: usize) -> Vec<E::Fr> {
-    std::iter::successors(Some(E::Fr::ONE), |&x| Some(x * q))
-      .take(k)
-      .collect()
+    powers(&q, k)
   }
 
   /// TODO: write doc
@@ -182,7 +180,7 @@ where
      -> (Vec<E::G1Affine>, Vec<Vec<E::Fr>>) {
       let kzg_compute_batch_polynomial = |f: Vec<Vec<E::Fr>>, q: E::Fr| -> Vec<E::Fr> {
         // Compute B(x) = f_0(x) + q * f_1(x) + ... + q^(k-1) * f_{k-1}(x)
-        let B: UniPoly<E::Fr> = f.into_iter().map(UniPoly::new).rlc(&q);
+        let B: UniPoly<E::Fr> = f.into_par_iter().map(UniPoly::new).rlc(&q);
         B.coeffs
       };
       ///////// END kzg_open_batch closure helpers

--- a/src/provider/shplonk.rs
+++ b/src/provider/shplonk.rs
@@ -3,7 +3,7 @@ use crate::provider::kzg_commitment::KZGCommitmentEngine;
 use crate::provider::non_hiding_kzg::{trim, KZGProverKey, KZGVerifierKey, UniversalKZGParam};
 use crate::provider::pedersen::Commitment;
 use crate::provider::traits::DlogGroup;
-use crate::provider::util::iterators::DoubleEndedIteratorExt;
+use crate::provider::util::iterators::IndexedParallelIteratorExt as _;
 use crate::spartan::polys::univariate::UniPoly;
 use crate::traits::commitment::Len;
 use crate::traits::evaluation::EvaluationEngineTrait;
@@ -12,9 +12,7 @@ use crate::{CommitmentEngineTrait, NovaError};
 use ff::{Field, PrimeFieldBits};
 use group::{Curve, Group as group_Group};
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
-use rayon::iter::{
-  IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
+use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::marker::PhantomData;
 
@@ -191,7 +189,7 @@ where
     // Phase 3
     // Compute B(x) = f_0(x) + q * f_1(x) + ... + q^(k-1) * f_{k-1}(x)
     let q = HyperKZG::<E, NE>::get_batch_challenge(&evals, transcript);
-    let batched_Pi: UniPoly<E::Fr> = polys.into_iter().map(UniPoly::new).rlc(&q);
+    let batched_Pi: UniPoly<E::Fr> = polys.into_par_iter().map(UniPoly::new).rlc(&q);
 
     // Q(x), R(x) = P(x) / D(x), where D(x) = (x - r) * (x + r) * (x - r^2) = 1 * x^3 - r^2 * x^2 - r^2 * x + r^4
     let D = UniPoly::new(vec![u[2] * u[2], -u[2], -u[2], E::Fr::from(1)]);
@@ -300,7 +298,7 @@ where
       }
     }
 
-    let C_P: E::G1 = pi.comms.iter().map(|comm| comm.to_curve()).rlc(&q);
+    let C_P: E::G1 = pi.comms.par_iter().map(|comm| comm.to_curve()).rlc(&q);
     let C_Q = pi.C_Q;
     let C_H = pi.C_H;
     let r_squared = u[2];
@@ -339,6 +337,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::provider::util::iterators::DoubleEndedIteratorExt as _;
   use crate::traits::TranscriptEngineTrait;
   use crate::{provider::keccak::Keccak256Transcript, CommitmentEngineTrait, CommitmentKey};
   use halo2curves::bn256::G1;

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -202,7 +202,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
 
     // Sample challenge for random linear-combination of outer claims
     let outer_r = transcript.squeeze(b"out_r")?;
-    let outer_r_powers = powers::<E>(&outer_r, num_instances);
+    let outer_r_powers = powers(&outer_r, num_instances);
 
     // Verify outer sumcheck: Az * Bz - uCz_E for each instance
     let (sc_proof_outer, r_x, claims_outer) = SumcheckProof::prove_cubic_with_additive_term_batch(
@@ -257,7 +257,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     let inner_r = transcript.squeeze(b"in_r")?;
     let inner_r_square = inner_r.square();
     let inner_r_cube = inner_r_square * inner_r;
-    let inner_r_powers = powers::<E>(&inner_r_cube, num_instances);
+    let inner_r_powers = powers(&inner_r_cube, num_instances);
 
     let claims_inner_joint = evals_Az_Bz_Cz
       .iter()
@@ -405,7 +405,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
 
     // Sample challenge for random linear-combination of outer claims
     let outer_r = transcript.squeeze(b"out_r")?;
-    let outer_r_powers = powers::<E>(&outer_r, num_instances);
+    let outer_r_powers = powers(&outer_r, num_instances);
 
     let (claim_outer_final, r_x) = self.sc_proof_outer.verify_batch(
       &vec![E::Scalar::ZERO; num_instances],
@@ -456,7 +456,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     let inner_r = transcript.squeeze(b"in_r")?;
     let inner_r_square = inner_r.square();
     let inner_r_cube = inner_r_square * inner_r;
-    let inner_r_powers = powers::<E>(&inner_r_cube, num_instances);
+    let inner_r_powers = powers(&inner_r_cube, num_instances);
 
     // Compute inner claims Mzᵢ = (Azᵢ + r⋅Bzᵢ + r²⋅Czᵢ),
     // which are batched by Sumcheck into one claim:  ∑ᵢ r³ⁱ⋅Mzᵢ

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -840,7 +840,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
     let rho = transcript.squeeze(b"r")?;
 
     let s = transcript.squeeze(b"r")?;
-    let s_powers = powers::<E>(&s, num_instances * num_claims_per_instance);
+    let s_powers = powers(&s, num_instances * num_claims_per_instance);
 
     let (claim_sc_final, rand_sc) = {
       // Gather all claims into a single vector
@@ -1176,7 +1176,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARK<E, EE> {
 
     // Sample a challenge for the random linear combination of all scaled claims
     let s = transcript.squeeze(b"r")?;
-    let coeffs = powers::<E>(&s, claims.len());
+    let coeffs = powers(&s, claims.len());
 
     // At the start of each round, the running claim is equal to the random linear combination
     // of the Sumcheck claims, evaluated over the bound polynomials.

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -367,7 +367,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
       .collect::<Vec<E::Scalar>>();
 
     let s = transcript.squeeze(b"r")?;
-    let coeffs = powers::<E>(&s, claims.len());
+    let coeffs = powers(&s, claims.len());
 
     // compute the joint claim
     let claim = zip_with!((claims.iter(), coeffs.iter()), |c_1, c_2| *c_1 * c_2).sum();
@@ -879,7 +879,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
     let num_claims = 10;
     let s = transcript.squeeze(b"r")?;
-    let coeffs = powers::<E>(&s, num_claims);
+    let coeffs = powers(&s, num_claims);
     let claim = (coeffs[7] + coeffs[8]) * claim; // rest are zeros
 
     // verify sc

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -453,7 +453,7 @@ pub(in crate::spartan) fn batch_eval_prove<E: Engine>(
 
   // generate a challenge, and powers of it for random linear combination
   let rho = transcript.squeeze(b"r")?;
-  let powers_of_rho = powers::<E>(&rho, num_claims);
+  let powers_of_rho = powers(&rho, num_claims);
 
   let (claims, u_xs, comms): (Vec<_>, Vec<_>, Vec<_>) =
     u_vec.into_iter().map(|u| (u.e, u.x, u.c)).multiunzip();
@@ -511,7 +511,7 @@ pub(in crate::spartan) fn batch_eval_verify<E: Engine>(
 
   // generate a challenge
   let rho = transcript.squeeze(b"r")?;
-  let powers_of_rho = powers::<E>(&rho, num_claims);
+  let powers_of_rho = powers(&rho, num_claims);
 
   // Compute nᵢ and n = maxᵢ{nᵢ}
   let num_rounds = u_vec.iter().map(|u| u.x.len()).collect::<Vec<_>>();


### PR DESCRIPTION
- Optimized performance by introducing parallel scans methods across multiple components, focusing on the `rlc<T, F>` method and the `powers` function.
- Switched from `DoubleEndedIteratorExt` to `IndexedParallelIteratorExt` across several files for iterator processing in parallel, and modified corresponding imports accordingly.
- Left `DoubleEndedIteratorExt` as an option, since it's more efficient on small polynomials,
- Added `rayon-scan` to general dependencies

## Benches
https://gist.github.com/huitseeker/9094bf6b1c68d83f4c0290e68c6c5beb

Excerpt:
```
Benchmarking PCS-Proving 10/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [5.3010 ms 5.3071 ms 5.3111 ms]
                        change: [-1.9609% -1.7245% -1.5197%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking PCS-Proving 10/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [5.0915 ms 5.1006 ms 5.1113 ms]
                        change: [-1.4249% -0.9489% -0.4561%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Benchmarking PCS-Verifying 10/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.7398 ms 1.7941 ms 1.8332 ms]
                        change: [+1.4410% +5.8646% +10.456%] (p = 0.03 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Verifying 10/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.6421 ms 1.6721 ms 1.7167 ms]
                        change: [-25.528% -23.891% -22.609%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking PCS-Proving 12/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [13.860 ms 13.897 ms 13.922 ms]
                        change: [-2.9355% -2.0591% -1.1507%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking PCS-Proving 12/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [12.516 ms 12.894 ms 13.414 ms]
                        change: [-1.9522% -0.1449% +2.1939%] (p = 0.92 > 0.05)
                        No change in performance detected.

Benchmarking PCS-Verifying 12/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.7331 ms 1.7738 ms 1.8319 ms]
                        change: [+4.0118% +8.5040% +13.413%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Verifying 12/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.6813 ms 1.7043 ms 1.7406 ms]
                        change: [-27.955% -25.826% -23.707%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking PCS-Proving 14/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [45.807 ms 46.013 ms 46.171 ms]
                        change: [-1.8652% -1.1684% -0.4207%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Benchmarking PCS-Proving 14/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [40.215 ms 40.674 ms 41.234 ms]
                        change: [-1.5516% -0.1620% +1.3679%] (p = 0.84 > 0.05)
                        No change in performance detected.

Benchmarking PCS-Verifying 14/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.6864 ms 1.7380 ms 1.7911 ms]
                        change: [+3.3281% +6.5028% +9.7707%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Verifying 14/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.6934 ms 1.7149 ms 1.7339 ms]
                        change: [-38.309% -36.955% -35.256%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking PCS-Proving 16/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [56.960 ms 57.401 ms 57.911 ms]
                        change: [-1.9650% -0.4809% +1.1637%] (p = 0.60 > 0.05)
                        No change in performance detected.
Benchmarking PCS-Proving 16/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [144.40 ms 146.11 ms 147.10 ms]
                        change: [-3.0841% -1.3092% +0.1681%] (p = 0.16 > 0.05)
                        No change in performance detected.

Benchmarking PCS-Verifying 16/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.7697 ms 1.8230 ms 1.8705 ms]
                        change: [+8.8669% +11.972% +14.877%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Verifying 16/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.7504 ms 1.7893 ms 1.8288 ms]
                        change: [-39.552% -38.348% -37.334%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking PCS-Proving 18/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [92.503 ms 94.145 ms 95.466 ms]
                        change: [-3.4856% -1.2100% +1.0332%] (p = 0.34 > 0.05)
                        No change in performance detected.
Benchmarking PCS-Proving 18/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [126.80 ms 127.90 ms 129.16 ms]
                        change: [-0.2031% +0.6876% +1.6003%] (p = 0.17 > 0.05)
                        No change in performance detected.

Benchmarking PCS-Verifying 18/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.8290 ms 1.8495 ms 1.8756 ms]
                        change: [+5.9647% +9.8855% +14.680%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Verifying 18/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.7422 ms 1.7515 ms 1.7584 ms]
                        change: [-45.244% -44.721% -44.209%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking PCS-Proving 20/arecibo::provider::hyperkzg::EvaluationEngine<halo2cur
                        time:   [197.93 ms 198.95 ms 199.83 ms]
                        change: [+1.0665% +1.9132% +2.8369%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking PCS-Proving 20/arecibo::provider::shplonk::EvaluationEngine<halo2curv
                        time:   [333.84 ms 335.52 ms 337.42 ms]
                        change: [-0.7533% +0.0132% +0.8489%] (p = 0.98 > 0.05)
                        No change in performance detected.

Benchmarking PCS-Verifying 20/arecibo::provider::hyperkzg::EvaluationEngine<halo2c
                        time:   [1.8954 ms 1.9183 ms 1.9365 ms]
                        change: [+0.5823% +5.3112% +9.8971%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Benchmarking PCS-Verifying 20/arecibo::provider::shplonk::EvaluationEngine<halo2cu
                        time:   [1.6963 ms 1.7098 ms 1.7195 ms]
                        change: [-47.135% -46.221% -45.047%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Follows #260.
Fixes #223 