### PR TITLE
chore: Update Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/lurk-lab/arecibo"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
-rust-version="1.74.1"
+rust-version="1.79"
 
 [dependencies]
 bellpepper-core = { version = "0.4.0", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 profile = "default"
-channel = "1.78"
+channel = "1.79"
 targets = [ "wasm32-unknown-unknown" ]
 

--- a/src/gadgets/nonnative/util.rs
+++ b/src/gadgets/nonnative/util.rs
@@ -14,6 +14,7 @@ use std::io::{self, Write};
 pub struct Bit<Scalar: PrimeField> {
   /// The linear combination which constrain the value of the bit
   pub bit: LinearCombination<Scalar>,
+  #[allow(unused)]
   /// The value of the bit (filled at witness-time)
   pub value: Option<bool>,
 }

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -74,8 +74,7 @@ pub fn alloc_scalar_as_base<E, CS>(
   input: Option<E::Scalar>,
 ) -> Result<AllocatedNum<E::Base>, SynthesisError>
 where
-  E: Engine,
-  <E as Engine>::Scalar: PrimeFieldBits,
+  E: Engine<Scalar: PrimeFieldBits>,
   CS: ConstraintSystem<<E as Engine>::Base>,
 {
   AllocatedNum::alloc(cs.namespace(|| "allocate scalar as base"), || {


### PR DESCRIPTION
- Updated Rust toolchain from version `1.78` to `1.79`,
- Added an unused attribute to address potential compilation errors related to unused variables in the `Bit` struct in `nonnative/util.rs`.
- Refactored type constraints for increased readability in `alloc_scalar_as_base` function within `utils.rs`.

Companion PR at https://github.com/lurk-lab/lurk-rs/pull/1252
Fixes #382 