### PR TITLE
Public gadget utilities

### DIFF
--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -2,4 +2,4 @@
 pub mod ecc;
 pub(crate) mod nonnative;
 pub(crate) mod r1cs;
-pub(crate) mod utils;
+pub mod utils;


### PR DESCRIPTION
In `arecibo` we have a few gadget utilities that have been written. So far, they are only available to this crate. While working in `bellpepper-gadgets` or any other gadget repositories, a few of those utilities could come in handy.

There are already cases [where they have been copied](https://github.com/lurk-lab/bellpepper-gadgets/blob/94034f6dd90153dd446aa898ac49dcb1d9230c45/crates/emulated/src/field_element.rs#L559) so I believe that making them public should be alright.