### PR TITLE
chore: encapsulate sparse API

### DIFF
--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -112,9 +112,9 @@ fn add_constraint<S: PrimeField>(
 ) {
   let (A, B, C, nn) = X;
   let n = **nn;
-  assert_eq!(n + 1, A.indptr.len(), "A: invalid shape");
-  assert_eq!(n + 1, B.indptr.len(), "B: invalid shape");
-  assert_eq!(n + 1, C.indptr.len(), "C: invalid shape");
+  assert_eq!(n, A.num_rows(), "A: invalid shape");
+  assert_eq!(n, B.num_rows(), "B: invalid shape");
+  assert_eq!(n, C.num_rows(), "C: invalid shape");
 
   let add_constraint_component = |index: Index, coeff: &S, M: &mut SparseMatrix<S>| {
     // we add constraints to the matrix only if the associated coefficient is non-zero

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -513,13 +513,11 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> BatchedRelaxedR1CSSNARKTrait<E>
                           r_y: &[E::Scalar]|
      -> Vec<E::Scalar> {
       let evaluate_with_table =
-        // TODO(@winston-h-zhang): review
         |M: &SparseMatrix<E::Scalar>, T_x: &[E::Scalar], T_y: &[E::Scalar]| -> E::Scalar {
-          M.indptr
-            .par_windows(2)
+          M.par_iter_rows()
             .enumerate()
-            .map(|(row_idx, ptrs)| {
-              M.get_row_unchecked(ptrs.try_into().unwrap())
+            .map(|(row_idx, row)| {
+              M.get_row(row)
                 .map(|(val, col_idx)| T_x[row_idx] * T_y[*col_idx] * val)
                 .sum::<E::Scalar>()
             })

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -174,8 +174,9 @@ fn compute_eval_table_sparse<E: Engine>(
   assert_eq!(rx.len(), S.num_cons);
 
   let inner = |M: &SparseMatrix<E::Scalar>, M_evals: &mut Vec<E::Scalar>| {
-    for (row_idx, ptrs) in M.indptr.windows(2).enumerate() {
-      for (val, col_idx) in M.get_row_unchecked(ptrs.try_into().unwrap()) {
+    for (row_idx, row) in M.iter_rows().enumerate() {
+      for (val, col_idx) in M.get_row(row) {
+        // TODO(@winston-h-zhang): Parallelize? Will need more complicated locking
         M_evals[*col_idx] += rx[row_idx] * val;
       }
     }

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -351,11 +351,10 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
      -> Vec<E::Scalar> {
       let evaluate_with_table =
         |M: &SparseMatrix<E::Scalar>, T_x: &[E::Scalar], T_y: &[E::Scalar]| -> E::Scalar {
-          M.indptr
-            .par_windows(2)
+          M.par_iter_rows()
             .enumerate()
-            .map(|(row_idx, ptrs)| {
-              M.get_row_unchecked(ptrs.try_into().unwrap())
+            .map(|(row_idx, row)| {
+              M.get_row(row)
                 .map(|(val, col_idx)| T_x[row_idx] * T_y[*col_idx] * val)
                 .sum::<E::Scalar>()
             })


### PR DESCRIPTION
Small PR to clean up the sparse matrix API, so that manipulating the rows is clear.