### PR TITLE
Batch inversion & normalization

### DIFF
--- a/src/provider/util/mod.rs
+++ b/src/provider/util/mod.rs
@@ -21,7 +21,7 @@ pub mod field {
     let mut scratch_space = v
       .iter()
       .map(|x| {
-        if x.is_zero_vartime() {
+        if !x.is_zero_vartime() {
           Ok(*x)
         } else {
           Err(NovaError::InternalError)


### PR DESCRIPTION
- Uses Montgomery-style batch inversion from ff:Field, rather than reimplementing in two places,
- Uses batch normalization for HyperKZG inversions.