### PR TITLE
Refactor to use bellpepper's new conditional selects

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -7,8 +7,8 @@
 use crate::{
   constants::{NIO_NOVA_FOLD, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS},
   gadgets::{
-    alloc_num_equals, alloc_scalar_as_base, alloc_zero, conditionally_select_vec, le_bits_to_num,
-    AllocatedPoint, AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance,
+    alloc_num_equals, alloc_scalar_as_base, alloc_zero, le_bits_to_num, AllocatedPoint,
+    AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance,
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{
@@ -17,7 +17,7 @@ use crate::{
   Commitment,
 };
 use abomonation_derive::Abomonation;
-use bellpepper::gadgets::Assignment;
+use bellpepper::gadgets::{boolean_utils::conditionally_select_slice, Assignment};
 use bellpepper_core::{
   boolean::{AllocatedBit, Boolean},
   num::AllocatedNum,
@@ -318,7 +318,7 @@ impl<'a, E: Engine, SC: StepCircuit<E::Base>> NovaAugmentedCircuit<'a, E, SC> {
     );
 
     // Compute z_{i+1}
-    let z_input = conditionally_select_vec(
+    let z_input = conditionally_select_slice(
       cs.namespace(|| "select input to F"),
       &z_0,
       &z_i,

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -2,13 +2,13 @@
 #![allow(non_snake_case)]
 use crate::{
   gadgets::utils::{
-    alloc_num_equals, alloc_one, alloc_zero, conditionally_select, conditionally_select2,
-    select_num_or_one, select_num_or_zero, select_num_or_zero2, select_one_or_diff2,
-    select_one_or_num2, select_zero_or_num2,
+    alloc_num_equals, alloc_one, alloc_zero, conditionally_select2, select_num_or_one,
+    select_num_or_zero, select_num_or_zero2, select_one_or_diff2, select_one_or_num2,
+    select_zero_or_num2,
   },
   traits::Group,
 };
-use bellpepper::gadgets::Assignment;
+use bellpepper::gadgets::{boolean_utils::conditionally_select, Assignment};
 use bellpepper_core::{
   boolean::{AllocatedBit, Boolean},
   num::AllocatedNum,

--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -15,6 +15,5 @@ mod utils;
 #[cfg(test)]
 pub(crate) use utils::alloc_one;
 pub(crate) use utils::{
-  alloc_num_equals, alloc_scalar_as_base, alloc_zero, conditionally_select_vec, le_bits_to_num,
-  scalar_as_base,
+  alloc_num_equals, alloc_scalar_as_base, alloc_zero, le_bits_to_num, scalar_as_base,
 };

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -8,14 +8,16 @@ use crate::{
   gadgets::{
     ecc::AllocatedPoint,
     utils::{
-      alloc_bignat_constant, alloc_one, alloc_scalar_as_base, conditionally_select,
-      conditionally_select_bignat, le_bits_to_num,
+      alloc_bignat_constant, alloc_one, alloc_scalar_as_base, conditionally_select_bignat,
+      le_bits_to_num,
     },
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{commitment::CommitmentTrait, Engine, Group, ROCircuitTrait, ROConstantsCircuit},
 };
-use bellpepper::gadgets::{boolean::Boolean, num::AllocatedNum, Assignment};
+use bellpepper::gadgets::{
+  boolean::Boolean, boolean_utils::conditionally_select, num::AllocatedNum, Assignment,
+};
 use bellpepper_core::{ConstraintSystem, SynthesisError};
 use ff::Field;
 use itertools::Itertools as _;

--- a/src/supernova/circuit.rs
+++ b/src/supernova/circuit.rs
@@ -15,8 +15,8 @@ use crate::{
   constants::{NIO_NOVA_FOLD, NUM_HASH_BITS},
   gadgets::{
     alloc_num_equals, alloc_scalar_as_base, alloc_zero, conditionally_select_alloc_relaxed_r1cs,
-    conditionally_select_vec, conditionally_select_vec_allocated_relaxed_r1cs_instance,
-    le_bits_to_num, AllocatedPoint, AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance,
+    conditionally_select_vec_allocated_relaxed_r1cs_instance, le_bits_to_num, AllocatedPoint,
+    AllocatedR1CSInstance, AllocatedRelaxedR1CSInstance,
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{commitment::CommitmentTrait, Engine, ROCircuitTrait, ROConstantsCircuit},
@@ -28,7 +28,7 @@ use bellpepper_core::{
   ConstraintSystem, SynthesisError,
 };
 
-use bellpepper::gadgets::Assignment;
+use bellpepper::gadgets::{boolean_utils::conditionally_select_slice, Assignment};
 
 use abomonation_derive::Abomonation;
 use ff::{Field, PrimeField};
@@ -619,7 +619,7 @@ impl<'a, E: Engine, SC: EnforcingStepCircuit<E::Base>> SuperNovaAugmentedCircuit
     );
 
     // Compute z_{i+1}
-    let z_input = conditionally_select_vec(
+    let z_input = conditionally_select_slice(
       cs.namespace(|| "select input to F"),
       &z_0,
       &z_i,


### PR DESCRIPTION
- Function `conditionally_select_vec` is removed and replaced with `conditionally_select_slice` across multiple files for consistency.
- Duplicate functions `conditionally_select` and `conditionally_select_vec` are removed from various modules.
- Unused import, `itertools::Itertools`, removed from `src/gadgets/utils.rs`.

See https://github.com/lurk-lab/bellpepper/pull/85