### PR TITLE
No more assert on result

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,7 @@
 xclippy = [
     "clippy", "--all-targets", "--",
     "-Wclippy::all",
+    "-Wclippy::assertions_on_result_states",
     "-Wclippy::cast_lossless",
     "-Wclippy::checked_conversions",
     "-Wclippy::dbg_macro",

--- a/benches/common/supernova/bench.rs
+++ b/benches/common/supernova/bench.rs
@@ -99,29 +99,28 @@ pub fn bench_snark_internal_with_arity<
       // Benchmark the prove time
       group.bench_function(bench_params.bench_id("Prove"), |b| {
         b.iter(|| {
-          assert!(CompressedSNARK::<_, S1, S2>::prove(
+          CompressedSNARK::<_, S1, S2>::prove(
             black_box(&pp),
             black_box(&prover_key),
-            black_box(&recursive_snark)
+            black_box(&recursive_snark),
           )
-          .is_ok());
+          .unwrap();
         })
       });
 
-      let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &prover_key, &recursive_snark);
-      assert!(res.is_ok());
-      let compressed_snark = res.unwrap();
+      let compressed_snark =
+        CompressedSNARK::<_, S1, S2>::prove(&pp, &prover_key, &recursive_snark).unwrap();
       // Benchmark the verification time
       group.bench_function(bench_params.bench_id("Verify"), |b| {
         b.iter(|| {
-          assert!(black_box(&compressed_snark)
+          black_box(&compressed_snark)
             .verify(
               black_box(&pp),
               black_box(&verifier_key),
               black_box(&z0_primary),
               black_box(&z0_secondary),
             )
-            .is_ok());
+            .unwrap();
         })
       });
     }
@@ -129,26 +128,26 @@ pub fn bench_snark_internal_with_arity<
       // Benchmark the prove time
       group.bench_function(bench_params.bench_id("Prove"), |b| {
         b.iter(|| {
-          assert!(black_box(&mut recursive_snark.clone())
+          black_box(&mut recursive_snark.clone())
             .prove_step(
               black_box(&pp),
               &bench.primary_circuit(0),
-              &bench.secondary_circuit()
+              &bench.secondary_circuit(),
             )
-            .is_ok());
+            .unwrap();
         })
       });
 
       // Benchmark the verification time
       group.bench_function(bench_params.bench_id("Verify"), |b| {
         b.iter(|| {
-          assert!(black_box(&mut recursive_snark.clone())
+          black_box(&mut recursive_snark.clone())
             .verify(
               black_box(&pp),
               black_box(&[<Bn256EngineKZG as Engine>::Scalar::from(2u64)]),
               black_box(&[<GrumpkinEngine as Engine>::Scalar::from(2u64)]),
             )
-            .is_ok());
+            .unwrap();
         })
       });
     }

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -86,17 +86,19 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   .unwrap();
 
   for i in 0..num_steps {
-    let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
-    assert!(res.is_ok());
+    recursive_snark
+      .prove_step(&pp, &c_primary, &c_secondary)
+      .unwrap();
 
     // verify the recursive snark at each step of recursion
-    let res = recursive_snark.verify(
-      &pp,
-      i + 1,
-      &[<E1 as Engine>::Scalar::from(2u64)],
-      &[<E2 as Engine>::Scalar::from(2u64)],
-    );
-    assert!(res.is_ok());
+    recursive_snark
+      .verify(
+        &pp,
+        i + 1,
+        &[<E1 as Engine>::Scalar::from(2u64)],
+        &[<E2 as Engine>::Scalar::from(2u64)],
+      )
+      .unwrap();
   }
 
   let bench_params = BenchParams {
@@ -108,29 +110,27 @@ fn bench_compressed_snark_internal<S1: RelaxedR1CSSNARKTrait<E1>, S2: RelaxedR1C
   // Bench time to produce a compressed SNARK
   group.bench_function(bench_params.bench_id("Prove"), |b| {
     b.iter(|| {
-      assert!(CompressedSNARK::<_, S1, S2>::prove(
+      CompressedSNARK::<_, S1, S2>::prove(
         black_box(&pp),
         black_box(&pk),
-        black_box(&recursive_snark)
+        black_box(&recursive_snark),
       )
-      .is_ok());
+      .unwrap();
     })
   });
-  let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark);
-  assert!(res.is_ok());
-  let compressed_snark = res.unwrap();
+  let compressed_snark = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark).unwrap();
 
   // Benchmark the verification time
   group.bench_function(bench_params.bench_id("Verify"), |b| {
     b.iter(|| {
-      assert!(black_box(&compressed_snark)
+      black_box(&compressed_snark)
         .verify(
           black_box(&vk),
           black_box(num_steps),
           black_box(&[<E1 as Engine>::Scalar::from(2u64)]),
           black_box(&[<E2 as Engine>::Scalar::from(2u64)]),
         )
-        .is_ok());
+        .unwrap();
     })
   });
 }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -94,17 +94,19 @@ fn bench_recursive_snark(c: &mut Criterion) {
     .unwrap();
 
     for i in 0..num_warmup_steps {
-      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, &c_primary, &c_secondary)
+        .unwrap();
 
       // verify the recursive snark at each step of recursion
-      let res = recursive_snark.verify(
-        &pp,
-        i + 1,
-        &[<E1 as Engine>::Scalar::from(2u64)],
-        &[<E2 as Engine>::Scalar::from(2u64)],
-      );
-      assert!(res.is_ok());
+      recursive_snark
+        .verify(
+          &pp,
+          i + 1,
+          &[<E1 as Engine>::Scalar::from(2u64)],
+          &[<E2 as Engine>::Scalar::from(2u64)],
+        )
+        .unwrap();
     }
 
     let bench_params = BenchParams {
@@ -116,27 +118,27 @@ fn bench_recursive_snark(c: &mut Criterion) {
     group.bench_function(bench_params.bench_id("Prove"), |b| {
       b.iter(|| {
         // produce a recursive SNARK for a step of the recursion
-        assert!(black_box(&mut recursive_snark.clone())
+        black_box(&mut recursive_snark.clone())
           .prove_step(
             black_box(&pp),
             black_box(&c_primary),
             black_box(&c_secondary),
           )
-          .is_ok());
+          .unwrap();
       })
     });
 
     // Benchmark the verification time
     group.bench_function(bench_params.bench_id("Verify"), |b| {
       b.iter(|| {
-        assert!(black_box(&recursive_snark)
+        black_box(&recursive_snark)
           .verify(
             black_box(&pp),
             black_box(num_warmup_steps),
             black_box(&[<E1 as Engine>::Scalar::from(2u64)]),
             black_box(&[<E2 as Engine>::Scalar::from(2u64)]),
           )
-          .is_ok());
+          .unwrap();
       });
     });
     group.finish();

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -179,13 +179,13 @@ fn bench_recursive_snark(c: &mut Criterion) {
         .unwrap();
 
         // produce a recursive SNARK for a step of the recursion
-        assert!(recursive_snark
+        recursive_snark
           .prove_step(
             black_box(&pp),
             black_box(&circuit_primary),
             black_box(&circuit_secondary),
           )
-          .is_ok());
+          .unwrap();
       })
     });
     group.finish();

--- a/examples/and.rs
+++ b/examples/and.rs
@@ -270,8 +270,9 @@ fn main() {
 
     let start = Instant::now();
     for circuit_primary in circuits.iter() {
-      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, circuit_primary, &circuit_secondary)
+        .unwrap();
     }
     println!(
       "RecursiveSNARK::prove {} AND ops: took {:?} ",
@@ -288,7 +289,7 @@ fn main() {
       &[<E2 as Engine>::Scalar::ZERO],
     );
     println!("RecursiveSNARK::verify: {:?}", res.is_ok(),);
-    assert!(res.is_ok());
+    res.unwrap();
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with HyperKZG...");
@@ -327,7 +328,7 @@ fn main() {
       res.is_ok(),
       start.elapsed()
     );
-    assert!(res.is_ok());
+    res.unwrap();
     println!("=========================================================");
   }
 }

--- a/examples/hashchain.rs
+++ b/examples/hashchain.rs
@@ -167,8 +167,9 @@ fn main() {
 
     for (i, circuit_primary) in circuits.iter().enumerate() {
       let start = Instant::now();
-      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, circuit_primary, &circuit_secondary)
+        .unwrap();
 
       println!("RecursiveSNARK::prove {} : took {:?} ", i, start.elapsed());
     }
@@ -182,7 +183,7 @@ fn main() {
       &[<E2 as Engine>::Scalar::ZERO],
     );
     println!("RecursiveSNARK::verify: {:?}", res.is_ok(),);
-    assert!(res.is_ok());
+    res.unwrap();
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with HyperKZG...");
@@ -221,7 +222,7 @@ fn main() {
       res.is_ok(),
       start.elapsed()
     );
-    assert!(res.is_ok());
+    res.unwrap();
     println!("=========================================================");
   }
 }

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -314,7 +314,6 @@ fn main() {
     for (i, circuit_primary) in minroot_circuits.iter().enumerate() {
       let start = Instant::now();
       let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
       println!(
         "RecursiveSNARK::prove_step {}: {:?}, took {:?} ",
         i,
@@ -332,7 +331,7 @@ fn main() {
       res.is_ok(),
       start.elapsed()
     );
-    assert!(res.is_ok());
+    res.unwrap();
 
     // produce a compressed SNARK
     println!("Generating a CompressedSNARK using Spartan with HyperKZG...");
@@ -372,7 +371,7 @@ fn main() {
       res.is_ok(),
       start.elapsed()
     );
-    assert!(res.is_ok());
+    res.unwrap();
     println!("=========================================================");
   }
 }

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -53,7 +53,7 @@ mod tests {
     let (inst, witness) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that this is satisfiable
-    assert!(shape.is_sat(&ck, &inst, &witness).is_ok());
+    shape.is_sat(&ck, &inst, &witness).unwrap();
   }
 
   #[test]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -427,7 +427,7 @@ mod tests {
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable
-    assert!(shape1.is_sat(&ck1, &inst1, &witness1).is_ok());
+    shape1.is_sat(&ck1, &inst1, &witness1).unwrap();
 
     // Execute the base case for the secondary
     let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
@@ -446,7 +446,7 @@ mod tests {
     let _ = circuit2.synthesize(&mut cs2);
     let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();
     // Make sure that it is satisfiable
-    assert!(shape2.is_sat(&ck2, &inst2, &witness2).is_ok());
+    shape2.is_sat(&ck2, &inst2, &witness2).unwrap();
   }
 
   #[test]

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -1056,7 +1056,7 @@ mod tests {
     let e_new = a_p.scalar_mul(&s);
     assert!(e_p.x == e_new.x && e_p.y == e_new.y);
     // Make sure that this is satisfiable
-    assert!(shape.is_sat(&ck, &inst, &witness).is_ok());
+    shape.is_sat(&ck, &inst, &witness).unwrap();
   }
 
   fn synthesize_add_equal<G, CS>(mut cs: CS) -> (AllocatedPoint<G>, AllocatedPoint<G>)
@@ -1111,7 +1111,7 @@ mod tests {
     let e_new = a_p.add(&a_p);
     assert!(e_p.x == e_new.x && e_p.y == e_new.y);
     // Make sure that it is satisfiable
-    assert!(shape.is_sat(&ck, &inst, &witness).is_ok());
+    shape.is_sat(&ck, &inst, &witness).unwrap();
   }
 
   fn synthesize_add_negation<G, CS>(mut cs: CS) -> AllocatedPoint<G>
@@ -1180,6 +1180,6 @@ mod tests {
     );
     assert!(e_p.is_infinity);
     // Make sure that it is satisfiable
-    assert!(shape.is_sat(&ck, &inst, &witness).is_ok());
+    shape.is_sat(&ck, &inst, &witness).unwrap();
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1180,18 +1180,19 @@ mod tests {
     )
     .unwrap();
 
-    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2);
-
-    assert!(res.is_ok());
+    recursive_snark
+      .prove_step(&pp, &test_circuit1, &test_circuit2)
+      .unwrap();
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(
-      &pp,
-      num_steps,
-      &[<E1 as Engine>::Scalar::ZERO],
-      &[<Dual<E1> as Engine>::Scalar::ZERO],
-    );
-    assert!(res.is_ok());
+    recursive_snark
+      .verify(
+        &pp,
+        num_steps,
+        &[<E1 as Engine>::Scalar::ZERO],
+        &[<Dual<E1> as Engine>::Scalar::ZERO],
+      )
+      .unwrap();
   }
 
   #[test]
@@ -1230,29 +1231,30 @@ mod tests {
     .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, &circuit_primary, &circuit_secondary)
+        .unwrap();
 
       // verify the recursive snark at each step of recursion
-      let res = recursive_snark.verify(
-        &pp,
-        i + 1,
-        &[<E1 as Engine>::Scalar::ONE],
-        &[<Dual<E1> as Engine>::Scalar::ZERO],
-      );
-      assert!(res.is_ok());
+      recursive_snark
+        .verify(
+          &pp,
+          i + 1,
+          &[<E1 as Engine>::Scalar::ONE],
+          &[<Dual<E1> as Engine>::Scalar::ZERO],
+        )
+        .unwrap();
     }
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(
-      &pp,
-      num_steps,
-      &[<E1 as Engine>::Scalar::ONE],
-      &[<Dual<E1> as Engine>::Scalar::ZERO],
-    );
-    assert!(res.is_ok());
-
-    let (zn_primary, zn_secondary) = res.unwrap();
+    let (zn_primary, zn_secondary) = recursive_snark
+      .verify(
+        &pp,
+        num_steps,
+        &[<E1 as Engine>::Scalar::ONE],
+        &[<Dual<E1> as Engine>::Scalar::ZERO],
+      )
+      .unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
     assert_eq!(zn_primary, vec![<E1 as Engine>::Scalar::ONE]);
@@ -1308,20 +1310,20 @@ mod tests {
     .unwrap();
 
     for _i in 0..num_steps {
-      let res = recursive_snark.prove_step(&pp, &circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, &circuit_primary, &circuit_secondary)
+        .unwrap();
     }
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(
-      &pp,
-      num_steps,
-      &[<E1 as Engine>::Scalar::ONE],
-      &[<Dual<E1> as Engine>::Scalar::ZERO],
-    );
-    assert!(res.is_ok());
-
-    let (zn_primary, zn_secondary) = res.unwrap();
+    let (zn_primary, zn_secondary) = recursive_snark
+      .verify(
+        &pp,
+        num_steps,
+        &[<E1 as Engine>::Scalar::ONE],
+        &[<Dual<E1> as Engine>::Scalar::ZERO],
+      )
+      .unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
     assert_eq!(zn_primary, vec![<E1 as Engine>::Scalar::ONE]);
@@ -1340,9 +1342,7 @@ mod tests {
     let (pk, vk) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark);
-    assert!(res.is_ok());
-    let compressed_snark = res.unwrap();
+    let compressed_snark = CompressedSNARK::<_, S1, S2>::prove(&pp, &pk, &recursive_snark).unwrap();
 
     // verify the compressed SNARK
     compressed_snark
@@ -1560,25 +1560,27 @@ mod tests {
     .unwrap();
 
     for circuit_primary in roots.iter().take(num_steps) {
-      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
-      assert!(res.is_ok());
+      recursive_snark
+        .prove_step(&pp, circuit_primary, &circuit_secondary)
+        .unwrap();
     }
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(&pp, num_steps, &z0_primary, &z0_secondary);
-    assert!(res.is_ok());
+    recursive_snark
+      .verify(&pp, num_steps, &z0_primary, &z0_secondary)
+      .unwrap();
 
     // produce the prover and verifier keys for compressed snark
     let (pk, vk) = CompressedSNARK::<_, S<E1, EE1>, S<_, EE2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res = CompressedSNARK::<_, S<E1, EE1>, S<_, EE2>>::prove(&pp, &pk, &recursive_snark);
-    assert!(res.is_ok());
-    let compressed_snark = res.unwrap();
+    let compressed_snark =
+      CompressedSNARK::<_, S<E1, EE1>, S<_, EE2>>::prove(&pp, &pk, &recursive_snark).unwrap();
 
     // verify the compressed SNARK
-    let res = compressed_snark.verify(&vk, num_steps, &z0_primary, &z0_secondary);
-    assert!(res.is_ok());
+    compressed_snark
+      .verify(&vk, num_steps, &z0_primary, &z0_secondary)
+      .unwrap();
   }
 
   #[test]
@@ -1618,20 +1620,19 @@ mod tests {
     .unwrap();
 
     // produce a recursive SNARK
-    let res = recursive_snark.prove_step(&pp, &test_circuit1, &test_circuit2);
-
-    assert!(res.is_ok());
+    recursive_snark
+      .prove_step(&pp, &test_circuit1, &test_circuit2)
+      .unwrap();
 
     // verify the recursive SNARK
-    let res = recursive_snark.verify(
-      &pp,
-      num_steps,
-      &[<E1 as Engine>::Scalar::ONE],
-      &[<Dual<E1> as Engine>::Scalar::ZERO],
-    );
-    assert!(res.is_ok());
-
-    let (zn_primary, zn_secondary) = res.unwrap();
+    let (zn_primary, zn_secondary) = recursive_snark
+      .verify(
+        &pp,
+        num_steps,
+        &[<E1 as Engine>::Scalar::ONE],
+        &[<Dual<E1> as Engine>::Scalar::ZERO],
+      )
+      .unwrap();
 
     assert_eq!(zn_primary, vec![<E1 as Engine>::Scalar::ONE]);
     assert_eq!(zn_secondary, vec![<Dual<E1> as Engine>::Scalar::from(5u64)]);

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -232,7 +232,7 @@ mod tests {
     let (U1, W1) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the first instance is satisfiable
-    assert!(shape.is_sat(&ck, &U1, &W1).is_ok());
+    shape.is_sat(&ck, &U1, &W1).unwrap();
 
     // Now get the instance and assignment for second instance
     let mut cs = SatisfyingAssignment::<E>::new();
@@ -240,7 +240,7 @@ mod tests {
     let (U2, W2) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the second instance is satisfiable
-    assert!(shape.is_sat(&ck, &U2, &W2).is_ok());
+    shape.is_sat(&ck, &U2, &W2).unwrap();
 
     // execute a sequence of folds
     execute_sequence(
@@ -309,7 +309,7 @@ mod tests {
     r_U = U;
 
     // check if the running instance is satisfiable
-    assert!(shape.is_sat_relaxed(ck, &r_U, &r_W).is_ok());
+    shape.is_sat_relaxed(ck, &r_U, &r_W).unwrap();
   }
 
   fn test_tiny_r1cs_with<E: Engine>() {
@@ -352,7 +352,7 @@ mod tests {
         };
 
         // check that generated instance is satisfiable
-        assert!(S.is_sat(ck, &U, &W).is_ok());
+        S.is_sat(ck, &U, &W).unwrap();
 
         (O, U, W)
       };

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -453,23 +453,23 @@ mod tests {
     // The prover does not recompute so it may produce a proof, but it should not verify
     let point = vec![Fr::from(0), Fr::from(0)];
     let eval = Fr::ONE;
-    assert!(test_inner(point, eval).is_ok());
+    test_inner(point, eval).unwrap();
 
     let point = vec![Fr::from(0), Fr::from(1)];
     let eval = Fr::from(2);
-    assert!(test_inner(point, eval).is_ok());
+    test_inner(point, eval).unwrap();
 
     let point = vec![Fr::from(1), Fr::from(1)];
     let eval = Fr::from(4);
-    assert!(test_inner(point, eval).is_ok());
+    test_inner(point, eval).unwrap();
 
     let point = vec![Fr::from(0), Fr::from(2)];
     let eval = Fr::from(3);
-    assert!(test_inner(point, eval).is_ok());
+    test_inner(point, eval).unwrap();
 
     let point = vec![Fr::from(2), Fr::from(2)];
     let eval = Fr::from(9);
-    assert!(test_inner(point, eval).is_ok());
+    test_inner(point, eval).unwrap();
 
     // Try a couple incorrect evaluations and expect failure
     let point = vec![Fr::from(2), Fr::from(2)];
@@ -524,7 +524,7 @@ mod tests {
     // eval = 57
     let eval = Fr::from(57);
 
-    assert!(test_inner(n, &poly, &point, eval).is_ok());
+    test_inner(n, &poly, &point, eval).unwrap();
 
     // wrong eval
     let eval = Fr::from(56);
@@ -562,15 +562,8 @@ mod tests {
 
     // verify the evaluation
     let mut verifier_transcript = Keccak256Transcript::<NE>::new(b"TestEval");
-    assert!(EvaluationEngine::<E, NE>::verify(
-      &vk,
-      &mut verifier_transcript,
-      &C,
-      &point,
-      &eval,
-      &proof
-    )
-    .is_ok());
+    EvaluationEngine::<E, NE>::verify(&vk, &mut verifier_transcript, &C, &point, &eval, &proof)
+      .unwrap();
     let post_c_v = verifier_transcript.squeeze(b"c").unwrap();
 
     // check if the prover transcript and verifier transcript are kept in the

--- a/src/provider/shplonk.rs
+++ b/src/provider/shplonk.rs
@@ -330,8 +330,8 @@ mod tests {
   use super::*;
   use crate::provider::util::iterators::DoubleEndedIteratorExt as _;
   use crate::traits::TranscriptEngineTrait;
-  use crate::zip_with;
   use crate::{provider::keccak::Keccak256Transcript, CommitmentEngineTrait, CommitmentKey};
+  use crate::{zip_with, zip_with_for_each};
   use halo2curves::bn256::G1;
   use itertools::Itertools;
 
@@ -371,7 +371,7 @@ mod tests {
     let K_x = EvaluationEngine::<E, NE>::compute_k_polynomial(&batched_Pi, &Q_x, &D, &R_x, a);
 
     let mut C_P = G1::identity();
-    q_powers.iter().zip_eq(comms.iter()).for_each(|(q_i, C_i)| {
+    zip_with_for_each!(iter, (q_powers, comms), |q_i, C_i| {
       C_P += *C_i * q_i;
     });
 
@@ -480,10 +480,7 @@ mod tests {
         .map(|poly| UniPoly::new(poly).evaluate(evaluation_scalar))
         .collect::<Vec<Fr>>();
 
-      let expected = zip_with!((evals.iter(), q_powers.iter()), |eval, q| eval * q)
-        .collect::<Vec<Fr>>()
-        .into_iter()
-        .sum::<Fr>();
+      let expected = zip_with!(iter, (evals, q_powers), |eval, q| eval * q).sum::<Fr>();
 
       let actual = batched_Pi.evaluate(evaluation_scalar);
       assert_eq!(expected, actual);

--- a/src/provider/shplonk.rs
+++ b/src/provider/shplonk.rs
@@ -556,15 +556,8 @@ mod tests {
         .unwrap();
 
     let mut verifier_transcript = Keccak256Transcript::<NE>::new(b"TestEval");
-    assert!(EvaluationEngine::<E, NE>::verify(
-      &vk,
-      &mut verifier_transcript,
-      &C,
-      &point,
-      &eval,
-      &proof
-    )
-    .is_ok());
+    EvaluationEngine::<E, NE>::verify(&vk, &mut verifier_transcript, &C, &point, &eval, &proof)
+      .unwrap();
   }
 
   #[test]

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -874,16 +874,15 @@ pub(crate) mod tests {
     let rows = num_cons;
     let cols = num_vars + num_io + 1;
 
-    let res = R1CSShape::new(
+    R1CSShape::new(
       num_cons,
       num_vars,
       num_io,
       SparseMatrix::new(&A, rows, cols),
       SparseMatrix::new(&B, rows, cols),
       SparseMatrix::new(&C, rows, cols),
-    );
-    assert!(res.is_ok());
-    res.unwrap()
+    )
+    .unwrap()
   }
 
   fn test_pad_tiny_r1cs_with<E: Engine>() {
@@ -913,7 +912,7 @@ pub(crate) mod tests {
     for (num_cons, num_vars, num_io, num_entries) in cases {
       let S = R1CSShape::<E>::random(num_cons, num_vars, num_io, num_entries, &mut rng);
       let (W, U) = S.random_witness_instance(&ck, &mut rng);
-      assert!(S.is_sat_relaxed(&ck, &U, &W).is_ok());
+      S.is_sat_relaxed(&ck, &U, &W).unwrap();
     }
   }
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -370,7 +370,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
     let coeffs = powers(&s, claims.len());
 
     // compute the joint claim
-    let claim = zip_with!((claims.iter(), coeffs.iter()), |c_1, c_2| *c_1 * c_2).sum();
+    let claim = zip_with!(iter, (claims, coeffs), |c_1, c_2| *c_1 * c_2).sum();
 
     let mut e = claim;
     let mut r: Vec<E::Scalar> = Vec::new();

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -798,7 +798,7 @@ mod tests {
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable
-    assert!(shape1.is_sat(&ck1, &inst1, &witness1).is_ok());
+    shape1.is_sat(&ck1, &inst1, &witness1).unwrap();
 
     // Execute the base case for the secondary
     let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
@@ -826,7 +826,7 @@ mod tests {
     let _ = circuit2.synthesize(&mut cs2);
     let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();
     // Make sure that it is satisfiable
-    assert!(shape2.is_sat(&ck2, &inst2, &witness2).is_ok());
+    shape2.is_sat(&ck2, &inst2, &witness2).unwrap();
   }
 
   #[test]

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -487,26 +487,22 @@ mod test {
     .unwrap();
 
     for circuit in test_circuits.iter().take(NUM_STEPS) {
-      let prove_res = recursive_snark.prove_step(&pp, circuit, &secondary_circuit);
+      recursive_snark
+        .prove_step(&pp, circuit, &secondary_circuit)
+        .unwrap();
 
-      let verify_res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
-
-      assert!(prove_res.is_ok());
-      assert!(verify_res.is_ok());
+      recursive_snark
+        .verify(&pp, &z0_primary, &z0_secondary)
+        .unwrap();
     }
 
     let (prover_key, verifier_key) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
-    let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
+    let compressed_snark = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark).unwrap();
 
-    assert!(compressed_prove_res.is_ok());
-
-    let compressed_snark = compressed_prove_res.unwrap();
-
-    let compressed_verify_res =
-      compressed_snark.verify(&pp, &verifier_key, &z0_primary, &z0_secondary);
-
-    assert!(compressed_verify_res.is_ok());
+    compressed_snark
+      .verify(&pp, &verifier_key, &z0_primary, &z0_secondary)
+      .unwrap();
   }
 
   #[test]
@@ -670,26 +666,22 @@ mod test {
     .unwrap();
 
     for circuit in test_circuits.iter().take(NUM_STEPS) {
-      let prove_res = recursive_snark.prove_step(&pp, circuit, &secondary_circuit);
+      recursive_snark
+        .prove_step(&pp, circuit, &secondary_circuit)
+        .unwrap();
 
-      let verify_res = recursive_snark.verify(&pp, &z0_primary, &z0_secondary);
-
-      assert!(prove_res.is_ok());
-      assert!(verify_res.is_ok());
+      recursive_snark
+        .verify(&pp, &z0_primary, &z0_secondary)
+        .unwrap();
     }
 
     let (prover_key, verifier_key) = CompressedSNARK::<_, S1, S2>::setup(&pp).unwrap();
 
-    let compressed_prove_res = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark);
+    let compressed_snark = CompressedSNARK::prove(&pp, &prover_key, &recursive_snark).unwrap();
 
-    assert!(compressed_prove_res.is_ok());
-
-    let compressed_snark = compressed_prove_res.unwrap();
-
-    let compressed_verify_res =
-      compressed_snark.verify(&pp, &verifier_key, &z0_primary, &z0_secondary);
-
-    assert!(compressed_verify_res.is_ok());
+    compressed_snark
+      .verify(&pp, &verifier_key, &z0_primary, &z0_secondary)
+      .unwrap();
   }
 
   #[test]

--- a/src/supernova/test.rs
+++ b/src/supernova/test.rs
@@ -518,7 +518,7 @@ fn test_recursive_circuit_with<E1>(
   }
   let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
   // Make sure that this is satisfiable
-  assert!(shape1.is_sat(&ck1, &inst1, &witness1).is_ok());
+  shape1.is_sat(&ck1, &inst1, &witness1).unwrap();
 
   // Execute the base case for the secondary
   let zero2 = <<E1 as Engine>::Base as Field>::ZERO;
@@ -549,7 +549,7 @@ fn test_recursive_circuit_with<E1>(
   }
   let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();
   // Make sure that it is satisfiable
-  assert!(shape2.is_sat(&ck2, &inst2, &witness2).is_ok());
+  shape2.is_sat(&ck2, &inst2, &witness2).unwrap();
 }
 
 #[test]
@@ -863,12 +863,12 @@ where
       .is_ok());
 
     // verify the recursive SNARK
-    let res = recursive_snark
+    recursive_snark
       .verify(&pp, &z0_primary, &z0_secondary)
       .map_err(|err| {
         print_constraints_name_on_error_index(&err, &pp, circuit_primary, &circuit_secondary, 2)
-      });
-    assert!(res.is_ok());
+      })
+      .unwrap();
   }
 }
 


### PR DESCRIPTION
An assertion failure on a Result cannot output the useful message of the error.

This removes the systematic pattern of asserting on result states, specially when it comes to tests / benches.
Prohibits them for good measure, using [clippy](https://rust-lang.github.io/rust-clippy/master/index.html#/assertions_on_result_states).