### PR TITLE
feat: Implement `Clone` trait for various structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,7 +788,7 @@ where
 }
 
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct CompressedSNARK<E1, S1, S2>
 where

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 /// A SNARK that holds the proof of a step of an incremental computation
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct NIFS<E: Engine> {
   pub(crate) comm_T: CompressedCommitment<E>,

--- a/src/spartan/batched.rs
+++ b/src/spartan/batched.rs
@@ -41,7 +41,7 @@ use crate::{
 /// A succinct proof of knowledge of a witness to a batch of relaxed R1CS instances
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   sc_proof_outer: SumcheckProof<E>,

--- a/src/spartan/batched_ppsnark.rs
+++ b/src/spartan/batched_ppsnark.rs
@@ -95,7 +95,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> DigestHelperTrait<E> for VerifierK
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct BatchedRelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   // commitment to oracles: the first three are for Az, Bz, Cz,

--- a/src/supernova/snark.rs
+++ b/src/supernova/snark.rs
@@ -39,7 +39,7 @@ where
 }
 
 /// A SNARK that proves the knowledge of a valid `RecursiveSNARK`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct CompressedSNARK<E1, S1, S2>
 where


### PR DESCRIPTION
- Added `Clone` trait derivation to enhance cloning capabilities within the codebase.
- Improved duplication of `CompressedSNARK` and `NIFS` structures by integrating `Clone` trait.
- Optimized SNARK computations and funcs handling by cloning `CompressedSNARK` structure.

This is motivated by a companion update to Lurk, where the compression mechanism requires returning a uniform type upon calling `.compress()` on a proof that can be recursive or compressed.

> [!NOTE]
> See use in https://github.com/lurk-lab/lurk-rs/pull/1214
