### PR TITLE
chore: Update dependency versions and sources in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version="1.71.0"
 
 [dependencies]
 bellpepper-core = { version = "0.4.0", default-features = false }
-bellpepper = { git="https://github.com/huitseeker/bellpepper", branch="dev", default-features = false }
+bellpepper = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
 halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
@@ -23,7 +23,7 @@ rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
 subtle = "2.5"
 pasta_curves = { version = "0.5.0", features = ["repr-c", "serde"] }
-neptune = { git = "https://github.com/huitseeker/neptune", branch="switch-bellpepper-dependency", default-features = false, features = ["abomonation"] }
+neptune = { git = "https://github.com/lurk-lab/neptune", branch="dev", default-features = false, features = ["abomonation"] }
 generic-array = "1.0.0"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 rust-version="1.71.0"
 
 [dependencies]
-bellpepper-core = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }
-bellpepper = { git="https://github.com/lurk-lab/bellpepper", branch="dev", default-features = false }
+bellpepper-core = { version = "0.4.0", default-features = false }
+bellpepper = { git="https://github.com/huitseeker/bellpepper", branch="dev", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
 halo2curves = { version = "0.6.0", features = ["bits", "derive_serde"] }
@@ -23,7 +23,7 @@ rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
 subtle = "2.5"
 pasta_curves = { version = "0.5.0", features = ["repr-c", "serde"] }
-neptune = { git = "https://github.com/lurk-lab/neptune", branch="dev", default-features = false, features = ["abomonation"] }
+neptune = { git = "https://github.com/huitseeker/neptune", branch="switch-bellpepper-dependency", default-features = false, features = ["abomonation"] }
 generic-array = "1.0.0"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"


### PR DESCRIPTION
Companion PR of https://github.com/lurk-lab/bellpepper/pull/84

## In detail
- Updated the version of `bellpepper-core` dependency to `0.4.0`.
- Changed the repository source for `bellpepper` and `neptune` dependencies from `lurk-lab` to `huitseeker`.
- Transitioned `neptune` dependency's branch from "dev" to "switch-bellpepper-dependency".

> [!IMPORTANT]
> The CI failure on cargo-deny is expected (on commits pointing at the branch of the above PR).
> To stamp, please wait for the commit pointing:
> -  the bellpepper dependency back to https://github.com/lurk-rs/bellpepper@dev
> - the neptune dependency back to https://github.com/lurk-rs/neptune@dev